### PR TITLE
[DS-459] BGT schema definition

### DIFF
--- a/datasets/bgt/bgt.json
+++ b/datasets/bgt/bgt.json
@@ -8,8 +8,8 @@
   "auth": "BGT",
   "tables": [
     {
-      "id": "ligstandplaatsen",
-      "Title": "Lig- en standplaatsen",
+      "id": "ligstandplaats",
+      "Title": "Lig- en standplaats",
       "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
@@ -43,8 +43,8 @@
       }
     },
     {
-      "id": "ligstandplaatsenlabel",
-      "Title": "Labels lig- en standplaatsen",
+      "id": "ligstandplaatslabel",
+      "Title": "Labels lig- en standplaats",
       "type": "table",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
@@ -205,8 +205,8 @@
       }
     },
     {
-      "id": "bakken",
-      "title": "Bakken",
+      "id": "bak",
+      "title": "bak",
       "description": "BGT plus BAK",
       "type": "table",
       "schema": {
@@ -310,8 +310,8 @@
       }
     },
     {
-      "id": "borden",
-      "title": "Borden",
+      "id": "bord",
+      "title": "bord",
       "description": "BGT plus BRD",
       "type": "table",
       "schema": {
@@ -732,8 +732,8 @@
       }
     },
     {
-      "id": "kasten",
-      "title": "Kasten",
+      "id": "kast",
+      "title": "kast",
       "description": "BGT plus KST",
       "type": "table",
       "schema": {
@@ -842,8 +842,8 @@
       }
     },
     {
-      "id": "masten",
-      "title": "Masten",
+      "id": "mast",
+      "title": "mast",
       "description": "BGT plus MST",
       "type": "table",
       "schema": {
@@ -1265,8 +1265,8 @@
       }
     },
     {
-      "id": "putten",
-      "title": "Putten",
+      "id": "put",
+      "title": "put",
       "description": "BGT plus PUT",
       "type": "table",
       "schema": {
@@ -2010,7 +2010,6 @@
         }
       }
     },
-    ,
     {
       "id": "overbruggingsdeel",
       "title": "Overbruggingsdeel",
@@ -2110,7 +2109,6 @@
         }
       }
     },
-
     {
       "id": "paal",
       "title": "Paal",
@@ -2331,6 +2329,111 @@
               "naaldbos",
               "rietland",
               "struiken"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "overigterreindeel",
+      "title": "Overig terreindeel",
+      "description": "BGT OTRN",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "erf",
+              "zand",
+              "onverhard",
+              "open_verharding",
+              "gesloten_verharding"
             ],
             "description": "Typering categorie object."
           }
@@ -2822,7 +2925,6 @@
         }
       }
     },
-
     {
       "id": "tunneldeel",
       "title": "Tunneldeel",
@@ -3331,6 +3433,46 @@
             "type": "string",
             "enum": ["berm", "verkeerseiland"],
             "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "CFT",
+      "title": "CFT boven- en onderbouw",
+      "description": "BGT CFT",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "guid": {
+            "type": "string",
+            "description": "Unieke identificatie vanuit bronbestand."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
           }
         }
       }

--- a/datasets/bgt/bgt.json
+++ b/datasets/bgt/bgt.json
@@ -155,7 +155,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -275,7 +275,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -385,7 +385,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -500,7 +500,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -604,7 +604,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -708,7 +708,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -827,7 +827,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -942,7 +942,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1051,7 +1051,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1168,7 +1168,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1272,7 +1272,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1385,7 +1385,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1498,7 +1498,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1619,7 +1619,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1723,7 +1723,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1827,7 +1827,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -1937,7 +1937,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2051,7 +2051,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2156,7 +2156,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2264,7 +2264,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2385,7 +2385,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2509,7 +2509,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2623,7 +2623,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2725,7 +2725,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -2913,7 +2913,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -3017,7 +3017,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -3126,7 +3126,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -3230,7 +3230,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -3334,7 +3334,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -3433,7 +3433,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",
@@ -3564,7 +3564,7 @@
             "type": "string",
             "description": "Bronhouder object."
           },
