### PR TITLE
Several fixes to the metaschema

### DIFF
--- a/schema@v1.1.1/row-meta-schema.json
+++ b/schema@v1.1.1/row-meta-schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "rootProperty": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "auth": {
           "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/auth"
@@ -12,6 +12,59 @@
 
         "description": {
           "type": "string"
+        },
+
+        "type": {
+          "type": "string"
+        },
+
+        "$comment": {
+          "type": "string"
+        },
+
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        },
+
+        "shortname": {
+          "type": "string"
+        },
+
+        "items": {
+          "type": "object"
+        },
+
+        "maximum": {
+          "type": "number"
+        },
+
+        "minimum": {
+          "type": "number"
+        },
+
+        "exclusiveMaximum": {
+          "type": "integer"
+        },
+
+        "multipeOf": {
+          "type": "number"
+        },
+
+        "minLength": {
+          "type": "integer"
+        },
+
+        "maxLength": {
+          "type": "integer"
+        },
+
+        "contentEncoding": {
+          "type": "string"
+        },
+
+        "properties": {
+          "type": "object"
         },
 
         "enum": {
@@ -80,14 +133,7 @@
       "allOf": [
         {
           "type": "array",
-          "minItems": 2,
-          "contains": {
-            "const": "id"
-          }
-        },
-        {
-          "type": "array",
-          "minItems": 2,
+          "minItems": 1,
           "contains": {
             "const": "schema"
           }
@@ -97,11 +143,17 @@
     "display": {
       "type": "string"
     },
+    "additionalRelations": {
+      "type": "object"
+    },
+    "isTemporal": {
+      "type": "boolean"
+    },
     "mainGeometry": {
       "type": "string"
     },
     "identifier": {
-      "type": "string"
+      "type": ["array", "string"]
     },
     "properties": {
       "type": "object",

--- a/schema@v1.1.1/schema.json
+++ b/schema@v1.1.1/schema.json
@@ -58,7 +58,7 @@
     "idString": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[a-z][ a-z0-9]*$"
+      "pattern": "^[a-z][ A-Za-z0-9]*$"
     },
     "id": {
       "oneOf": [
@@ -94,8 +94,8 @@
     "contactPoint": {
       "type": "object",
       "properties": {
-        "name": { "type": "string" },
-        "email": { "type": "string" }
+        "name": {"type": "string"},
+        "email": {"type": "string"}
       }
     },
     "auth": {


### PR DESCRIPTION
Added new table fields that were not yet in the meta-schema:
- additionalRelations
- isTemporal

Relaxing pattern for identifiers (we are using camelCase now).

Made table "identifier" "array" type possible.

Remove "id" from the "required" fields of a table.

Changed "additionalProperties" from true -> false for the row schema.
This means that all possible attributes for row schemas have to be
made explicit in the metaschema.

Add more metaschema for the row definitions

Because we are using additionalProperties=false now
our metaschema should contain all the field attributes that are in use.

Furthermore:

For local schemas, the schema urls were not modified during publishing.
Effectively making them not useable for schema validation.
This has now been fixed by first creating a copy of the relevant files
 (metaschema and schemas) and modifying the schema urls before
 publishing (to a custom location).