### PR TITLE
Provenance: added check by $ref attribute when used .

### DIFF
--- a/row-meta-schema.json
+++ b/row-meta-schema.json
@@ -6,29 +6,40 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
-        "title": {
-          "type": "string"
+        "auth": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/auth"
         },
+
         "description": {
           "type": "string"
         },
-        "format": {
-          "type": "string"
-        },
-        "relation": {
-          "type": "string"
-        },
-        "uri": {
-          "type": "string",
-          "format": "uri-reference"
-        },
+
         "enum": {
           "type": "array"
         },
-        "auth": {
-          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/auth"
+
+        "format": {
+          "type": "string"
+        },
+
+        "provenance": {
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v1.1.1#properties/provenance"
+        },
+
+        "relation": {
+          "type": "string"
+        },
+
+        "title": {
+          "type": "string"
+        },
+
+        "uri": {
+          "type": "string",
+          "format": "uri-reference"
         }
       },
+
       "oneOf": [
         {
           "required": ["type"],

--- a/schema.json
+++ b/schema.json
@@ -15,34 +15,46 @@
       "type": "object",
       "required": ["id", "type"],
       "properties": {
-        "id": {
-          "$ref": "#/definitions/id"
+        "auth": {
+          "$ref": "#/definitions/auth"
         },
-        "type": {
-          "$ref": "#/definitions/type"
-        },
-        "title": {
-          "$ref": "#/definitions/title"
-        },
-        "description": {
-          "$ref": "#/definitions/description"
-        },
+
         "dateCreated": {
           "type": "string",
           "format": "date-time"
         },
-        "auth": {
-          "$ref": "#/definitions/auth"
-        },
+
         "dateModified": {
           "type": "string",
           "format": "date-time"
         },
+
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+
         "license": {
           "type": "string"
+        },
+
+        "provenance": {
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v1.1.1#properties/provenance"
+        },
+
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+
+        "type": {
+          "$ref": "#/definitions/type"
         }
       }
     },
+
     "idString": {
       "type": "string",
       "minLength": 1,
@@ -82,8 +94,8 @@
     "contactPoint": {
       "type": "object",
       "properties": {
-        "name": {"type": "string"},
-        "email": {"type": "string"}
+        "name": { "type": "string" },
+        "email": { "type": "string" }
       }
     },
     "auth": {
@@ -153,4 +165,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
There are serveral options to enforce the correct use of the provenance attribute on dataset, table and/or row level. Choosen is to use the ./meta/provenance.json as the definition enforcer. The schema.json and row-meta-schema.json where adjusted to reference the ./meta/provenance.json. In the schema.json are general properties definied for the dataset and table. Addtional general properties on row level is definied in the row-meta-schema.json file. So both needed to be adjusted.