### PR TITLE
Yrob/#ab5522 separate id from url

### DIFF
--- a/datasets/aardgasvrijezones/aardgasvrijezones.json
+++ b/datasets/aardgasvrijezones/aardgasvrijezones.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "aardgasvrijezones",
+  "path": "aardgasvrijezones",
   "title": "Aardgasvrije buurten en buurtinitiatieven",
   "description": "(Deels) gerealiseerde of geplande aardgasvrije buurten, en buurtinitiatieven voor aardgasvrij in Amsterdam",
   "license": "public",

--- a/datasets/anpr/anpr.json
+++ b/datasets/anpr/anpr.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "anpr",
+    "path": "anpr",
     "title": "Automatic Number Plate Recognition",
     "status": "beschikbaar",
     "description": "Gegevens over automatisch gedecteerde kentekenplaten",

--- a/datasets/asbestdaken/asbestdaken.json
+++ b/datasets/asbestdaken/asbestdaken.json
@@ -1,5 +1,6 @@
 {
     "id": "asbestdaken",
+    "path": "asbestdaken",
     "type": "dataset",
     "title": "Asbestdaken",
     "status": "niet_beschikbaar",
@@ -101,4 +102,3 @@
         }
     ]
 }
-

--- a/datasets/bag/bag.json
+++ b/datasets/bag/bag.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "bag",
+  "path": "bag",
   "title": "bag",
   "status": "niet_beschikbaar",
   "version": "0.0.1",

--- a/datasets/basiskaart/basiskaart.json
+++ b/datasets/basiskaart/basiskaart.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "basiskaart",
+  "path": "basiskaart",
   "title": "Basiskaart",
   "description": "Gegevens uit BGT (basisregistratie grootschalige topografie) en KBK (kleinschalige basis kaart)",
   "license": "public",
@@ -8,7 +9,7 @@
   "version": "0.0.1",
   "publisher": "OIS",
   "owner": "Gemeente Amsterdam",
-  "authorizationGrantor": "OIS", 
+  "authorizationGrantor": "OIS",
   "keywords": ["GBT", "KBK", "KBK10", "KBK50"],
   "crs": "EPSG:28992",
   "tables": [

--- a/datasets/bbga/bbga.json
+++ b/datasets/bbga/bbga.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "bbga",
+    "path": "bbga",
   "title": "BBGA",
   "status": "beschikbaar",
   "description": "Basisbestand Gebieden Amsterdam",

--- a/datasets/bbga/bbga.json
+++ b/datasets/bbga/bbga.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "bbga",
-    "path": "bbga",
+  "path": "bbga",
   "title": "BBGA",
   "status": "beschikbaar",
   "description": "Basisbestand Gebieden Amsterdam",

--- a/datasets/bedrijveninvesteringszones/bedrijveninvesteringszones.json
+++ b/datasets/bedrijveninvesteringszones/bedrijveninvesteringszones.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "bedrijveninvesteringszones",
+    "path": "bedrijveninvesteringszones",
   "title": "Bedrijveninvesteringszones",
   "description": "Bedrijveninvesteringszones in Amsterdam",
   "license": "public",

--- a/datasets/bedrijveninvesteringszones/bedrijveninvesteringszones.json
+++ b/datasets/bedrijveninvesteringszones/bedrijveninvesteringszones.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "bedrijveninvesteringszones",
-    "path": "bedrijveninvesteringszones",
+  "path": "bedrijveninvesteringszones",
   "title": "Bedrijveninvesteringszones",
   "description": "Bedrijveninvesteringszones in Amsterdam",
   "license": "public",

--- a/datasets/beheerkaart_basis/beheerkaart_basis.json
+++ b/datasets/beheerkaart_basis/beheerkaart_basis.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "beheerkaart_basis",
-    "path": "beheerkaart_basis",
+  "path": "beheerkaart_basis",
   "title": "beheerkaart_basis",
   "status": "beschikbaar",
   "description": "Voor het beheer van de publieke ruimte, heeft Amsterdam behoefte aan een eenduidige afbakening van de te beheren objecten. De formeel vastgestelde openbare ruimte volstaat hiervoor niet, omdat het uitgaat van de toekenning van officiële straatnamen (besluit) door de gemeenteraad. Daardoor zijn niet alle te beheren objecten onderdeel van de administratieve openbare ruimte. Om die reden heeft OIS de 'te beheren publieke ruimte’ afgeleid uit de basisregistraties grootschalige topografie (BGT) en Kadaster (BRK).",

--- a/datasets/beheerkaart_basis/beheerkaart_basis.json
+++ b/datasets/beheerkaart_basis/beheerkaart_basis.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "beheerkaart_basis",
+    "path": "beheerkaart_basis",
   "title": "beheerkaart_basis",
   "status": "beschikbaar",
   "description": "Voor het beheer van de publieke ruimte, heeft Amsterdam behoefte aan een eenduidige afbakening van de te beheren objecten. De formeel vastgestelde openbare ruimte volstaat hiervoor niet, omdat het uitgaat van de toekenning van officiële straatnamen (besluit) door de gemeenteraad. Daardoor zijn niet alle te beheren objecten onderdeel van de administratieve openbare ruimte. Om die reden heeft OIS de 'te beheren publieke ruimte’ afgeleid uit de basisregistraties grootschalige topografie (BGT) en Kadaster (BRK).",

--- a/datasets/beheerkaart_cbs_grid/beheerkaart_cbs_grid.json
+++ b/datasets/beheerkaart_cbs_grid/beheerkaart_cbs_grid.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "beheerkaartCbsGrid",
-    "path": "beheerkaartCbsGrid",
+  "path": "beheerkaartCbsGrid",
   "title": "beheerkaart_cbs_grid",
   "status": "beschikbaar",
   "description": "Integratie van elementen beheerkaart publieke ruimte en landelijk CBSgrid",

--- a/datasets/beheerkaart_cbs_grid/beheerkaart_cbs_grid.json
+++ b/datasets/beheerkaart_cbs_grid/beheerkaart_cbs_grid.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "beheerkaartCbsGrid",
+    "path": "beheerkaartCbsGrid",
   "title": "beheerkaart_cbs_grid",
   "status": "beschikbaar",
   "description": "Integratie van elementen beheerkaart publieke ruimte en landelijk CBSgrid",

--- a/datasets/bekendmakingen/bekendmakingen.json
+++ b/datasets/bekendmakingen/bekendmakingen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "bekendmakingen",
-    "path": "bekendmakingen",
+  "path": "bekendmakingen",
   "title": "Bekendmakingen en kennisgevingen",
   "description": "Bekendmakingen en kennisgevingen voor bijvoorbeeld aanvragen voor vergunningen en ontheffingen en besluiten hierover, algemene mededelingen van de gemeente of inspraakmogelijkheden.",
   "license": "public",

--- a/datasets/bekendmakingen/bekendmakingen.json
+++ b/datasets/bekendmakingen/bekendmakingen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "bekendmakingen",
+    "path": "bekendmakingen",
   "title": "Bekendmakingen en kennisgevingen",
   "description": "Bekendmakingen en kennisgevingen voor bijvoorbeeld aanvragen voor vergunningen en ontheffingen en besluiten hierover, algemene mededelingen van de gemeente of inspraakmogelijkheden.",
   "license": "public",

--- a/datasets/belastingen/belastingen.json
+++ b/datasets/belastingen/belastingen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "belastingen",
+    "path": "belastingen",
   "title": "Belastingen",
   "status": "beschikbaar",
   "description": "Belastinggebieden en gerelateerde tarieven.",

--- a/datasets/belastingen/belastingen.json
+++ b/datasets/belastingen/belastingen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "belastingen",
-    "path": "belastingen",
+  "path": "belastingen",
   "title": "Belastingen",
   "status": "beschikbaar",
   "description": "Belastinggebieden en gerelateerde tarieven.",

--- a/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
+++ b/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
@@ -1,6 +1,6 @@
 {
   "id": "beschermdestadsdorpsgezichten",
-    "path": "beschermdestadsdorpsgezichten",
+  "path": "beschermdestadsdorpsgezichten",
   "type": "dataset",
   "title": "Beschermde stads- en dorpsgezichten",
   "description": "Alle gemeentelijke en rijks aangewezen beschermde stads- en dorpsgezichten in de Gemeente Amsterdam.",

--- a/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
+++ b/datasets/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten.json
@@ -1,5 +1,6 @@
 {
   "id": "beschermdestadsdorpsgezichten",
+    "path": "beschermdestadsdorpsgezichten",
   "type": "dataset",
   "title": "Beschermde stads- en dorpsgezichten",
   "description": "Alle gemeentelijke en rijks aangewezen beschermde stads- en dorpsgezichten in de Gemeente Amsterdam.",

--- a/datasets/blackspots/blackspots.json
+++ b/datasets/blackspots/blackspots.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "blackspots",
-    "path": "blackspots",
+  "path": "blackspots",
   "title": "blackspots",
   "status": "beschikbaar",
   "description": "Blackspots",

--- a/datasets/blackspots/blackspots.json
+++ b/datasets/blackspots/blackspots.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "blackspots",
+    "path": "blackspots",
   "title": "blackspots",
   "status": "beschikbaar",
   "description": "Blackspots",

--- a/datasets/bodem/bodem.json
+++ b/datasets/bodem/bodem.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "bodem",
+    "path": "bodem",
     "title": "Bodemonderzoeken",
     "status": "beschikbaar",
     "description": "Informatie over onderzoeken naar asbest, grond en grondwater",
@@ -30,7 +31,7 @@
             },
             "locatie": {
               "type": "string",
-              "description": "Naam van de locatie waar de meting is uitgevoerd",         
+              "description": "Naam van de locatie waar de meting is uitgevoerd",
               "provenance":"locatienaam"
             },
             "amNummer": {
@@ -39,7 +40,7 @@
             },
             "typeOnderzoek": {
               "type": "string",
-              "enum": ["Verkennend Onderzoek 5","Monitoring 3","Verkennend Onderzoek 10","Besluit Opslag Ondergrondse Tanks 1","Sanerings Onderzoek 1","Nader Onderzoek 4","Nulsituatie Onderzoek 1","Orienterend Onderzoek 3","Overig 4","Besluit Opslag Ondergrondse Tanks 3","Orienterend Onderzoek 1","Indicatief Onderzoek 2","Overig 1","Verkennend Onderzoek 1","Sanerings Plan 1","Evaluatie Sanering 4","Evaluatie Sanering 2","Verkennend Onderzoek 9","Nulsituatie Onderzoek 7","Sanerings Plan 4","Indicatief Onderzoek 7","Evaluatie Sanering 6","Nader Onderzoek 3","Nulsituatie Onderzoek 6","Overig 3","Nader Onderzoek 7","Verkennend Onderzoek 6","Nader Onderzoek 6","Evaluatie Sanering 3","Beperkt Onderzoek, BSB-combi-protoco","Verkennend Onderzoek 3","Nader Onderzoek 2","Besluit Opslag Ondergrondse Tanks 2"]            
+              "enum": ["Verkennend Onderzoek 5","Monitoring 3","Verkennend Onderzoek 10","Besluit Opslag Ondergrondse Tanks 1","Sanerings Onderzoek 1","Nader Onderzoek 4","Nulsituatie Onderzoek 1","Orienterend Onderzoek 3","Overig 4","Besluit Opslag Ondergrondse Tanks 3","Orienterend Onderzoek 1","Indicatief Onderzoek 2","Overig 1","Verkennend Onderzoek 1","Sanerings Plan 1","Evaluatie Sanering 4","Evaluatie Sanering 2","Verkennend Onderzoek 9","Nulsituatie Onderzoek 7","Sanerings Plan 4","Indicatief Onderzoek 7","Evaluatie Sanering 6","Nader Onderzoek 3","Nulsituatie Onderzoek 6","Overig 3","Nader Onderzoek 7","Verkennend Onderzoek 6","Nader Onderzoek 6","Evaluatie Sanering 3","Beperkt Onderzoek, BSB-combi-protoco","Verkennend Onderzoek 3","Nader Onderzoek 2","Besluit Opslag Ondergrondse Tanks 2"]
             },
             "rapportnummer": {
               "type": "string"
@@ -50,7 +51,7 @@
               "provenance": "bureau"
             },
             "rapportdatum": {
-                "type": "string"                
+                "type": "string"
             },
             "naamBoring": {
                 "type": "string",
@@ -72,10 +73,10 @@
                 "type": "string",
                 "enum": ["Monster", "Mengmonster"],
                 "provenance": "monster_mengmonster"
-            },   
+            },
             "materiaal": {
                 "type": "string",
-                "enum": ["grond"],                
+                "enum": ["grond"],
                 "description": "Het materiaal waarop de meting betrekking heeft"
             }
             , "bovenkant": {
@@ -88,60 +89,60 @@
                 "type": "string"
             }
             , "waardeLutum": {
-                "type": "number",                
-                "multipleOf": 0.01, 
+                "type": "number",
+                "multipleOf": 0.01,
                 "provenance": "lutum"
             }
             , "waardeOrganischeStof": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "organische_stof"
             }
             , "waardeCadmium": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "cadmium"
             }
             , "waardeKwik": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "kwik"
             }
             , "waardeKoper": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "koper"
             }
             , "waardeNikkel": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "nikkel"
             }
             , "waardeLood": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "lood"
             }
             , "waardeZink": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "zink"
             }
             , "waardeChroom": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "chroom"
             }
             , "waardeArseen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "arseen"
