### PR TITLE
Remove amsterdamseSleutel field, is not used anymore

### DIFF
--- a/datasets/bag/bag.json
+++ b/datasets/bag/bag.json
@@ -41,10 +41,6 @@
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
           },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
-          },
           "woonplaatsPtt": {
             "type": "string",
             "description": "Woonplaatsnaam volgens de schrijfwijze van PostNL."
@@ -167,10 +163,6 @@
             "type": "string",
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
-          },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
           },
           "geconstateerd": {
             "type": "boolean",
@@ -331,10 +323,6 @@
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
           },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
-          },
           "geconstateerd": {
             "type": "boolean",
             "description": "Dit geeft aan dat een LIGPLAATS in de registratie is opgenomen als gevolg van een feitelijke constatering en niet op basis van een regulier brondocument."
@@ -494,10 +482,6 @@
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
           },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
-          },
           "straatcode": {
             "type": "string",
             "description": "Straatcode."
@@ -645,10 +629,6 @@
             "type": "string",
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
-          },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
           },
           "huisnummer": {
             "type": "integer",
@@ -848,10 +828,6 @@
             "type": "string",
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
-          },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
           },
           "cbsNummer": {
             "type": "string",
@@ -1152,10 +1128,6 @@
             "type": "string",
             "format": "date-time",
             "description": "De datum waarop de toestand is geregistreerd."
-          },
-          "amsterdamseSleutel": {
-            "type": "string",
-            "description": "Amsterdamse identificerende code."
           },
           "geconstateerd": {
             "type": "boolean",


### PR DESCRIPTION
GOB has removed the use of the amsterdamseSleutel field
for their datasets. So, this field also needs to be removed
from the GOB amsterdam schemas.