-          "indicatieInOnderzoek": {
+          "aanduidingInOnderzoek": {
             "type": "string",
             "enum": ["N", "J"],
             "description": "Indicatie in onderzoek object.",

--- a/datasets/bgt/bgt.json
+++ b/datasets/bgt/bgt.json
@@ -3473,6 +3473,11 @@
           "relatievehoogteligging": {
             "type": "number",
             "description": "Relatieve verhoogte ligging object."
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["bovenbouw", "onderbouw"],
+            "description": "Typering categorie object."
           }
         }
       }

--- a/datasets/bgt/bgt.json
+++ b/datasets/bgt/bgt.json
@@ -1,0 +1,3339 @@
+{
+  "type": "dataset",
+  "id": "bgt",
+  "title": "Basisregistratie grootschalige topografie (BGT)",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "auth": "BGT",
+  "tables": [
+    {
+      "id": "ligstandplaatsen",
+      "Title": "Lig- en standplaatsen",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "bagIdentificatie",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "bagIdentificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object vanuit de basisregistratie adressen en gebouwen (BAG)."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van object."
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["standplaats", "ligplaats"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "ligstandplaatsenlabel",
+      "Title": "Labels lig- en standplaatsen",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "bagIdentificatie",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "bagIdentificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het record vanuit de basisregistratie adressen en gebouwen (BAG)."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het label horende bij het object."
+          },
+          "adres": {
+            "type": "string",
+            "description": "Adres van het object."
+          },
+          "tekst": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Inhoud van label horende bij het object."
+          },
+          "hoek": {
+            "type": "integer",
+            "description": "Graad(°) definitie van het object."
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["standplaats", "ligplaats"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "functioneelbeheergebied",
+      "Title": "Functioneel- of beheergebied",
+      "description": "BGT FGD en BGT plus FGD",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "naam": {
+            "type": "string",
+            "description": "Naam van het object."
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "kering",
+              "begraafplaats",
+              "bushalte",
+              "functioneel_beheer_hondenuitlaatplaats",
+              "halte",
+              "infrastructuur_waterstaatwerken",
+              "recreatie_bungalowpark",
+              "recreatie_park",
+              "recreatie_speeltuin",
+              "recreatie_sportterein",
+              "recreatie_volkstuin"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "bakken",
+      "title": "Bakken",
+      "description": "BGT plus BAK",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "afval_apart_plaats",
+              "afvalbak",
+              "container",
+              "drinkbak",
+              "onbekend"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "borden",
+      "title": "Borden",
+      "description": "BGT plus BRD",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "informatiebord",
+              "onbekend",
+              "plaatsnaambord",
+              "reclamebord",
+              "scheepvaartbord",
+              "straatnaambord",
+              "verkeersbord",
+              "verklikker_transportleiding",
+              "waarschuwingshek",
+              "wegwijzer"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "gebouwinstallatie",
+      "title": "Gebouwinstallatie",
+      "description": "BGT plus GISE",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["bordes", "luifel", "onbekend", "toegangstrap"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "installatie",
+      "title": "Installatie",
+      "description": "BGT plus ISE",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["onbekend", "pomp"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "kunstwerkdeel",
+      "title": "Kunstwerkdeel",
+      "description": "BGT KDL en BGT plus KDL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "duiker L",
+              "duiker V",
+              "faunavoorziening",
+              "keermuur",
+              "onbekend_L",
+              "gemaal",
+              "hoogspanningsmast_P",
+              "hoogspanningsmast_V",
+              "perron",
+              "sluis",
+              "steiger",
+              "strekdam",
+              "stuw_L",
+              "stuw_V"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "kasten",
+      "title": "Kasten",
+      "description": "BGT plus KST",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "cai-kast",
+              "elektrakast",
+              "gaskast",
+              "gms_kast",
+              "onbekend",
+              "openbare_verlichtingkast",
+              "rioolkast",
+              "telecom_kast",
+              "telkast",
+              "verkeersregelinstallatiekast"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "masten",
+      "title": "Masten",
+      "description": "BGT plus MST",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "bovenleidingmast",
+              "onbekend",
+              "straalzender",
+              "zendmast"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "overigbouwwerk",
+      "title": "Overig bouwwerk",
+      "description": "BGT OBW en BGT plus OBW",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "bunker",
+              "onbekend",
+              "schuur",
+              "voedersilo",
+              "bassin",
+              "bezinkbak",
+              "lage_trafo",
+              "open_loods",
+              "opslagtank",
+              "overkapping",
+              "transitie",
+              "windtrubine"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "scheiding",
+      "title": "Scheiding",
+      "description": "BGT SDG en BGT plus SDG",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["draadraster", "faunaraster", "onbekend_L"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "overigescheiding",
+      "title": "Overige scheiding",
+      "description": "BGT plus OSDG",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "damwand",
+              "geluidscherm",
+              "hek",
+              "kademuur",
+              "muur_L",
+              "muur_V",
+              "onbekend_L",
+              "walbescherming"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "putten",
+      "title": "Putten",
+      "description": "BGT plus PUT",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "waterleidingput",
+              "onbekend",
+              "kolk",
+              "gasput",
+              "drainageput",
+              "brandkraan_-put",
+              "bezine-_olieput",
+              "inspectie-_rioolput"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "straatmeubilair",
+      "title": "Straatmeubilair",
+      "description": "BGT plus SMR",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "telefooncel",
+              "speelvoorziening",
+              "slagboom",
+              "reclamezuil",
+              "picknicktafel",
+              "openbaar_toilet",
+              "lichtpunt",
+              "kunstobject",
+              "herdenkingsmonument",
+              "fietsrek",
+              "bolder",
+              "betaalautomaat",
+              "bank",
+              "abri",
+              "brievenbus",
+              "fietsenkluis"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "sensor",
+      "title": "Sensor",
+      "description": "BGT plus SSR",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["waterstandmeter", "onbekend", "flitser", "camera"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "vegetatieobject",
+      "title": "Vegetatieobject",
+      "description": "BGT plus VGT",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["boom", "haag_L", "haag_V", "onbekend_L", "onbekend_V"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "waterinrichtingselement",
+      "title": "Waterinrichtingselement",
+      "description": "BGT plus WDI",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "geleidewerk",
+              "hoogtemerk",
+              "meerpaal",
+              "onbekend laag",
+              "remmingswerk"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "weginrichtingselement",
+      "title": "Weginrichtingselement",
+      "description": "BGT plus WGI",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "balustrade",
+              "boomspiegel_V",
+              "geleideconstructie_L",
+              "onbekend_V",
+              "lijnafwatering",
+              "molgoot",
+              "rooster_L",
+              "rooster_P",
+              "rooster_V",
+              "wegmarkering_L",
+              "wegmarkering_P",
+              "wegmarkering_V",
+              "wildrooster_L",
+              "wildrooster_V"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "waterinrichtingselement",
+      "title": "Waterinrichtingselement",
+      "description": "BGT plus WDI",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "geleidewerk",
+              "hoogtemerk",
+              "meerpaal",
+              "onbekend_L",
+              "remmingswerk"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    ,
+    {
+      "id": "overbruggingsdeel",
+      "title": "Overbruggingsdeel",
+      "description": "BGT ODL en BGT plus ODL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["dek", "landhoofd", "pijler", "pyloon", "sloof"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+
+    {
+      "id": "paal",
+      "title": "Paal",
+      "description": "BGT plus PAL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "afsluitpaal",
+              "drukknoppaal",
+              "haltepaal",
+              "hectometerpaal",
+              "lichtmast",
+              "onbekend",
+              "poller",
+              "portaal",
+              "telpaal",
+              "verkeersbordpaal",
+              "verkeersregelinstallatiepaal",
+              "vlaggenmast"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "begroeidterreindeel",
+      "title": "Begroeid terreindeel",
+      "description": "BGT BTRN",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "boomteelt",
+              "bouwland",
+              "fruitteelt",
+              "gemengd_bos",
+              "grasland_agrarisch",
+              "grasland_overig",
+              "groenvoorziening",
+              "heide",
+              "houtwal",
+              "loofbos",
+              "moeras",
+              "naaldbos",
+              "rietland",
+              "struiken"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "kruinlijn",
+      "title": "Kruinlijn",
+      "description": "BGT KLN",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["kruinlijn"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "openbareruimtelabel",
+      "title": "Openbare ruimte label",
+      "description": "BGT LBL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "identificatieBagOpr": {
+            "type": "string",
+            "description": "Identificatie BAG openbareruimte object.",
+            "provenance": "identificatieBAGOPR"
+          },
+          "openbareruimteType": {
+            "type": "string",
+            "description": "Omschrijving van type BAG openbareruimte.",
+            "provenance": "openbareruimtetype"
+          },
+          "tekst": {
+            "type": "string",
+            "description": "Omschrijving van type BAG openbareruimte."
+          },
+          "hoek": {
+            "type": "integer",
+            "description": "Graad(°) definitie van het object."
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "administratief_gebied",
+              "kunstwerk",
+              "landschappelijk_gebied",
+              "terrein",
+              "water",
+              "weg"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "nummeraanduidingpandlabel",
+      "title": "Nummeraanduiding pand label",
+      "description": "BGT LBL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "tekst": {
+            "type": "string",
+            "description": "Tekstgroote van label."
+          },
+          "teskt_afgekort": {
+            "type": "string",
+            "description": "Tekstgroote van afgekort label."
+          },
+          "identificatieBagPand": {
+            "type": "string",
+            "description": "BAG identificatie van pand.",
+            "provenance": "identificatieBAGPND"
+          },
+          "identificatieBagVboLaagsteHuisnummer": {
+            "type": "string",
+            "description": "BAG identificatie van verblijfsobject pand met laagste huisnummer.",
+            "provenance": "identificatieBAGVBOLaagsteHuisnummer"
+          },
+          "identificatieBagVboHoogsteHuisnummer": {
+            "type": "string",
+            "description": "BAG identificatie van verblijfsobject pand met laagste huisnummer.",
+            "provenance": "identificatieBAGVBOHoogsteHuisnummer"
+          },
+          "hoek": {
+            "type": "integer",
+            "description": "Graad(°) definitie van het object."
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["pand"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "spoor",
+      "title": "Spoor",
+      "description": "BGT SPR",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["trein", "tram", "sneltram"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "pand",
+      "title": "Pand",
+      "description": "BGT PND",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["pand"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+
+    {
+      "id": "tunneldeel",
+      "title": "Tunneldeel",
+      "description": "BGT TDL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["tunneldeel"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "ondersteunendwaterdeel",
+      "title": "Ondersteunend waterdeel",
+      "description": "BGT OWDL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["oever slootkant"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "waterdeel",
+      "title": "Waterdeel",
+      "description": "BGT WDL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["greppel droge sloot", "waterloop", "watervlakte"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "wegdeel",
+      "title": "Wegdeel",
+      "description": "BGT WGL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": [
+              "baan voor vliegverkeer",
+              "fietspad",
+              "inrit",
+              "ov-baan",
+              "overweg",
+              "parkeervlak",
+              "rijbaan_autosnelweg",
+              "rijbaan_autoweg",
+              "rijbaan_lokale_weg",
+              "rijbaan_regionale_weg",
+              "ruiterpad",
+              "spoorbaan",
+              "voetgangersgebied",
+              "voetpad",
+              "voetpad_op_trap",
+              "woonerf"
+            ],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    },
+    {
+      "id": "ondersteunendwegdeel",
+      "title": "Ondersteunend wegdeel",
+      "description": "BGT OWGL",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bgt/bgt.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "lokaalId",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke identificatie van het record."
+          },
+          "namespaceId": {
+            "type": "string",
+            "description": "Unieke identificatie van de namespace.",
+            "provenance": "identificatie_namespace"
+          },
+          "lokaalId": {
+            "type": "string",
+            "description": "Unieke identificatie van het object.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Poloygoon definitie van het object."
+          },
+          "startdatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Startdatum van het object.",
+            "provenance": "objectbegintijd"
+          },
+          "einddatumObject": {
+            "type": "string",
+            "format": "date",
+            "description": "Einddtijd van het object.",
+            "provenance": "objecteindtijd"
+          },
+          "tijdstipregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van registatie van het object."
+          },
+          "eindregistratie": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van beëindiging van het object."
+          },
+          "lvPublicatiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Moment van publicatie van het object in landelijke voorziening GBT.",
+            "provenance": "lv-publicatiedatum"
+          },
+          "bronhouder": {
+            "type": "string",
+            "description": "Bronhouder object."
+          },
+          "indicatieInOnderzoek": {
+            "type": "string",
+            "enum": ["N", "J"],
+            "description": "Indicatie in onderzoek object.",
+            "provenance": "inonderzoek"
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Relatieve verhoogte ligging object."
+          },
+          "bgtStatus": {
+            "type": "string",
+            "description": "BGT status van het object.",
+            "provenance": "bgt-status"
+          },
+          "bgtPlusStatus": {
+            "type": "string",
+            "description": "BGT plus status van het object.",
+            "provenance": "plus-status"
+          },
+          "bgtType": {
+            "type": "string",
+            "description": "BGT type van het object.",
+            "provenance": "bgt-type"
+          },
+          "categorie": {
+            "type": "string",
+            "enum": ["berm", "verkeerseiland"],
+            "description": "Typering categorie object."
+          }
+        }
+      }
+    }
+  ]
+}

--- a/datasets/bgt/bgt.json
+++ b/datasets/bgt/bgt.json
@@ -180,6 +180,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "naam": {
             "type": "string",
             "description": "Naam van het object."
@@ -295,6 +300,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": [
@@ -399,6 +409,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -510,6 +525,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["bordes", "luifel", "onbekend", "toegangstrap"],
@@ -609,6 +629,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["onbekend", "pomp"],
@@ -707,6 +732,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -822,6 +852,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": [
@@ -932,6 +967,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": [
@@ -1035,6 +1075,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -1148,6 +1193,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["draadraster", "faunaraster", "onbekend_L"],
@@ -1246,6 +1296,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -1355,6 +1410,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": [
@@ -1462,6 +1522,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -1579,6 +1644,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["waterstandmeter", "onbekend", "flitser", "camera"],
@@ -1678,6 +1748,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["boom", "haag_L", "haag_V", "onbekend_L", "onbekend_V"],
@@ -1776,6 +1851,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -2096,10 +2176,19 @@
             "description": "BGT plus status van het object.",
             "provenance": "plus-status"
           },
-          "bgtType": {
+          "type": {
             "type": "string",
-            "description": "BGT type van het object.",
-            "provenance": "bgt-type"
+            "description": "Type van het object."
+          },
+          "hoortBijTyperOverbrugging": {
+            "type": "string",
+            "description": "Type van het object.",
+            "provenance": "hoortbijtyperoverbrugging"
+          },
+          "overbruggingIsBeweegbaaar": {
+            "type": "string",
+            "description": "Type van het object.",
+            "provenance": "overbruggingisbeweegbaaar"
           },
           "categorie": {
             "type": "string",
@@ -2199,6 +2288,15 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
+          "hectometeraanduiding": {
+            "type": "string",
+            "description": "Aanduiding gebruik hectometer."
           },
           "categorie": {
             "type": "string",
@@ -2307,10 +2405,20 @@
             "description": "BGT plus status van het object.",
             "provenance": "plus-status"
           },
-          "bgtType": {
+          "bgtFysiekvoorkomen": {
             "type": "string",
-            "description": "BGT type van het object.",
-            "provenance": "bgt-type"
+            "description": "BGT type fysiekvoorkomen van het object.",
+            "provenance": "bgt-fysiekvoorkomen"
+          },
+          "bgtPlusFysiekvoorkomen": {
+            "type": "string",
+            "description": "BGT plus type fysiekvoorkomen van het object.",
+            "provenance": "plus-fysiekvoorkomen"
+          },
+          "optalud": {
+            "type": "string",
+            "enum": ["J", "N"],
+            "description": "Indicatie of het object valt op het schuine vlak langs een weg, spoor, watergang of van een dijk."          
           },
           "categorie": {
             "type": "string",
@@ -2421,10 +2529,19 @@
             "description": "BGT plus status van het object.",
             "provenance": "plus-status"
           },
-          "bgtType": {
+          "bgtFysiekvoorkomen": {
             "type": "string",
-            "description": "BGT type van het object.",
-            "provenance": "bgt-type"
+            "description": "BGT fysieke typering van het object.",
+            "provenance": "bgt-fysiekvoorkomen"
+          },
+          "bgtPlusFysiekvoorkomen": {
+            "type": "string",
+            "description": "BGT fysieke typering van het object.",
+            "provenance": "plus-fysiekvoorkomen"
+          },
+          "optalud": {
+            "type": "string",
+            "description": "Indicatie of het object valt op het schuine vlak langs een weg, spoor, watergang of van een dijk."
           },
           "categorie": {
             "type": "string",
@@ -2526,10 +2643,13 @@
             "description": "BGT plus status van het object.",
             "provenance": "plus-status"
           },
-          "bgtType": {
+          "optalud": {
             "type": "string",
-            "description": "BGT type van het object.",
-            "provenance": "bgt-type"
+            "description": "Indicatie of het object valt op het schuine vlak langs een weg, spoor, watergang of van een dijk."
+          },
+          "hoortbij": {
+            "type": "string",
+            "description": "Vermelding gerelateerde dataset binnen BGT als tekst."
           },
           "categorie": {
             "type": "string",
@@ -2818,6 +2938,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["trein", "tram", "sneltram"],
@@ -2916,6 +3041,16 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
+          "identificatieBagPnd": {
+            "type": "string",
+            "description": "BAG identificatie van het object.",
+            "provenance": "identificatieBAGPND"
           },
           "categorie": {
             "type": "string",
@@ -3016,6 +3151,11 @@
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
           },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
+          },
           "categorie": {
             "type": "string",
             "enum": ["tunneldeel"],
@@ -3114,6 +3254,11 @@
             "type": "string",
             "description": "BGT type van het object.",
             "provenance": "bgt-type"
+          },
+          "bgtPlusType": {
+            "type": "string",
+            "description": "BGT plus type van het object.",
+            "provenance": "plus-type"
           },
           "categorie": {
             "type": "string",
@@ -3308,10 +3453,25 @@
             "description": "BGT plus status van het object.",
             "provenance": "plus-status"
           },
-          "bgtType": {
+          "bgtFunctie": {
             "type": "string",
-            "description": "BGT type van het object.",
-            "provenance": "bgt-type"
+            "description": "BGT functie van het object.",
+            "provenance": "bgt-functie"
+          },
+          "bgtPlusFunctie": {
+            "type": "string",
+            "description": "BGT plus functie van het object.",
+            "provenance": "plus-functie"
+          },
+          "bgtFysiekvoorkomen": {
+            "type": "string",
+            "description": "BGT type fysiekvoorkomen van het object.",
+            "provenance": "bgt-fysiekvoorkomen"
+          },
+          "bgtPlusFysiekvoorkomen": {
+            "type": "string",
+            "description": "BGT plus type fysiekvoorkomen van het object.",
+            "provenance": "plus-fysiekvoorkomen"
           },
           "categorie": {
             "type": "string",


### PR DESCRIPTION
Particularities:

- source files "LBL" differ in structure. There are 3 kinds: Openbareruimte, Stand- en Ligplaats en Pand. These all have different fields and so therefor have their own table.

- Each table has a "categorie" field, which stores the enums of the type of data. And corresponds with the .csv source files that are combined. I.e. 
`"enum": ["standplaats", "ligplaats"],`
or
`  "enum": [
              "geleidewerk",
              "hoogtemerk",
              "meerpaal",
              "onbekend_L",
              "remmingswerk"
            ],`

- There are some provenance specifications defined, however trying to avoid this to be as much as complaint with the source terminology. Some are necessary like in case of more than one capital letter in the name. This does not go well with the logic that detects a capital as start of an underscore.

 