-            } 
+            }
             , "waardePak": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "pak"
             }
             , "waardeEox": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "eox"
             }
             , "waardePcb": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "pcb"
             }
             , "waardeMineraleOlie": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "minerale_olie"
             }
           }
@@ -181,21 +182,21 @@
             },
             "typeOnderzoek": {
               "type": "string",
-              "enum": ["1","4","9","8","12","7","13","5","14","6","3","11","2","VIJF TERREINEN"]            
-            },            
+              "enum": ["1","4","9","8","12","7","13","5","14","6","3","11","2","VIJF TERREINEN"]
+            },
             "rapportnummer": {
               "type": "string"
             },
             "naamBoring": {
                 "type": "string",
                 "description": "Naam van de uitgevoerde meting / boring bestaande"
-            }, 
+            },
             "grondwaterstand": {
                 "type": "integer"
             },
             "naamMonster": {
                 "type": "string"
-            },          
+            },
             "bovenkant": {
                 "type": "integer"
             },
@@ -206,160 +207,160 @@
                 "type": "string"
             }
             , "waardeDichloorethaan11": {
-                "type": "number",                
-                "multipleOf": 0.01, 
+                "type": "number",
+                "multipleOf": 0.01,
                 "provenance": "dichloorethaan_11"
             }
             , "waardeDichlooretheen11": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichlooretheen_11"
             }
             , "waardeTrichloorethaan111": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "trichloorethaan_111"
             }
             , "waardeTrichloorethaan112": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "trichloorethaan_112"
             }
             , "waardeDichloorethaan12": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichloorethaan_12"
             }
             , "waardeDichlooretheen12": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichlooretheen_12"
             }
             , "waardeDichloorpropaan12": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichloorpropaan_12"
             }
             , "waardeDichloorpropeen13": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichloorpropeen_13"
             }
             , "waardeBarium": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "barium"
             }
             , "waardeArseen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "arseen"
