### PR TITLE
AB#6554 Remove plaatscoordinaten from hcbrk's required properties

### DIFF
--- a/datasets/hcbrk/dataset.json
+++ b/datasets/hcbrk/dataset.json
@@ -17,7 +17,7 @@
         "additionalProperties": false,
         "identifier": "identificatie",
         "display": "identificatie",
-        "required": ["schema", "identificatie", "domein", "kadastraleAanduiding", "plaatscoordinaten", "type"],
+        "required": ["schema", "identificatie", "domein", "kadastraleAanduiding", "type"],
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"


### PR DESCRIPTION
Can't find in the [docs](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/) if this is intended, but it's not always available.