### PR TITLE
Upgrade requirements

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,7 +1,8 @@
 click==7.1.2
 environs==8.0.0
 python-swiftclient==3.9.0
-python-keystoneclient==4.0.0
+python-keystoneclient==4.2.0
 requests==2.25.1
 in_place==0.4.0
-bikeshed==2.2.3
+# bikeshed==2.3.0 + upgrade to aiohttp==3.7.4
+bikeshed @ git+https://github.com/tabatkins/bikeshed@24b346f6f7b4ef86a9efa9c719c372236fafd211

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,7 +14,7 @@ attrs==20.3.0
     # via
     #   aiohttp
     #   bikeshed
-bikeshed==2.2.3
+git+https://github.com/tabatkins/bikeshed@24b346f6f7b4ef86a9efa9c719c372236fafd211
     # via -r requirements.in
 certifi==2020.12.5
     # via
@@ -54,7 +54,7 @@ json-home-client==1.1.1
     # via bikeshed
 keystoneauth1==4.0.0
     # via python-keystoneclient
-lxml==4.5.2
+lxml==4.6.2
     # via bikeshed
 marshmallow==3.6.1
     # via environs
@@ -95,13 +95,13 @@ pbr==5.4.5
     #   oslo.utils
     #   python-keystoneclient
     #   stevedore
-pygments==2.6.1
+pygments==2.7.4
     # via bikeshed
 pyparsing==2.4.7
     # via oslo.utils
 python-dotenv==0.13.0
     # via environs
-python-keystoneclient==4.0.0
+python-keystoneclient==4.2.0
     # via -r requirements.in
 python-swiftclient==3.9.0
     # via -r requirements.in


### PR DESCRIPTION
Bikeshed has to be pinned to a specific git commit (https://github.com/tabatkins/bikeshed/commit/24b346f6f7b4ef86a9efa9c719c372236fafd211) to prevent it from downgrading aiohttp to 3.7.3. That commit is two commits after the 2.3.0 release and only changes bikeshed's requirements. The repo is big and pip clones it without --depth so installation is slow.