### PR TITLE
added ois_week_nummer

### DIFF
--- a/datasets/corona/corona.json
+++ b/datasets/corona/corona.json
@@ -39,6 +39,10 @@
             "type": "integer",
             "description": "Nummer van de week"
           },
+          "ois_week_nummer": {
+            "type": "integer",
+            "description": "Nummer van de week (waarbij bij een jaar start met week 0, wanneer de week overlapt met jaar daarvoor)"
+          },
           "jaar": {
             "type": "integer",
             "description": "jaartal in YYYY waarop aantallen betrekking hebben."

--- a/datasets/corona/corona.json
+++ b/datasets/corona/corona.json
@@ -41,7 +41,7 @@
           },
           "ois_week_nummer": {
             "type": "integer",
-            "description": "Nummer van de week (waarbij bij een jaar start met week 0, wanneer de week overlapt met jaar daarvoor)"
+            "description": "Nummer van de week (waarbij een jaar start met week 0, wanneer de week overlapt met jaar daarvoor)"
           },
           "jaar": {
             "type": "integer",


### PR DESCRIPTION
Source added `ois_week_nummer` that holds the week number 0 as the first week number of the year when the last week of previous year overlaps with next year. 

The latter leads to the situation that `week 53` holds days of 2020 and 2021. In the Corona dashboard, the progress is represented per week per year (a cumulation of events all days within a week and year). Leading to data for 2021 week 53. 