### PR TITLE
AB#6554 Revert "Move haalcentraalbrk back to hcbrk"

### DIFF
--- a/datasets/haalcentraal/brk/dataset.json
+++ b/datasets/haalcentraal/brk/dataset.json
@@ -1,6 +1,6 @@
 {
   "type": "dataset",
-  "id": "hcbrk",
+  "id": "haalcentraalbrk",
   "title": "BRK van Haal Centraal",
   "status": "beschikbaar",
   "description": "Deze dataset maakt de Haal Centraal BRK API toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal Centraal.",


### PR DESCRIPTION
Second attempt to move hcbrk to its new name. This reverts commit 61dedbff3e6c50d6adcc643e3b7f8fc8cd4ca6ff.

Still to do after this: update dso-api docs to point to the new name, and remove the hack from https://github.com/Amsterdam/dso-api/commit/476f407bb18460092674c246e3cd08189c54eb87.