### PR TITLE
Fix name of id. Should not start with uppercase.

### DIFF
--- a/datasets/huishoudelijkafval/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/huishoudelijkafval.json
@@ -326,7 +326,7 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "Id": {
+          "id": {
             "type": "string",
             "provenance": "cluster_id",
             "description": "Uniek identificerend kenmerk van cluster"
@@ -457,7 +457,7 @@
         "required": ["id", "schema"],
         "display": "id",
         "properties": {
-          "Id": {
+          "id": {
             "type": "string",
             "provenance": "weging_id",
             "description": "Uniek identificerend kenmerk weging. Deze is per container vastgelegd"


### PR DESCRIPTION
This caused errors in my developement environment

ERRORS:
huishoudelijkafval.cluster: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.
huishoudelijkafval.weging: (models.E004) 'id' can only be used as a field name if the field also sets 'primary_key=True'.