### PR TITLE
index.json on objectstore ((acc.)schemas.data.amsterdam.nl)

### DIFF
--- a/src/amsterdam_schema/publish/cli.py
+++ b/src/amsterdam_schema/publish/cli.py
@@ -87,7 +87,7 @@ def get_index_file_obj(publishable_paths: List[List[str]]) -> BytesIO:
         dataset_ext = path_parts[-1]
         folder = "/".join(path_parts[2:-1])
         dataset = splitext(dataset_ext)[0]
-        index[dataset] = f"{folder}/{dataset}"
+        index[folder] = f"{folder}/{dataset}"
     return BytesIO(json.dumps(index).encode("utf-8"))
 
 


### PR DESCRIPTION
Schema definitions are stored at ((acc.)schemas.data.amsterdam.nl) following the structure:

/folder/schema_file

Most of the time the folder name and schema file name are the same. I.e. /wior/wior

Grex is an example where the structure is as follows:

/grex/projecten

In the index.json, which acts like a referrer for the schema file location, is a dictionary (this logic was recently changed in the context of schema versioning support). Containing as a key the schema file name. Which is great for situations like /wior/wior. Where also the dataset id corresponds to wior. For grex the folder name is identical to the datset id. In this case grex. The schema file name is the odd duck.

To keep the current logic and preventing issues the folder name is now used as key in the index.json. This should cope with grex and all other structures.