### PR TITLE
Make WOZ dataset temporal

### DIFF
--- a/datasets/woz/woz.json
+++ b/datasets/woz/woz.json
@@ -75,6 +75,14 @@
                 },
                 "volgnummer": {
                   "type": "string"
+                },
+                "beginGeldigheid": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "eindGeldigheid": {
+                  "type": "string",
+                  "format": "date"
                 }
               }
             },
@@ -91,6 +99,14 @@
                 },
                 "volgnummer": {
                   "type": "string"
+                },
+                "beginGeldigheid": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "eindGeldigheid": {
+                  "type": "string",
+                  "format": "date"
                 }
               }
             },

--- a/datasets/woz/woz.json
+++ b/datasets/woz/woz.json
@@ -1,6 +1,7 @@
 {
   "type": "dataset",
   "id": "woz",
+  "path": "woz",
   "title": "woz",
   "status": "beschikbaar",
   "version": "0.0.1",

--- a/datasets/woz/woz.json
+++ b/datasets/woz/woz.json
@@ -9,6 +9,12 @@
     {
       "id": "wozobjecten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/woz/wozobjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -119,6 +125,12 @@
     {
       "id": "wozdeelobjecten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/woz/wozdeelobjecten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
It was impossible to make WOZ temporal, because WOZ is using different field for the temporality (`wozobjectnummer` and not `identificatie`). Now that temporality can be defined at the table level and the the correc `identifier` is fetched, we can continue to make the WOZ dataset work.
