### PR TITLE
Move haalcentraalbrk back to hcbrk

### DIFF
--- a/datasets/hcbrk/dataset.json
+++ b/datasets/hcbrk/dataset.json
@@ -1,6 +1,6 @@
 {
   "type": "dataset",
-  "id": "haalcentraalbrk",
+  "id": "hcbrk",
   "title": "BRK van Haal Centraal",
   "status": "beschikbaar",
   "description": "Deze dataset maakt de Haal Centraal BRK API toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal Centraal.",


### PR DESCRIPTION
Breaks too much stuff because the name is hardcoded elsewhere.