-            } 
+            }
             , "waardeBenzeen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "benzeen"
             }
             , "waardeCadmium": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "cadmium"
             }
             , "waardeChloride": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "chloride"
             }
             , "waardeChloroform": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "chloroform"
             }
             , "waardeCisDichlooretheen12": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "cis_dichlooretheen_12"
             }
             , "waardeCobalt": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "cobalt"
             }
             , "waardeDichloorbenzenen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichloorbenzenen"
             }
             , "waardeDichloormethaan": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "dichloormethaan"
             }
             , "waardeEthylbenzeen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "ethylbenzeen"
             }
             , "waardeKoper": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "koper"
             }
             , "waardeKwik": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "kwik"
             }
             , "waardeLood": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "lood"
             }
             , "waardeMineraleOlie": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "minerale_olie"
             }
             , "waardeMolybdeen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "molybdeen"
             }
             , "waardeMonochloorbenzeen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "monochloorbenzeen"
             }
             , "waardeNaftaleen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "naftaleen"
             }
             , "waardeNikkel": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "nikkel"
             }
             , "waardePh": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "ph"
             }
             , "waardeStyreen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "styreen"
             }
             , "waardeTetrachlooretheen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "tetrachlooretheen"
             }
             , "waardeTetrachloormethaan": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "tetrachloormethaan"
             }
             , "waardeTolueen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "tolueen"
             }
             , "waardeTransDichlooretheen12": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "trans_dichlooretheen_12"
             }
             , "waardeTribroommethaan": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "tribroommethaan"
             }
             , "waardeTrichlooretheen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "trichlooretheen"
             }
             , "waardeTrichloormethaan": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "trichloormethaan"
             }
             , "waardeVinylchloride": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "vinylchloride"
             }
             , "waardeXylenen": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "xylenen"
             }
             , "waardeZink": {
-                "type": "integer",                
+                "type": "integer",
                 "provenance": "zink"
             }
           }
@@ -386,13 +387,13 @@
             "geometry": {
               "$ref": "https://geojson.org/schema/Geometry.json",
               "provenance": "geometrie"
-            },   
+            },
             "xcoordinaat": {
                 "type": "number"
-            }, 
+            },
             "ycoordinaat": {
                 "type": "number"
-            },   
+            },
             "locatie": {
               "type": "string",
               "description": "Naam van de locatie waar de meting is uitgevoerd",
@@ -400,17 +401,17 @@
             },
             "materiaal": {
                 "type": "string",
-                "enum": ["grond"],                
+                "enum": ["grond"],
                 "description": "Het materiaal waarop de meting betrekking heeft"
-            },            
+            },
             "typeOnderzoek": {
               "type": "string",
-              "enum": ["Verkennend Onderzoek 5","Verkennend Onderzoek 3","Nader Onderzoek 2","Indicatief Onderzoek 1","Indicatief Onderzoek 3","Verkennend Onderzoek 10","Orienterend Onderzoek 2","Nader Onderzoek 4","Nulsituatie Onderzoek 1","Orienterend Onderzoek 3","Overig 2","Orienterend Onderzoek 1","Indicatief Onderzoek 2","Overig 1","Verkennend Onderzoek 7","Verkennend Onderzoek 1","Sanerings Plan 1","Evaluatie Sanering 2","Verkennend Onderzoek 8","Verkennend Onderzoek 9","Verkennend Onderzoek 2","Sanerings Plan 4","Nader Onderzoek 5","Nader Onderzoek 1","Nader Onderzoek 3","Indicatief Onderzoek 4","Overig 3","Verkennend Onderzoek 4","Nader Onderzoek 7","Evaluatie Sanering 1","Verkennend Onderzoek 6","Nader Onderzoek 6","Evaluatie Sanering 3"]            
-            },  
+              "enum": ["Verkennend Onderzoek 5","Verkennend Onderzoek 3","Nader Onderzoek 2","Indicatief Onderzoek 1","Indicatief Onderzoek 3","Verkennend Onderzoek 10","Orienterend Onderzoek 2","Nader Onderzoek 4","Nulsituatie Onderzoek 1","Orienterend Onderzoek 3","Overig 2","Orienterend Onderzoek 1","Indicatief Onderzoek 2","Overig 1","Verkennend Onderzoek 7","Verkennend Onderzoek 1","Sanerings Plan 1","Evaluatie Sanering 2","Verkennend Onderzoek 8","Verkennend Onderzoek 9","Verkennend Onderzoek 2","Sanerings Plan 4","Nader Onderzoek 5","Nader Onderzoek 1","Nader Onderzoek 3","Indicatief Onderzoek 4","Overig 3","Verkennend Onderzoek 4","Nader Onderzoek 7","Evaluatie Sanering 1","Verkennend Onderzoek 6","Nader Onderzoek 6","Evaluatie Sanering 3"]
+            },
             "naamBoring": {
                 "type": "string",
                 "description": "Naam van de uitgevoerde meting / boring bestaande"
-            },         
+            },
             "naamMonster": {
                 "type": "string"
             },
@@ -418,19 +419,19 @@
                 "type": "string",
                 "enum": ["Monster", "Mengmonster"],
                 "provenance": "monster_mengmonster"
-            },            
+            },
             "bovenkant": {
                 "type": "integer"
             },
             "onderkant": {
                 "type": "integer"
-            },           
+            },
             "waardeConcentratie": {
                 "type": "integer",
                 "provenance": "concentratie"
             },
             "stof": {
-                "type": "string",                
+                "type": "string",
                 "enum": ["Asbest (som)"]
             }
           }

--- a/datasets/bouwstroompunten/bouwstroompunten.json
+++ b/datasets/bouwstroompunten/bouwstroompunten.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "bouwstroompunten",
+    "path": "bouwstroompunten",
     "title": "Bouwstroompunten",
     "status": "beschikbaar",
     "description": "Informatie over bouwstroompunten",
@@ -29,7 +30,7 @@
                 "provenance":"power_station_id"
               },
             "geometry": {
-              "$ref": "https://geojson.org/schema/Geometry.json"              
+              "$ref": "https://geojson.org/schema/Geometry.json"
             },
             "provincie": {
               "type": "string",
@@ -37,7 +38,7 @@
             },
             "capaciteit": {
               "type": "string",
-              "provenance":"capacity"            
+              "provenance":"capacity"
             },
             "locatie": {
               "type": "string",
@@ -58,7 +59,7 @@
             "straat": {
               "type": "string",
               "provenance": "street"
-            },            
+            },
             "huisnummer": {
               "type": "string",
               "provenance": "house_number"
@@ -71,7 +72,7 @@
               "type": "boolean",
               "enum": [true, false],
               "provenance": "licence_needed"
-            },            
+            },
             "contactPersoon": {
               "type": "string",
               "provenance": "contact_person"
@@ -85,21 +86,20 @@
               "provenance": "municipality"
             },
             "email": {
-              "type": "string"              
+              "type": "string"
             },
             "datumtijdAangemaakt": {
               "type": "string",
-              "format": "date-time",    
-              "provenance": "createdat"          
+              "format": "date-time",
+              "provenance": "createdat"
             },
             "datumtijdGewijzigd": {
-              "type": "string", 
-              "format": "date-time",               
-              "provenance": "updatedat"          
+              "type": "string",
+              "format": "date-time",
+              "provenance": "updatedat"
             }
           }
         }
-      }  
+      }
     ]
   }
-  

--- a/datasets/brk/brk.json
+++ b/datasets/brk/brk.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "brk",
-    "path": "brk",
+  "path": "brk",
   "title": "brk",
   "status": "niet_beschikbaar",
   "version": "0.0.1",

--- a/datasets/brk/brk.json
+++ b/datasets/brk/brk.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "brk",
+    "path": "brk",
   "title": "brk",
   "status": "niet_beschikbaar",
   "version": "0.0.1",

--- a/datasets/brp/brp.json
+++ b/datasets/brp/brp.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "brp",
-    "path": "brp",
+  "path": "brp",
   "title": "Basisregistratie Personen (BRP)",
   "status": "niet_beschikbaar",
   "description": "Deze dataset maakt de basisregistratie personen toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal-Centraal.",

--- a/datasets/brp/brp.json
+++ b/datasets/brp/brp.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "brp",
+    "path": "brp",
   "title": "Basisregistratie Personen (BRP)",
   "status": "niet_beschikbaar",
   "description": "Deze dataset maakt de basisregistratie personen toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal-Centraal.",

--- a/datasets/cmsa/cmsa.json
+++ b/datasets/cmsa/cmsa.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "cmsa",
-    "path": "cmsa",
+  "path": "cmsa",
   "title": "CMSA: Crowd Monitoring Systeem Amsterdam",
   "status": "beschikbaar",
   "description": "Locaties en context t.a.v. crowd monitoring sensoren: 3D sensoren, wifi sensoren, (tel)camera's en beacons.",

