### PR TITLE
[huishoudelijkafval] toevoeging verwijzing nummeraanduiding

### DIFF
--- a/datasets/huishoudelijkafval/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/huishoudelijkafval.json
@@ -164,21 +164,27 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "bag:verblijfsobject",
+            "relation": "baggob:verblijfsobjecten:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:idententificatie",
+            "relation": "gebieden:buurten:identificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "bag:openbareruimte",
+            "relation": "baggob:openbareruimtes:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
+          },
+          "bagNummeraanduiding": {
+            "type": "string",
+            "relation": "baggob:nummeraanduidingen:identificatie",
+            "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+            "description": "Identificatie nummeraanduiding"
           }
         }
       }
@@ -272,21 +278,27 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "bag:verblijfsobject",
+            "relation": "baggob:verblijfsobjecten:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:idententificatie",
+            "relation": "gebieden:buurten:identificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "bag:openbareruimte",
+            "relation": "baggob:openbareruimtes:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
+          },
+          "bagNummeraanduiding": {
+            "type": "string",
+            "relation": "baggob:nummeraanduidingen:identificatie",
+            "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+            "description": "Identificatie nummeraanduiding"
           }
         }
       }
@@ -360,21 +372,27 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "bag:verblijfsobject",
+            "relation": "baggob:verblijfsobjecten:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "bag:buurt",
+            "relation": "gebieden:buurten:identificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "bag:openbareruimte",
+            "relation": "baggob:openbareruimtes:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
+          },
+          "bagNummeraanduiding": {
+            "type": "string",
+            "relation": "baggob:nummeraanduidingen:identificatie",
+            "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+            "description": "Identificatie nummeraanduiding"
           }
         }
       }
@@ -548,21 +566,27 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "bag:verblijfsobject",
+            "relation": "baggob:verblijfsobjecten:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:idententificatie",
+            "relation": "gebieden:buurten:identificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "bag:openbareruimte",
+            "relation": "baggob:openbareruimtes:identificatie",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
+          },
+          "bagNummeraanduiding": {
+            "type": "string",
+            "relation": "baggob:nummeraanduidingen:identificatie",
+            "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+            "description": "Identificatie nummeraanduiding"
           }
         }
       }


### PR DESCRIPTION
Added relation to baggob nummeraanduiding as a 1:N.
Because baggob contains historical records (versions of) the identificatie is added as the third part of the relation.
Also added the baggob relations to existing bag relations.

On request of team Ruimte.