### PR TITLE
Fix type op status fields in openbareverlichting schema

### DIFF
--- a/datasets/openbareverlichting/openbareverlichting.json
+++ b/datasets/openbareverlichting/openbareverlichting.json
@@ -63,12 +63,12 @@
             "provenance": "lon"
           },
           "storingstatus": {
-            "type": "boolean",
+            "type": "integer",
             "enum": [0, 1],
             "description": "Indicatie of een storing bekend is van een openbare verlichting. Waarde 1 is storing, waarde 0 geen storing."
           },
           "meldingstatus": {
-            "type": "boolean",
+            "type": "integer",
             "enum": [0, 1],
             "description": "Indicatie of een melding is gemaakt op een openbare verlichting. Waarde 1 is melding, waarde 0 geen melding."
           }


### PR DESCRIPTION
Type boolean leads to wrong SQL queries
that are not accepted by PostgreSQL.