--- a/datasets/cmsa/cmsa.json
+++ b/datasets/cmsa/cmsa.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "cmsa",
+    "path": "cmsa",
   "title": "CMSA: Crowd Monitoring Systeem Amsterdam",
   "status": "beschikbaar",
   "description": "Locaties en context t.a.v. crowd monitoring sensoren: 3D sensoren, wifi sensoren, (tel)camera's en beacons.",

--- a/datasets/corona/corona.json
+++ b/datasets/corona/corona.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "corona",
+    "path": "corona",
   "title": "corona",
   "status": "beschikbaar",
   "description": "Corona datasets voor handhaving",

--- a/datasets/corona/corona.json
+++ b/datasets/corona/corona.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "corona",
-    "path": "corona",
+  "path": "corona",
   "title": "corona",
   "status": "beschikbaar",
   "description": "Corona datasets voor handhaving",

--- a/datasets/covid_19/covid_19.json
+++ b/datasets/covid_19/covid_19.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "covid_19",
+    "path": "covid_19",
   "title": "Covid19 gebiedsrestricties",
   "description": "Gebieden die op grond van artikel 2.8 van de Algemene Plaatselijke Verordening (APV) als algemeen overlastgebied of als dealeroverlastgebied (of beiden) zijn aagewezen",
   "license": "public",

--- a/datasets/covid_19/covid_19.json
+++ b/datasets/covid_19/covid_19.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "covid_19",
-    "path": "covid_19",
+  "path": "covid_19",
   "title": "Covid19 gebiedsrestricties",
   "description": "Gebieden die op grond van artikel 2.8 van de Algemene Plaatselijke Verordening (APV) als algemeen overlastgebied of als dealeroverlastgebied (of beiden) zijn aagewezen",
   "license": "public",

--- a/datasets/crowdmonitor/crowdmonitor.json
+++ b/datasets/crowdmonitor/crowdmonitor.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "crowdmonitor",
+    "path": "crowdmonitor",
     "title": "crowdmonitor",
     "status": "beschikbaar",
     "description": "Het aantal passanten per locatie, per sensor, per periode. De periode kan zijn 'uur', 'dag' of 'week' en begint op 'datumUur'",

--- a/datasets/deelmobiliteit/deelmobiliteit.json
+++ b/datasets/deelmobiliteit/deelmobiliteit.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "deelmobiliteit",
-    "path": "deelmobiliteit",
+  "path": "deelmobiliteit",
   "title": "Deelmobiliteit",
   "description": "Locaties en contextuele informatie over deelvoertuigen zoals auto’s, fietsen en scooters.",
   "license": "public",

--- a/datasets/deelmobiliteit/deelmobiliteit.json
+++ b/datasets/deelmobiliteit/deelmobiliteit.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "deelmobiliteit",
+    "path": "deelmobiliteit",
   "title": "Deelmobiliteit",
   "description": "Locaties en contextuele informatie over deelvoertuigen zoals auto’s, fietsen en scooters.",
   "license": "public",

--- a/datasets/evenementen/evenementen.json
+++ b/datasets/evenementen/evenementen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "evenementen",
-    "path": "evenementen",
+  "path": "evenementen",
   "title": "Evenementen",
   "description": "Evenementen in Amsterdam",
   "license": "public",

--- a/datasets/evenementen/evenementen.json
+++ b/datasets/evenementen/evenementen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "evenementen",
+    "path": "evenementen",
   "title": "Evenementen",
   "description": "Evenementen in Amsterdam",
   "license": "public",

--- a/datasets/explosieven/explosieven.json
+++ b/datasets/explosieven/explosieven.json
@@ -1,11 +1,12 @@
 {
     "type": "dataset",
     "id": "explosieven",
+    "path": "explosieven",
     "title": "explosieven",
-    "description": "Informatie over bominslagen, gevrijwaarde gebieden, verdachte gebieden en uitgevoerde onderzoeken",  
+    "description": "Informatie over bominslagen, gevrijwaarde gebieden, verdachte gebieden en uitgevoerde onderzoeken",
     "license": "public",
     "status": "beschikbaar",
-    "version": "0.0.1",  
+    "version": "0.0.1",
     "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],
     "publisher": "OIS",
     "owner": "Gemeente Amsterdam",
@@ -35,7 +36,7 @@
               } ,
               "kenmerk": {
                   "type": "string"
-              },                        
+              },
               "detailType": {
                   "type": "string",
                   "provenance":"soort_hand"
@@ -58,12 +59,12 @@
               "opmerkingen": {
                   "type": "string",
                   "provenance":"opmerkinge"
-              }              
+              }
             }
           }
         },
         {
-          "id": "bominslag",          
+          "id": "bominslag",
           "title": "Bominslag",
           "type": "table",
           "schema": {
@@ -84,7 +85,7 @@
                 "provenance": "geometrie"
               },
               "kenmerk": {
-                "type": "string"                       
+                "type": "string"
               },
               "detailType": {
                 "type": "string",
@@ -92,18 +93,18 @@
               },
               "datumInslag": {
                 "type": "string",
-                "format":"date",    
+                "format":"date",
                 "provenance":"datum"
               },
               "datum": {
                 "type": "string",
-                "format":"date",    
+                "format":"date",
                 "provenance":"datum1"
-              },             
+              },
               "bron": {
                 "type": "string",
                 "provenance":"bron1"
-              },             
+              },
               "intekening": {
                 "type": "string"
               },
@@ -115,14 +116,14 @@
                 "provenance":"opmerkinge"
               },
               "oorlogsinc": {
-                "type": "string"               
+                "type": "string"
               } ,
               "pdf": {
                 "type": "string",
-                "format": "uri",                
+                "format": "uri",
                 "provenance":"hyperlink"
-              }                             
-                         
+              }
+
             }
           }
         },
@@ -145,54 +146,54 @@
               },
               "geometry": {
                 "$ref": "https://geojson.org/schema/Geometry.json"
-              },            
+              },
               "kenmerk": {
                 "type": "string"
-              },              
+              },
               "detailType": {
                 "type": "string",
                 "provenance":"hoofdgroep"
-              },                     
+              },
               "subtype": {
                 "type": "string",
                 "provenance":"subsoort"
-              },            
+              },
               "kaliber": {
                 "type": "string"
-              },            
+              },
               "aantal": {
                 "type": "string",
                 "provenance":"aantallen"
-              },            
+              },
               "verschijning": {
                 "type": "string",
                 "provenance":"verschijni"
-              },            
+              },
               "oorlogshandeling": {
                 "type": "string",
                 "provenance":"oorlogshan"
-              },            
+              },
               "afbakening": {
-                "type": "string"                  
-              },            
+                "type": "string"
+              },
               "horizontaal": {
                 "type": "string",
                 "provenance":"horizontal"
-              },            
+              },
               "cartografie": {
                 "type": "string",
                 "provenance":"cartografi"
-              },            
+              },
               "opmerkingen": {
                 "type": "string",
                 "provenance":"opmerkinge"
-              },           
+              },
               "pdf": {
-                "type": "string", 
-                "format": "uri",              
+                "type": "string",
+                "format": "uri",
                 "provenance":"hyperlink"
-              }         
-                   
+              }
+
             }
           }
         },
@@ -218,7 +219,7 @@
                 } ,
                 "kenmerk": {
                     "type": "string"
-                },                
+                },
                 "detailType": {
                     "type": "string",
                     "provenance":"soort_rapp"
@@ -241,11 +242,10 @@
                 },
                 "datum": {
                     "type": "string",
-                    "format":"date"                   
-                }                           
+                    "format":"date"
+                }
               }
             }
-          }              
+          }
       ]
     }
-  

--- a/datasets/fietspaaltjes/fietspaaltjes.json
+++ b/datasets/fietspaaltjes/fietspaaltjes.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "fietspaaltjes",
-    "path": "fietspaaltjes",
+  "path": "fietspaaltjes",
   "title": "fietspaaltjes",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/fietspaaltjes/fietspaaltjes.json
+++ b/datasets/fietspaaltjes/fietspaaltjes.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "fietspaaltjes",
+    "path": "fietspaaltjes",
   "title": "fietspaaltjes",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/financien/financien.json
