### PR TITLE
Add additionalRelation definition for woonplaats -> openbareruimtes

### DIFF
--- a/datasets/bag/bag.json
+++ b/datasets/bag/bag.json
@@ -24,6 +24,13 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
+        "additionalRelations": {
+          "openbareruimtes": {
+            "table": "openbareruimtes",
+            "field": "ligtInWoonplaats",
+            "format": "summary"
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"


### PR DESCRIPTION
As requested by Dataportaal (Chris van Mook)

This adds a backwards relation from woonplaats -> openbareruimtes