### PR TITLE
Guido/ab4367 change source owner email addrs

### DIFF
--- a/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
+++ b/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
@@ -14,7 +14,7 @@
   "temporalUnit": "uren",
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "wekelijks",
   "spatialDescription": "Gemeente Amsterdam",

--- a/datasets/financien/financien.json
+++ b/datasets/financien/financien.json
@@ -14,7 +14,7 @@
   "keywords": ["AFS", "AMI", "boekingen", "verplichtingen", "werkorders"],
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/huishoudelijkafval/2.1.0/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/2.1.0/huishoudelijkafval.json
@@ -34,7 +34,7 @@
   "temporalUnit": "uren",
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/rdw/rdw.json
+++ b/datasets/rdw/rdw.json
@@ -6,16 +6,9 @@
   "description": "De RDW is de organisatie die de registratie van gemotoriseerde voertuigen en rijbewijzen in Nederland verzorgt. De RDW is een zelfstandig bestuursorgaan van de Nederlandse overheid.",
   "version": "0.0.1",
   "crs": "EPSG:28992",
-  "contactPoint": {
-    "type": "object",
-    "properties": {
-      "name": {
-        "type": "string"
-      },
-      "email": {
-        "type": "string"
-      }
-    }
+    "contactPoint": {
+    "name": "",
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "objective": "Het doel van deze dataset om op basis van een kenteken contextuele informatie op te vragen.",
   "tables": [

--- a/datasets/referentiekalender/referentiekalender.json
+++ b/datasets/referentiekalender/referentiekalender.json
@@ -13,7 +13,7 @@
   "keywords": ["kalender", "referentie", "datum"],
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/rioolnetwerk/rioolnetwerk.json
+++ b/datasets/rioolnetwerk/rioolnetwerk.json
@@ -14,7 +14,7 @@
   "temporalUnit": "dagen",
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "maandelijks",
   "spatialDescription": "Gemeente Amsterdam",

--- a/datasets/varen/varen.json
+++ b/datasets/varen/varen.json
@@ -14,7 +14,7 @@
   "temporalUnit": "nvt",
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "maandelijks",
   "spatialDescription": "Gemeente Amsterdam",

--- a/datasets/wagenpark/wagenpark.json
+++ b/datasets/wagenpark/wagenpark.json
@@ -34,7 +34,7 @@
   "temporalUnit": "seconden",
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/woningbouwplannen/woningbouwplannen.json
+++ b/datasets/woningbouwplannen/woningbouwplannen.json
@@ -14,7 +14,7 @@
   "temporalUnit": "nvt",
   "contactPoint": {
     "name": "",
-    "email": "datapunt@amsterdam.nl"
+    "email": "datapunt.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "jaarlijks",
   "spatialDescription": "Gemeente Amsterdam",


### PR DESCRIPTION
Those datasets with a default `contactPoint` have their email address updated from `datapunt@amsterdam.nl` to `datapunt.ois@amsterdam.nl` (eg team-datadiensten's email address)

In addition fixed the `rdw` schema. It included a `contactPoint` schema definition  instead of an actual `contactPoint`