### PR TITLE
[AB#7364] fix RDW performance issues

### DIFF
--- a/datasets/rdw/rdw.json
+++ b/datasets/rdw/rdw.json
@@ -35,7 +35,7 @@
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
           "id": {
-            "type": "number",
+            "type": "integer",
             "description": "Unieke identifictie record."
           },
           "kenteken": {


### PR DESCRIPTION
By definining the data as numeric, PostgreSQL can't use indices for the
parent_id in sub-tables. It tries to cast all integers to numeric instead.