+++ b/datasets/financien/financien.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "financien",
-    "path": "financien",
+  "path": "financien",
   "title": "Financien",
   "status": "beschikbaar",
   "description": "directie OIS (Onderzoek, Informatie en Statistiek) financiele gegevens uit centrale administratie Amsterdam Financieel Systeem (AFS) via DWH Amsterdamse Management Informatie (AMI)",

--- a/datasets/financien/financien.json
+++ b/datasets/financien/financien.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "financien",
+    "path": "financien",
   "title": "Financien",
   "status": "beschikbaar",
   "description": "directie OIS (Onderzoek, Informatie en Statistiek) financiele gegevens uit centrale administratie Amsterdam Financieel Systeem (AFS) via DWH Amsterdamse Management Informatie (AMI)",

--- a/datasets/gebieden/gebieden.json
+++ b/datasets/gebieden/gebieden.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "gebieden",
-    "path": "gebieden",
+  "path": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/gebieden/gebieden.json
+++ b/datasets/gebieden/gebieden.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "gebieden",
+    "path": "gebieden",
   "title": "gebieden",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/geluidszones/geluidszones.json
+++ b/datasets/geluidszones/geluidszones.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "geluidszones",
+    "path": "geluidszones",
     "title": "geluidszones",
     "description": "Informatie over geluidszones metro, spoorwegen, industrie en schiphol",
     "license": "public",
@@ -187,4 +188,3 @@
       }
     ]
   }
-  

--- a/datasets/grex/grex.json
+++ b/datasets/grex/grex.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "grex",
+    "path": "grex",
   "title": "grex",
   "status": "beschikbaar",
   "description": "Grondexploitatie projecten",

--- a/datasets/grex/grex.json
+++ b/datasets/grex/grex.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "grex",
-    "path": "grex",
+  "path": "grex",
   "title": "grex",
   "status": "beschikbaar",
   "description": "Grondexploitatie projecten",

--- a/datasets/hcbrk/hcbrk.json
+++ b/datasets/hcbrk/hcbrk.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "hcbrk",
+    "path": "hcbrk",
   "title": "BRK van HaalCentraal",
   "status": "beschikbaar",
   "description": "Deze dataset maakt de HaalCentraal BRK API toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal-Centraal.",

--- a/datasets/hcbrk/hcbrk.json
+++ b/datasets/hcbrk/hcbrk.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "hcbrk",
-    "path": "hcbrk",
+  "path": "hcbrk",
   "title": "BRK van HaalCentraal",
   "status": "beschikbaar",
   "description": "Deze dataset maakt de HaalCentraal BRK API toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal-Centraal.",

--- a/datasets/hoofdroutes/hoofdroutes.json
+++ b/datasets/hoofdroutes/hoofdroutes.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "hoofdroutes",
+    "path": "hoofdroutes",
   "title": "Hoofdwegen",
   "status": "beschikbaar",
   "description": "Hoofdwegen",

--- a/datasets/hoofdroutes/hoofdroutes.json
+++ b/datasets/hoofdroutes/hoofdroutes.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "hoofdroutes",
-    "path": "hoofdroutes",
+  "path": "hoofdroutes",
   "title": "Hoofdwegen",
   "status": "beschikbaar",
   "description": "Hoofdwegen",

--- a/datasets/horeca/horeca.json
+++ b/datasets/horeca/horeca.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "horeca",
+    "path": "horeca",
   "title": "horeca",
   "status": "beschikbaar",
   "description": null,

--- a/datasets/horeca/horeca.json
+++ b/datasets/horeca/horeca.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "horeca",
-    "path": "horeca",
+  "path": "horeca",
   "title": "horeca",
   "status": "beschikbaar",
   "description": null,

--- a/datasets/hr/hr.json
+++ b/datasets/hr/hr.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "hr",
+    "path": "hr",
   "title": "hr",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/hr/hr.json
+++ b/datasets/hr/hr.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "hr",
-    "path": "hr",
+  "path": "hr",
   "title": "hr",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/huishoudelijkafval/2.0.0/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/2.0.0/huishoudelijkafval.json
