### PR TITLE
Fix publishing paths

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,3 +16,7 @@ upgrade:
 	pur --patch=Django -r requirements.in
 	pur --no-recursive -r requirements_dev.txt
 	pip-compile -v --upgrade --output-file requirements.txt requirements.in
+
+.PHONY: release
+release:
+	python publish.py


### PR DESCRIPTION
Er zat nog een flaw in de structuur. Een mapje per versie is prima, alleen is dat niet de structuur die uiteindelijk on-line moet komen. Dat is nu gecorrigeerd.
