### PR TITLE
Enable ligtInGemeente relations

### DIFF
--- a/datasets/baggob/baggob.json
+++ b/datasets/baggob/baggob.json
@@ -107,13 +107,13 @@
             "description": "Levenscyclus van de woonplaats, Woonplaats aangewezen, Woonplaats ingetrokken. omschrijving"
           },
           "ligtInGemeente": {
-            "type": "string",
+            "type": "object",
             "properties": {
               "identificatie": {
                 "type": "string"
               }
             },
-            "$comment": "relation brk:gemeentes *stringify*",
+            "relation": "brk:gemeentes",
             "description": "De gemeente waarin de woonplaats ligt."
           },
           "heeftDossier": {

--- a/datasets/gebieden/gebieden.json
+++ b/datasets/gebieden/gebieden.json
@@ -477,8 +477,13 @@
             "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
           },
           "ligtInGemeente": {
-            "type": "string",
-            "$comment": "relation brk:gemeentes *stringify*",
+            "type": "object",
+            "properties": {
+                "identificatie": {
+                "type": "string"
+            }
+          },
+            "relation": "brk:gemeentes",
             "description": "De gemeente waar het stadsdeel in ligt."
           },
           "geometrie": {


### PR DESCRIPTION
The ligtInGemeente relations were disabled during incremental implementation of GOB datasets.
These relations can be enabled now.