@@ -1,5 +1,6 @@
 {
   "id": "huishoudelijkafval",
+    "path": "huishoudelijkafval",
   "type": "dataset",
   "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
   "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],

--- a/datasets/huishoudelijkafval/2.0.0/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/2.0.0/huishoudelijkafval.json
@@ -1,6 +1,6 @@
 {
   "id": "huishoudelijkafval",
-    "path": "huishoudelijkafval",
+  "path": "huishoudelijkafval",
   "type": "dataset",
   "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
   "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],

--- a/datasets/huishoudelijkafval/2.1.0/huishoudelijkafval.json
+++ b/datasets/huishoudelijkafval/2.1.0/huishoudelijkafval.json
@@ -1,5 +1,6 @@
 {
   "id": "huishoudelijkafval",
+    "path": "huishoudelijkafval",
   "type": "dataset",
   "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
   "theme": ["Wonen", "duurzaamheid en milieu", "Ruimte en Topografie"],

--- a/datasets/leidingeninfrastructuur/leidingeninfrastructuur.json
+++ b/datasets/leidingeninfrastructuur/leidingeninfrastructuur.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "leidingeninfrastructuur",
+    "path": "leidingeninfrastructuur",
   "title": "Kabels en leidingen ondergrond",
   "status": "beschikbaar",
   "description": "Overzicht leidingen infrastructuur op basis van klic meldingen",

--- a/datasets/meetbouten/meetbouten.json
+++ b/datasets/meetbouten/meetbouten.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "meetbouten",
+    "path": "meetbouten",
   "title": "meetbouten",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/meetbouten/meetbouten.json
+++ b/datasets/meetbouten/meetbouten.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "meetbouten",
-    "path": "meetbouten",
+  "path": "meetbouten",
   "title": "meetbouten",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/meldingen/meldingen.json
+++ b/datasets/meldingen/meldingen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "meldingen",
+    "path": "meldingen",
   "title": "Meldingen",
   "status": "beschikbaar",
   "description": "SIA (Signalen Informatievoorziening Amsterdam) meldingen",

--- a/datasets/meldingen/meldingen.json
+++ b/datasets/meldingen/meldingen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "meldingen",
-    "path": "meldingen",
+  "path": "meldingen",
   "title": "Meldingen",
   "status": "beschikbaar",
   "description": "SIA (Signalen Informatievoorziening Amsterdam) meldingen",

--- a/datasets/milieuzones/milieuzones.json
+++ b/datasets/milieuzones/milieuzones.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "milieuzones",
-    "path": "milieuzones",
+  "path": "milieuzones",
   "title": "Milieuzones",
   "description": "Milieuzones gedefinieerd voor touringcar, taxi, brom-en snorfiets, vrachtautos en bestelautos.",
   "license": "public",

--- a/datasets/milieuzones/milieuzones.json
+++ b/datasets/milieuzones/milieuzones.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "milieuzones",
+    "path": "milieuzones",
   "title": "Milieuzones",
   "description": "Milieuzones gedefinieerd voor touringcar, taxi, brom-en snorfiets, vrachtautos en bestelautos.",
   "license": "public",

--- a/datasets/nap/nap.json
+++ b/datasets/nap/nap.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "nap",
+    "path": "nap",
   "title": "NAP",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/nap/nap.json
+++ b/datasets/nap/nap.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "nap",
-    "path": "nap",
+  "path": "nap",
   "title": "NAP",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/ondergrond/ondergrond.json
+++ b/datasets/ondergrond/ondergrond.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "ondergrond",
-    "path": "ondergrond",
+  "path": "ondergrond",
   "title": "Ondergrond",
   "status": "beschikbaar",
   "description": "Activiteiten die zijn gedaan in / op de ondergrond",

--- a/datasets/ondergrond/ondergrond.json
+++ b/datasets/ondergrond/ondergrond.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "ondergrond",
+    "path": "ondergrond",
   "title": "Ondergrond",
   "status": "beschikbaar",
   "description": "Activiteiten die zijn gedaan in / op de ondergrond",

--- a/datasets/openbareverlichting/openbareverlichting.json
+++ b/datasets/openbareverlichting/openbareverlichting.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "openbareverlichting",
+    "path": "openbareverlichting",
   "title": "Openbare verlichting",
   "description": "Type, locatie en status van openbare verlichting gemeente Amsterdam.",
   "license": "public",

--- a/datasets/openbareverlichting/openbareverlichting.json
+++ b/datasets/openbareverlichting/openbareverlichting.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "openbareverlichting",
-    "path": "openbareverlichting",
+  "path": "openbareverlichting",
   "title": "Openbare verlichting",
   "description": "Type, locatie en status van openbare verlichting gemeente Amsterdam.",
   "license": "public",

--- a/datasets/overlastgebieden/overlastgebieden.json
+++ b/datasets/overlastgebieden/overlastgebieden.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "overlastgebieden",
+    "path": "overlastgebieden",
   "title": "Overlastgebieden",
   "description": "Gebieden die op grond van artikel 2.8 van de Algemene Plaatselijke Verordening (APV) als algemeen overlastgebied of als dealeroverlastgebied (of beiden) zijn aagewezen",
   "license": "public",

--- a/datasets/overlastgebieden/overlastgebieden.json
+++ b/datasets/overlastgebieden/overlastgebieden.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "overlastgebieden",
-    "path": "overlastgebieden",
+  "path": "overlastgebieden",
   "title": "Overlastgebieden",
   "description": "Gebieden die op grond van artikel 2.8 van de Algemene Plaatselijke Verordening (APV) als algemeen overlastgebied of als dealeroverlastgebied (of beiden) zijn aagewezen",
   "license": "public",

--- a/datasets/parkeervakken/parkeervakken.json
+++ b/datasets/parkeervakken/parkeervakken.json
@@ -1,5 +1,6 @@
 {
   "id": "parkeervakken",
+    "path": "parkeervakken",
   "type": "dataset",
   "status": "beschikbaar",
   "title": "",

--- a/datasets/parkeervakken/parkeervakken.json
+++ b/datasets/parkeervakken/parkeervakken.json
@@ -1,6 +1,6 @@
 {
   "id": "parkeervakken",
-    "path": "parkeervakken",
+  "path": "parkeervakken",
   "type": "dataset",
   "status": "beschikbaar",
   "title": "",

--- a/datasets/parkeerzones/parkeerzones.json
+++ b/datasets/parkeerzones/parkeerzones.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "parkeerzones",
-    "path": "parkeerzones",
+  "path": "parkeerzones",
   "title": "Parkeerzones met en zonder uitzonderingen",
   "status": "beschikbaar",
   "description": "Parkeerzones gemeente Amsterdam",

--- a/datasets/parkeerzones/parkeerzones.json
+++ b/datasets/parkeerzones/parkeerzones.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "parkeerzones",
+    "path": "parkeerzones",
   "title": "Parkeerzones met en zonder uitzonderingen",
   "status": "beschikbaar",
   "description": "Parkeerzones gemeente Amsterdam",
@@ -33,23 +34,23 @@
             "type": "string",
             "format": "date",
             "description": "Startdatum geldigheid.",
-            "provenance": "b_dat_gebi" 
+            "provenance": "b_dat_gebi"
           },
           "eindGeldigheid": {
             "type": "string",
             "format": "date",
             "description": "Einddatum geldigheid.",
-            "provenance": "e_dat_gebi" 
+            "provenance": "e_dat_gebi"
           },
           "gebiedscode": {
             "type": "string",
             "description": "Gebiedscode waarbinnen de parkeerzone valt.",
-            "provenance": "gebied_cod" 
+            "provenance": "gebied_cod"
           },
           "gebiedsomschrijving": {
             "type": "string",
             "description": "Omschrijving van gebiedscode waarbinnen de parkeerzone valt.",
-            "provenance": "gebied_oms" 
+            "provenance": "gebied_oms"
           },
           "gebiedsnaam": {
             "type": "string",
@@ -59,28 +60,28 @@
           "gebiedsouder": {
             "type": "string",
             "description": "Naam van de overkoepelende parkeerzone waaronder de parkeerzone valt.",
-            "provenance": "parent"            
+            "provenance": "parent"
           },
           "domeincode": {
-            "type": "string",            
+            "type": "string",
             "description": "Domeincode waarbinnen de parkeerzone valt.",
-            "provenance": "domein_cod"            
+            "provenance": "domein_cod"
           },
           "gebruiksdoel": {
             "type": "string",
             "description": "Gebruiksdoel van de parkeerzone.",
-            "provenance": "gebruiks_d"             
+            "provenance": "gebruiks_d"
           },
           "indicatieZichtbaar": {
             "type": "string",
             "enum":["True", "False"],
             "description": "Indicatie of parkeerzone gepubliceerd mag worden.",
-            "provenance": "show"                        
-          },          
+            "provenance": "show"
+          },
           "gebiedskleurcode": {
             "type": "string",
-            "description": "Gedefinieerde gebiedskleur in hexidecimale code voor presentatie.",            
-            "provenance": "color"                        
+            "description": "Gedefinieerde gebiedskleur in hexidecimale code voor presentatie.",
+            "provenance": "color"
           }
         }
       }
@@ -111,45 +112,45 @@
               "type": "string",
               "format": "date",
               "description": "Startdatum geldigheid.",
-              "provenance": "b_dat_gebi" 
+              "provenance": "b_dat_gebi"
             },
             "eindGeldigheid": {
               "type": "string",
               "format": "date",
               "description": "Einddatum geldigheid.",
-              "provenance": "e_dat_gebi" 
+              "provenance": "e_dat_gebi"
             },
             "gebiedscode": {
               "type": "string",
               "description": "Gebiedscode waarbinnen de parkeerzone valt.",
-              "provenance": "gebied_cod" 
+              "provenance": "gebied_cod"
             },
             "gebiedsomschrijving": {
               "type": "string",
               "description": "Omschrijving van gebiedscode waarbinnen de parkeerzone valt.",
-              "provenance": "omschrijvi" 
+              "provenance": "omschrijvi"
             },
             "gebiedsnaam": {
               "type": "string",
               "description": "Naam van het gebied waarbinnen de parkeerzone valt.",
               "provenance": "gebied_naa"
-            },           
+            },
             "domeincode": {
-              "type": "string",            
+              "type": "string",
               "description": "Domeincode waarbinnen de parkeerzone valt.",
-              "provenance": "domein_cod"            
+              "provenance": "domein_cod"
             },
             "gebruiksdoel": {
               "type": "string",
               "description": "Gebruiksdoel van de parkeerzone.",
-              "provenance": "gebruiks_d"             
+              "provenance": "gebruiks_d"
             },
             "indicatieZichtbaar": {
               "type": "string",
               "enum":["True", "False"],
               "description": "Indicatie of parkeerzone gepubliceerd mag worden.",
-              "provenance": "show"                        
-            }            
+              "provenance": "show"
+            }
           }
         }
       }

--- a/datasets/precariobelasting/precariobelasting.json
+++ b/datasets/precariobelasting/precariobelasting.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "precariobelasting",
+    "path": "precariobelasting",
   "title": "Precariobelasting",
   "status": "beschikbaar",
   "description": "Precariobelasting voor terrassen, bedrijfsvaartuigen, passagiersvaartuigen en woonboten per belastinggebied, per jaar en per m2",

--- a/datasets/precariobelasting/precariobelasting.json
+++ b/datasets/precariobelasting/precariobelasting.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "precariobelasting",
-    "path": "precariobelasting",
+  "path": "precariobelasting",
   "title": "Precariobelasting",
   "status": "beschikbaar",
   "description": "Precariobelasting voor terrassen, bedrijfsvaartuigen, passagiersvaartuigen en woonboten per belastinggebied, per jaar en per m2",

--- a/datasets/rdw/rdw.json
+++ b/datasets/rdw/rdw.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "rdw",
-    "path": "rdw",
+  "path": "rdw",
   "title": "RDW",
   "status": "beschikbaar",
   "description": "De RDW is de organisatie die de registratie van gemotoriseerde voertuigen en rijbewijzen in Nederland verzorgt. De RDW is een zelfstandig bestuursorgaan van de Nederlandse overheid.",

