### PR TITLE
Add documentation about adding private schema location

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See, the `publish` tool expects a number of environment variables to be set.
 These are:
 
 ```console
-DATAPUNT_ENVIRONMENT=[acceptation|production|...]  # default is 'acceptance'
+DATAPUNT_ENVIRONMENT=[acceptance|production|...]  # default is 'acceptance'
 OS_USERNAME=dataservices
 OS_TENANT_NAME=...
 OS_PASSWORD=...
@@ -143,7 +143,7 @@ to follow the references to the metaschema during validation.
 This development location is a `container` on the `dataservices` objectstore.
 
 To create a new container, the `swift` commandline client can be used
-(has been installed via `pip install python-swiftclient`).
+(has been installed as part of `python-swiftclient`) that is a dependency.
 
 Create new container with:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See, the `publish` tool expects a number of environment variables to be set.
 These are:
 
 ```console
-DATAPUNT_ENVIRONMENT=[acceptation|production]
+DATAPUNT_ENVIRONMENT=[acceptation|production|...]  # default is 'acceptance'
 OS_USERNAME=dataservices
 OS_TENANT_NAME=...
 OS_PASSWORD=...
@@ -158,11 +158,17 @@ swift post --read-acl ".r:*,.rlistings" <schemas-yourname>
 ```
 
 Change the `SCHEMA_BASE_URL` environment variable to the http address
-of the container you just created:
+of the container you just created.
 
 ```console
 SCHEMA_BASE_URL=https://<OS_TENANT_NAME>.objectstore.eu/<schemas-yourname>
 ```
+
+The name of the objectstore container is constructed from 2 environment variables:
+`$CONTAINER_PREFIX-$DATAPUNT_ENVIRONMENT`
+
+The default value for `CONTAINER_PREFIX` is `schemas-`.
+
 
 ## Schema updates
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,36 @@ OS_AUTH_URL=https://identity.stack.cloudvps.com/v2.0
 Where the `OS` prefix stands for Object Store,
 and the `...` for values that you should provide.
 
+For development purposes, it can be convenient to publish schemas
+to an isolated development location on the objectstore.
+The `schema:$ref` attributes will be set correctly during the publishing process.
+This is essential for the validator in `schema-tools`
+to follow the references to the metaschema during validation.
+
+This development location is a `container` on the `dataservices` objectstore.
+
+To create a new container, the `swift` commandline client can be used
+(has been installed via `pip install python-swiftclient`).
+
+Create new container with:
+
+```console
+% swift post <schemas-yourname>  # example name, remove <>
+```
+
+Now make this location read-accessible over HTTP with:
+
+```console
+swift post --read-acl ".r:*,.rlistings" <schemas-yourname>
+```
+
+Change the `SCHEMA_BASE_URL` environment variable to the http address
+of the container you just created:
+
+```console
+SCHEMA_BASE_URL=https://<OS_TENANT_NAME>.objectstore.eu/<schemas-yourname>
+```
+
 ## Schema updates
 
 New and/or updated schemas require a version bump of

--- a/src/amsterdam_schema/publish/cli.py
+++ b/src/amsterdam_schema/publish/cli.py
@@ -138,14 +138,23 @@ def replace_schema_base_url(temp_dir: Path, schema_base_url: str) -> None:
     "--dp-env",
     envvar="DATAPUNT_ENVIRONMENT",
     default="acceptance",
-    help="Override the environment to be used, values can be 'acceptance' or 'production'",
+    help="Override the environment to be used, values can be 'acceptance' or 'production'.",
+)
+@click.option(
+    "--container-prefix",
+    envvar="CONTAINER_PREFIX",
+    default="schemas-",
+    help="""Prefix for the name of the objectstore container, default is 'schemas-'
+        This name will be prefixed to the value of DATAPUNT_ENVIRONMENT,
+        to create the full name of the objectstore container.
+    """,
 )
 @click.option(
     "--schema-base-url",
     envvar="SCHEMA_BASE_URL",
-    help="Override the base url in schema files (for testing)",
+    help="Override the base url in schema files (for testing).",
 )
-def main(dp_env: str, schema_base_url: str) -> None:
+def main(dp_env: str, container_prefix: str, schema_base_url: str) -> None:
     ROOT_PKG_NAME = "amsterdam_schema"
     with TemporaryDirectory() as temp_dir:
         files_root = Path(temp_dir)
@@ -181,7 +190,7 @@ def main(dp_env: str, schema_base_url: str) -> None:
                         options={"header": ["content-type:text/html"]},
                     )
                 )
-            uploads = swift.upload(f"schemas-{dp_env}", upload_objects)
+            uploads = swift.upload(f"{container_prefix}{dp_env}", upload_objects)
             errors = False
             for r in uploads:
                 if not r["success"]:


### PR DESCRIPTION
During development, it can be convient to publish the amsterdam-schema datasets to a personal development container in the objectstore (and not to ACC or PRD). Because, during publication, the `schema $ref` urls will be changed to point to the correct location. This is essential to be able to use the `json-schema` validation.

This PR adds documentation describing how to create such a personal container in the objectstore.