### PR TITLE
[huishoudelijkafval] revert relation to baggob

### DIFF
--- a/datasets/huishoudelijkafval/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/huishoudelijkafval.json
@@ -164,19 +164,19 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "baggob:verblijfsobjecten:identificatie",
+            "relation": "bag:verblijfsobject",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:identificatie",
+            "relation": "gebieden:buurten:idententificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "baggob:openbareruimtes:identificatie",
+            "relation": "bag:openbareruimte",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
           }
@@ -272,19 +272,19 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "baggob:verblijfsobjecten:identificatie",
+            "relation": "bag:verblijfsobject",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:identificatie",
+            "relation": "gebieden:buurten:idententificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "baggob:openbareruimtes:identificatie",
+            "relation": "bag:openbareruimte",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
           }
@@ -360,19 +360,19 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "baggob:verblijfsobjecten:identificatie",
+            "relation": "bag:verblijfsobject",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:identificatie",
+            "relation": "bag:buurt",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "baggob:openbareruimtes:identificatie",
+            "relation": "bag:openbareruimte",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
           }
@@ -548,19 +548,19 @@
           },
           "bagHoofdadresVerblijfsobject": {
             "type": "string",
-            "relation": "baggob:verblijfsobjecten:identificatie",
+            "relation": "bag:verblijfsobject",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
           },
           "gbdBuurt": {
             "type": "string",
-            "relation": "gebieden:buurten:identificatie",
+            "relation": "gebieden:buurten:idententificatie",
             "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
             "description": "Unie­ke iden­ti­fi­ca­tie van het ob­ject"
           },
           "bagOpenbareruimte": {
             "type": "string",
-            "relation": "baggob:openbareruimtes:identificatie",
+            "relation": "bag:openbareruimte",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Openbare ruimte identificatie"
           }


### PR DESCRIPTION
When relation to bag entities are adjusted to baggob (incl. historical) the API does not provide the FK column name with _id containing a URL reference to the parent record. This causes the clients to break that expects the _id FK field.