--- a/datasets/rdw/rdw.json
+++ b/datasets/rdw/rdw.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "rdw",
+    "path": "rdw",
   "title": "RDW",
   "status": "beschikbaar",
   "description": "De RDW is de organisatie die de registratie van gemotoriseerde voertuigen en rijbewijzen in Nederland verzorgt. De RDW is een zelfstandig bestuursorgaan van de Nederlandse overheid.",

--- a/datasets/referentiekalender/referentiekalender.json
+++ b/datasets/referentiekalender/referentiekalender.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "referentiekalender",
-    "path": "referentiekalender",
+  "path": "referentiekalender",
   "title": "Referentiekalender",
   "status": "beschikbaar",
   "description": "Een generieke hiërarchisch dataset met datum (yyyy-mm-dd) als laagste granulariteitsniveau.",

--- a/datasets/referentiekalender/referentiekalender.json
+++ b/datasets/referentiekalender/referentiekalender.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "referentiekalender",
+    "path": "referentiekalender",
   "title": "Referentiekalender",
   "status": "beschikbaar",
   "description": "Een generieke hiërarchisch dataset met datum (yyyy-mm-dd) als laagste granulariteitsniveau.",

--- a/datasets/rioolnetwerk/rioolnetwerk.json
+++ b/datasets/rioolnetwerk/rioolnetwerk.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "rioolnetwerk",
-    "path": "rioolnetwerk",
+  "path": "rioolnetwerk",
   "title": "Rioolnetwerk",
   "description": "Alle rioolleidingen en knopen welke door Waternet beschikbaar wordt gesteld.",
   "dateCreated": "2020-06-04T00:00:00",

--- a/datasets/rioolnetwerk/rioolnetwerk.json
+++ b/datasets/rioolnetwerk/rioolnetwerk.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "rioolnetwerk",
+    "path": "rioolnetwerk",
   "title": "Rioolnetwerk",
   "description": "Alle rioolleidingen en knopen welke door Waternet beschikbaar wordt gesteld.",
   "dateCreated": "2020-06-04T00:00:00",

--- a/datasets/risicozones/risicozones.json
+++ b/datasets/risicozones/risicozones.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "risicozones",
-    "path": "risicozones",
+  "path": "risicozones",
   "title": "Risicozones",
   "description": "Informatie over risicozones bedrijven en infrastructuur",
   "license": "public",

--- a/datasets/risicozones/risicozones.json
+++ b/datasets/risicozones/risicozones.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "risicozones",
+    "path": "risicozones",
   "title": "Risicozones",
   "description": "Informatie over risicozones bedrijven en infrastructuur",
   "license": "public",

--- a/datasets/schiphol/schiphol.json
+++ b/datasets/schiphol/schiphol.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "schiphol",
+    "path": "schiphol",
   "title": "Schiphol",
   "description": "Schiphol gerelateerde gegevens t.a.v. geluidzones, hoogtebeperkingradar, maatgevendetoetshoogte en vogelvrijwaringsgebied.",
   "license": "public",

--- a/datasets/schiphol/schiphol.json
+++ b/datasets/schiphol/schiphol.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "schiphol",
-    "path": "schiphol",
+  "path": "schiphol",
   "title": "Schiphol",
   "description": "Schiphol gerelateerde gegevens t.a.v. geluidzones, hoogtebeperkingradar, maatgevendetoetshoogte en vogelvrijwaringsgebied.",
   "license": "public",

--- a/datasets/spoorlijnen/spoorlijnen.json
+++ b/datasets/spoorlijnen/spoorlijnen.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "spoorlijnen",
+    "path": "spoorlijnen",
     "title": "Spoorlijnen",
     "description": "Informatie over metro- en tramspoorlijnen",
     "license": "public",
@@ -139,4 +140,3 @@
       }
     ]
   }
-  

--- a/datasets/sport/sport.json
+++ b/datasets/sport/sport.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "sport",
-    "path": "sport",
+  "path": "sport",
   "title": "Sport: Faciliteiten en aanbieders",
   "description": "Locaties en context ten aanzien van sportfaciliteiten en aanbieders.",
   "license": "public",

--- a/datasets/sport/sport.json
+++ b/datasets/sport/sport.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "sport",
+    "path": "sport",
   "title": "Sport: Faciliteiten en aanbieders",
   "description": "Locaties en context ten aanzien van sportfaciliteiten en aanbieders.",
   "license": "public",

--- a/datasets/stroomstoringen/stroomstoringen.json
+++ b/datasets/stroomstoringen/stroomstoringen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "stroomstoringen",
-    "path": "stroomstoringen",
+  "path": "stroomstoringen",
   "title": "Stroomstoringen",
   "description": "Stroomstoringen (van vandaag) Liander netwerk regio Amsterdam.",
   "dateCreated": "2021-06-14T00:00:00",

--- a/datasets/stroomstoringen/stroomstoringen.json
+++ b/datasets/stroomstoringen/stroomstoringen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "stroomstoringen",
+    "path": "stroomstoringen",
   "title": "Stroomstoringen",
   "description": "Stroomstoringen (van vandaag) Liander netwerk regio Amsterdam.",
   "dateCreated": "2021-06-14T00:00:00",

--- a/datasets/touringcars/touringcars.json
+++ b/datasets/touringcars/touringcars.json
@@ -1,6 +1,7 @@
 {
     "type": "dataset",
     "id": "touringcars",
+    "path": "touringcars",
     "title": "Touringcars",
     "status": "beschikbaar",
     "description": "Informatie voor busbedrijven en chauffeurs over parkeerplaatsen, aanbevolen- en verplichteroutes, in- en uitstaphaltes, maximale doorrijhoogtes en wegwerkzaamheden",
@@ -34,7 +35,7 @@
               "provenance":"title"
             },
             "bijzonderheden": {
-              "type": "string"            
+              "type": "string"
             },
             "plaatsen": {
               "type": "string",
@@ -79,10 +80,10 @@
             "omschrijving": {
               "type": "string",
               "title": "Aard/Scope wegwerkzaamheden",
-              "provenance":"title"              
+              "provenance":"title"
             },
             "opmerkingen": {
-              "type": "string"            
+              "type": "string"
             },
             "meerInformatie": {
               "type": "string",
@@ -121,11 +122,11 @@
             "omschrijving": {
               "type": "string",
               "title": "Locatie doorrijhoogte beperking",
-              "provenance":"title"              
+              "provenance":"title"
             },
             "maximaleDoorrijhoogte": {
               "type": "string",
-              "unit": "m"            
+              "unit": "m"
             }
           }
         }
@@ -154,16 +155,16 @@
             "omschrijving": {
               "type": "string",
               "title": "Naam halte",
-              "provenance":"title"              
+              "provenance":"title"
             },
             "bijzonderheden": {
-              "type": "string"                       
+              "type": "string"
             },
             "plaatsen": {
                 "type": "string",
                 "unit": "aantal",
                 "description": "Aantallen busplaatsen of coaches",
-                "provenance":"busplaatsen" 
+                "provenance":"busplaatsen"
             }
           }
         }
@@ -192,7 +193,7 @@
             "omschrijving": {
               "type": "string",
               "title": "Routenaam",
-              "provenance":"title"              
+              "provenance":"title"
             }
           }
         }
@@ -221,11 +222,10 @@
             "omschrijving": {
               "type": "string",
               "title": "Routenaam",
-              "provenance":"title"              
+              "provenance":"title"
             }
           }
         }
       }
     ]
   }
-  

--- a/datasets/varen/varen.json
+++ b/datasets/varen/varen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "varen",
-    "path": "varen",
+  "path": "varen",
   "title": "Varen",
   "description": "Inforatie over de over de pleziervaart en het ligplaatsen register voor de pleziervaart.",
   "dateCreated": "2020-08-01T00:00:00",

--- a/datasets/varen/varen.json
+++ b/datasets/varen/varen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "varen",
+    "path": "varen",
   "title": "Varen",
   "description": "Inforatie over de over de pleziervaart en het ligplaatsen register voor de pleziervaart.",
   "dateCreated": "2020-08-01T00:00:00",

