### PR TITLE
Simplify singular FK relations

### DIFF
--- a/datasets/bag/bag.json
+++ b/datasets/bag/bag.json
@@ -110,23 +110,14 @@
             "description": "Levenscyclus van de woonplaats, Woonplaats aangewezen, Woonplaats ingetrokken. omschrijving"
           },
           "ligtInGemeente": {
-            "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
             "relation": "brk:gemeentes",
+            "provenance": "$.ligtInGemeente.identificatie",
             "description": "De gemeente waarin de woonplaats ligt."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {
@@ -279,13 +270,9 @@
             "description": "De buurt waarin een standplaats ligt."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {
@@ -438,13 +425,9 @@
             "description": "De buurt waarin een ligplaats ligt."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {
@@ -582,13 +565,9 @@
             "description": "Beschrijving van de openbare ruimte bijvoorbeeld: Vogel. Wereldwijd komen 24 soorten albatrossen voor. De meeste leven op het zuidelijk halfrond. De grootste albatros heeft een spanwijdte van meer dan drie meter en is daarmee de grootste zeevogel ter wereld."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {
@@ -782,13 +761,9 @@
             "description": "De standplaats (landelijke identificatie) die door de nummeraanduiding wordt aangeduid."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {
@@ -1085,13 +1060,9 @@
             "description": "Buurt waarin het verblijfsobject ligt."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {
@@ -1237,13 +1208,9 @@
             "description": "Laagste bouwlaag van een pand."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           },
           "bagprocesCode": {

--- a/datasets/brk/brk.json
+++ b/datasets/brk/brk.json
@@ -610,13 +610,9 @@
             "description": ""
           },
           "vanKadastraalsubject": {
-            "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "brk:kadastralesubjecten",
+            "provenance": "$.vanKadastraalsubject.identificatie",
             "description": "Het Subject waarvoor deze tenaamstelling geldt."
           },
           "beginGeldigheid": {
@@ -1139,13 +1135,9 @@
             "description": "Een alfanumerieke aanduiding van de kadastrale sectie, deel van de kadastrale aanduiding van de onroerende zaak."
           },
           "isOnderdeelVanKadastralegemeentecode": {
-            "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "brk:kadastralegemeentecodes",
+            "provenance": "$.isOnderdeelVanKadastralegemeentecode.identificatie",
             "description": "Een alfanumerieke aanduiding van de kadastrale gemeentecode, deel van de kadastrale aanduiding van de onroerende zaak. (bv. ASD02)."
           },
           "geometrie": {
@@ -1177,13 +1169,9 @@
             "description": "De unieke aanduiding van een Kadastrale gemeentecode."
           },
           "isOnderdeelVanKadastralegemeente": {
-            "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "brk:kadastralegemeentes",
+            "provenance": "$.isOnderdeelVanKadastralegemeente.identificatie",
             "description": "De kadastrale gemeente waar de kadastrale gemeentecode onderdeel van is (bv. Sloten)."
           },
           "geometrie": {
@@ -1215,13 +1203,9 @@
             "description": "De unieke aanduiding van een Kadastrale gemeente."
           },
           "ligtInGemeente": {
-            "type": "object",
-            "properties": {
-              "identificatie": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "brk:gemeentes",
+            "provenance": "$.ligtInGemeente.identificatie",
             "description": "De burgelijke gemeente waarin de kadastrale gemeente ligt."
           },
           "geometrie": {

--- a/datasets/gebieden/gebieden.json
+++ b/datasets/gebieden/gebieden.json
@@ -477,13 +477,9 @@
             "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
           },
           "ligtInGemeente": {
-            "type": "object",
-            "properties": {
-                "identificatie": {
-                "type": "string"
-            }
-          },
+            "type": "string",
             "relation": "brk:gemeentes",
+            "provenance": "$.ligtInGemeente.identificatie",
             "description": "De gemeente waar het stadsdeel in ligt."
           },
           "geometrie": {
@@ -500,11 +496,7 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "schema",
-          "id",
-          "geometrie"
-        ],
+        "required": ["schema", "id", "geometrie"],
         "display": "id",
         "isTemporal": false,
         "properties": {


### PR DESCRIPTION
Singular FK relations (just a single identifier) were defined
as objects with one item (to mimick the ndjson response from GOB).

Has now been simplified to a simple scalar, using provenance
(jsonpath-based) to fetch the correct values from the ndjson.

The underlying goal is to remove the extra columns that are
automatically added for object-type relations in the schemas.