### PR TITLE
Protect HR dataset with HR/R scope

### DIFF
--- a/datasets/hr/dataset.json
+++ b/datasets/hr/dataset.json
@@ -3,6 +3,7 @@
   "id": "hr",
   "title": "hr",
   "status": "beschikbaar",
+  "auth": "HR/R",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [


### PR DESCRIPTION
The HR datasets needs to be protected. The HR/R scope has been added at dataset level.