--- a/datasets/vastgoed/vastgoed.json
+++ b/datasets/vastgoed/vastgoed.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "vastgoed",
-    "path": "vastgoed",
+  "path": "vastgoed",
   "title": "Vastgoed gemeente Amsterdam",
   "description": "Gegevens over de verhuurbare eenheden van het gemeentelijke vastgoed in volledig eigendom dan wel als een appartementsrecht.",
   "license": "public",

--- a/datasets/vastgoed/vastgoed.json
+++ b/datasets/vastgoed/vastgoed.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "vastgoed",
+    "path": "vastgoed",
   "title": "Vastgoed gemeente Amsterdam",
   "description": "Gegevens over de verhuurbare eenheden van het gemeentelijke vastgoed in volledig eigendom dan wel als een appartementsrecht.",
   "license": "public",

--- a/datasets/veiligeafstanden/veiligeafstanden.json
+++ b/datasets/veiligeafstanden/veiligeafstanden.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "veiligeafstanden",
+    "path": "veiligeafstanden",
   "title": "Veilige afstanden",
   "status": "beschikbaar",
   "description": "Locaties van vuurwerkopslagplaatsen, bunkerschepen, munitie-opslagplaatsen, sluizen, gasdrukregel- en meetstations en wachtplaatsen.",

--- a/datasets/veiligeafstanden/veiligeafstanden.json
+++ b/datasets/veiligeafstanden/veiligeafstanden.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "veiligeafstanden",
-    "path": "veiligeafstanden",
+  "path": "veiligeafstanden",
   "title": "Veilige afstanden",
   "status": "beschikbaar",
   "description": "Locaties van vuurwerkopslagplaatsen, bunkerschepen, munitie-opslagplaatsen, sluizen, gasdrukregel- en meetstations en wachtplaatsen.",

--- a/datasets/vergunningen/vergunningen.json
+++ b/datasets/vergunningen/vergunningen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "vergunningen",
-    "path": "vergunningen",
+  "path": "vergunningen",
   "title": "Vergunningen",
   "status": "beschikbaar",
   "description": "Vergunningen",

--- a/datasets/vergunningen/vergunningen.json
+++ b/datasets/vergunningen/vergunningen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "vergunningen",
+    "path": "vergunningen",
   "title": "Vergunningen",
   "status": "beschikbaar",
   "description": "Vergunningen",

--- a/datasets/verkiezingen/verkiezingen.json
+++ b/datasets/verkiezingen/verkiezingen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "verkiezingen",
+    "path": "verkiezingen",
   "title": "Verkiezingen",
   "status": "beschikbaar",
   "description": "Gegevens over verkiezingen",

--- a/datasets/verkiezingen/verkiezingen.json
+++ b/datasets/verkiezingen/verkiezingen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "verkiezingen",
-    "path": "verkiezingen",
+  "path": "verkiezingen",
   "title": "Verkiezingen",
   "status": "beschikbaar",
   "description": "Gegevens over verkiezingen",

--- a/datasets/verzinkbarepalen/verzinkbarepalen.json
+++ b/datasets/verzinkbarepalen/verzinkbarepalen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "verzinkbarepalen",
+    "path": "verzinkbarepalen",
   "title": "verzinkbare palen en overige afsluitingsmechanismen gemeente Amsterdam",
   "description": "Locaties en contextuele informatie over verzinkbare palen / afsluitingsmechanismen.",
   "license": "public",

--- a/datasets/verzinkbarepalen/verzinkbarepalen.json
+++ b/datasets/verzinkbarepalen/verzinkbarepalen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "verzinkbarepalen",
-    "path": "verzinkbarepalen",
+  "path": "verzinkbarepalen",
   "title": "verzinkbare palen en overige afsluitingsmechanismen gemeente Amsterdam",
   "description": "Locaties en contextuele informatie over verzinkbare palen / afsluitingsmechanismen.",
   "license": "public",

--- a/datasets/wagenpark/wagenpark.json
+++ b/datasets/wagenpark/wagenpark.json
@@ -1,5 +1,6 @@
 {
   "id": "wagenpark",
+    "path": "wagenpark",
   "type": "dataset",
   "authorizationGrantor": "n.v.t.",
   "theme": ["duurzaamheid en milieu"],

--- a/datasets/wagenpark/wagenpark.json
+++ b/datasets/wagenpark/wagenpark.json
@@ -1,6 +1,6 @@
 {
   "id": "wagenpark",
-    "path": "wagenpark",
+  "path": "wagenpark",
   "type": "dataset",
   "authorizationGrantor": "n.v.t.",
   "theme": ["duurzaamheid en milieu"],

--- a/datasets/winkelgebieden/winkelgebieden.json
+++ b/datasets/winkelgebieden/winkelgebieden.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "winkelgebieden",
-    "path": "winkelgebieden",
+  "path": "winkelgebieden",
   "title": "winkelgebieden",
   "status": "beschikbaar",
   "description": "Winkelgebieden",

--- a/datasets/winkelgebieden/winkelgebieden.json
+++ b/datasets/winkelgebieden/winkelgebieden.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "winkelgebieden",
+    "path": "winkelgebieden",
   "title": "winkelgebieden",
   "status": "beschikbaar",
   "description": "Winkelgebieden",

--- a/datasets/wior/wior.json
+++ b/datasets/wior/wior.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "wior",
+    "path": "wior",
   "title": "Werken in de openbare ruimte",
   "description": "Contextuele informatie over uitvoering en aanvragen werken in de openbare ruimte",
   "license": "public",

--- a/datasets/wior/wior.json
+++ b/datasets/wior/wior.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "wior",
-    "path": "wior",
+  "path": "wior",
   "title": "Werken in de openbare ruimte",
   "description": "Contextuele informatie over uitvoering en aanvragen werken in de openbare ruimte",
   "license": "public",

--- a/datasets/woningbouwplannen/woningbouwplannen.json
+++ b/datasets/woningbouwplannen/woningbouwplannen.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "woningbouwplannen",
-    "path": "woningbouwplannen",
+  "path": "woningbouwplannen",
   "title": "Woningbouwplannen en Strategische ruimtes",
   "description": "Deze dataset bevat de gegevens over de te realiseren woningen in Amsterdam.",
   "dateCreated": "2020-08-01T00:00:00",

--- a/datasets/woningbouwplannen/woningbouwplannen.json
+++ b/datasets/woningbouwplannen/woningbouwplannen.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "woningbouwplannen",
+    "path": "woningbouwplannen",
   "title": "Woningbouwplannen en Strategische ruimtes",
   "description": "Deze dataset bevat de gegevens over de te realiseren woningen in Amsterdam.",
   "dateCreated": "2020-08-01T00:00:00",

--- a/datasets/woz/woz.json
+++ b/datasets/woz/woz.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "woz",
+    "path": "woz",
   "title": "woz",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/woz/woz.json
+++ b/datasets/woz/woz.json
@@ -1,7 +1,7 @@
 {
   "type": "dataset",
   "id": "woz",
-    "path": "woz",
+  "path": "woz",
   "title": "woz",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/schema@v1.1.1/dataset.json
+++ b/schema@v1.1.1/dataset.json
@@ -11,7 +11,7 @@
   "properties": {
     "path": {
       "type": "string",
-      "format": "uri"
+      "format": "uri-reference"
     },
     "type": {
       "const": "dataset"

--- a/schema@v1.1.1/dataset.json
+++ b/schema@v1.1.1/dataset.json
@@ -7,8 +7,12 @@
       "$ref": "./schema@v1.1.1#/definitions/basicProperties"
     }
   ],
-  "required": ["tables", "version", "status"],
+  "required": ["tables", "version", "status", "path"],
   "properties": {
+    "path": {
+      "type": "string",
+      "format": "uri"
+    },
     "type": {
       "const": "dataset"
     },


### PR DESCRIPTION
API path en de ID property van datasets moeten onafhankelijk zijn om meerdere datasets met dezelfde naam te ondersteunen.
Daarom is aan de datasets het verplichte veld `path` toegevoegd.