### PR TITLE
AB#8702 Add missing waterdeelvlak table definition for basiskaart.

### DIFF
--- a/datasets/basiskaart/dataset.json
+++ b/datasets/basiskaart/dataset.json
@@ -8,7 +8,7 @@
   "version": "0.0.1",
   "publisher": "OIS",
   "owner": "Gemeente Amsterdam",
-  "authorizationGrantor": "OIS", 
+  "authorizationGrantor": "OIS",
   "keywords": ["GBT", "KBK", "KBK10", "KBK50"],
   "crs": "EPSG:28992",
   "tables": [
@@ -297,6 +297,53 @@
     {
       "id": "waterdeellijn",
       "title": "Waterdeel lijnobject",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unieke aanduiding van het record.",
+            "provenance": "identificatie_lokaalid"
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Lijn definitie van het object."
+          },
+          "type": {
+            "type": "string",
+            "description": "Typering van het object."
+          },
+          "relatievehoogteligging": {
+            "type": "number",
+            "description": "Getalaanduiding hoogte van het object."
+          },
+          "bron": {
+            "type": "string",
+            "enum": ["gbt", "kbk10", "kbk50"],
+            "description": "Herkomst van het record (GBT, KBK10 of KBK50)."
+          },
+          "minzoom": {
+            "type": "integer",
+            "description": "Getalaanduiding van minimale zoomlevel."
+          },
+          "maxzoom": {
+            "type": "integer",
+            "description": "Getalaanduiding van maximale zoomlevel."
+          }
+        }
+      }
+    },
+    {
+      "id": "waterdeelvlak",
+      "title": "Waterdeel vlakobject",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/datasets/basiskaart/dataset.json
+++ b/datasets/basiskaart/dataset.json
@@ -22,6 +22,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -69,6 +70,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -116,6 +118,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -163,6 +166,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -210,6 +214,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -257,6 +262,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -304,6 +310,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -351,6 +358,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -398,6 +406,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -445,6 +454,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -492,6 +502,7 @@
         "additionalProperties": false,
         "required": ["schema", "id"],
         "display": "id",
+        "mainGeometry": "geometrie",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"


### PR DESCRIPTION
The old SQL table create statements in `dataservices-airflow created
this table, hence it should have a correspondig schema definitions.