### PR TITLE
Give brp schema status 'niet_beschikbaar'

### DIFF
--- a/datasets/brp/brp.json
+++ b/datasets/brp/brp.json
@@ -2,7 +2,7 @@
   "type": "dataset",
   "id": "brp",
   "title": "Basisregistratie Personen (BRP)",
-  "status": "beschikbaar",
+  "status": "niet_beschikbaar",
   "description": "Deze dataset maakt de basisregistratie personen toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal-Centraal.",
   "version": "0.0.1",
   "crs": "EPSG:28992",
@@ -166,9 +166,7 @@
             "required": []
           }
         },
-        "required": [
-          "burgerservicenummer"
-        ]
+        "required": ["burgerservicenummer"]
       }
     }
   ]


### PR DESCRIPTION
I needed to check this change in with schema validator disabled.
There are quite some issues with this schema. We need to disable
this schema quickly, so these schema issues need to be resolved later.