### PR TITLE
AB#4367 Fix team datadiensten email address.

### DIFF
--- a/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
+++ b/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
@@ -14,7 +14,7 @@
   "temporalUnit": "uren",
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "wekelijks",
   "spatialDescription": "Gemeente Amsterdam",

--- a/datasets/financien/financien.json
+++ b/datasets/financien/financien.json
@@ -14,7 +14,7 @@
   "keywords": ["AFS", "AMI", "boekingen", "verplichtingen", "werkorders"],
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/huishoudelijkafval/2.1.0/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/2.1.0/huishoudelijkafval.json
@@ -34,7 +34,7 @@
   "temporalUnit": "uren",
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/rdw/rdw.json
+++ b/datasets/rdw/rdw.json
@@ -8,7 +8,7 @@
   "crs": "EPSG:28992",
     "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "objective": "Het doel van deze dataset om op basis van een kenteken contextuele informatie op te vragen.",
   "tables": [

--- a/datasets/referentiekalender/referentiekalender.json
+++ b/datasets/referentiekalender/referentiekalender.json
@@ -13,7 +13,7 @@
   "keywords": ["kalender", "referentie", "datum"],
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/rioolnetwerk/rioolnetwerk.json
+++ b/datasets/rioolnetwerk/rioolnetwerk.json
@@ -14,7 +14,7 @@
   "temporalUnit": "dagen",
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "maandelijks",
   "spatialDescription": "Gemeente Amsterdam",

--- a/datasets/varen/varen.json
+++ b/datasets/varen/varen.json
@@ -14,7 +14,7 @@
   "temporalUnit": "nvt",
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "maandelijks",
   "spatialDescription": "Gemeente Amsterdam",

--- a/datasets/wagenpark/wagenpark.json
+++ b/datasets/wagenpark/wagenpark.json
@@ -34,7 +34,7 @@
   "temporalUnit": "seconden",
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "tables": [
     {

--- a/datasets/woningbouwplannen/woningbouwplannen.json
+++ b/datasets/woningbouwplannen/woningbouwplannen.json
@@ -14,7 +14,7 @@
   "temporalUnit": "nvt",
   "contactPoint": {
     "name": "",
-    "email": "datapunt.ois@amsterdam.nl"
+    "email": "datadiensten.ois@amsterdam.nl"
   },
   "accrualPeriodicity": "jaarlijks",
   "spatialDescription": "Gemeente Amsterdam",


### PR DESCRIPTION
Misread the team datadiensten email address. It should
have been datadiensten.ois@amsterdam.nl.