### PR TITLE
Fix example path in docs

### DIFF
--- a/docs/ams-schema-spec.bs
+++ b/docs/ams-schema-spec.bs
@@ -125,7 +125,7 @@ Advisement: Let op: Zie [[#naamgeving]] voor de eisen waaraan {{dataset/id}} moe
     Een minimale dataset definitie. De 'title' en 'description' velden zijn niet verplicht,
     maar het is best practice ze toe te voegen.
     <pre class=include-code>
-        path: examples/minimaal/dataset.json
+        path: examples/datasets/minimaal/dataset.json
         highlight: json
     </pre>
 </div>
@@ -242,7 +242,7 @@ Advisement: Van deze bestandsnaam en padstructuur moet niet worden afgeweken beh
     Een `locaties` tabel in `./locaties/v1.0.0.json`.<br/>
     En een `personen` tabel in `./personen/v2.0.1.json`, waarvan ook de oudere versie `1.3.0` beschikbaar is.
     <pre class="include-code">
-            path: examples/bekendeAmsterdammers/dataset.json
+            path: examples/datasets/bekendeAmsterdammers/dataset.json
             highlight: json
             line-highlight: 7-20
         </pre>
@@ -287,7 +287,7 @@ Advisement: Let op: Zie [[#naamgeving]] voor de eisen waaraan {{tabel/id}} moet 
     Voorbeeld van een minimale tabel definitie. De {{tabel/title}} en {{tabel/description}} velden zijn niet verplicht,
     maar het is best practice ze toe te voegen.
     <pre class="include-code">
-        path: examples/minimaal/personen/v1.0.0.json
+        path: examples/datasets/minimaal/personen/v1.0.0.json
         highlight: json
         line-highlight: 0-7,25-27
     </pre>
@@ -349,7 +349,7 @@ Issue: Het identifier veld moet string zijn. De array optie wordt binnenkort ver
 
     Het {{display}} veld zorgt ervoor dat niet de "id" de maar de "naam" van een persoon als samenvattende titel wordt gebruikt.
     <pre class=include-code>
-        path: examples/minimaal/personen/v1.0.0.json
+        path: examples/datasets/minimaal/personen/v1.0.0.json
         highlight: json
         line-highlight: 7-25
     </pre>
@@ -445,7 +445,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
         <div [SYNCSCROLLA]>
             `personen/v1.2.1.json`
             <pre class="include-code">
-                path: examples/bekendeAmsterdammers/personen/v1.2.1.json
+                path: examples/datasets/bekendeAmsterdammers/personen/v1.2.1.json
                 highlight: json
                 line-highlight: 5,28
             </pre>
@@ -453,7 +453,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
         <div [SYNCSCROLLB]>
             `personen/v1.3.0.json`
             <pre class="include-code">
-                path: examples/bekendeAmsterdammers/personen/v1.3.0.json
+                path: examples/datasets/bekendeAmsterdammers/personen/v1.3.0.json
                 highlight: json
                 line-highlight: 5,28, 30-38
             </pre>
@@ -472,7 +472,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
         <div [SYNCSCROLLA]>
             `personen/v1.3.0.json`
             <pre class="include-code">
-                path: examples/bekendeAmsterdammers/personen/v1.3.0.json
+                path: examples/datasets/bekendeAmsterdammers/personen/v1.3.0.json
                 highlight: json
                 line-highlight: 5,10,18,20,28
             </pre>
@@ -480,7 +480,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
         <div [SYNCSCROLLB]>
             `personen/v2.0.0.json`
             <pre class="include-code">
-                path: examples/bekendeAmsterdammers/personen/v2.0.0.json
+                path: examples/datasets/bekendeAmsterdammers/personen/v2.0.0.json
                 highlight: json
                 line-highlight: 5,10,18-19,21,29
             </pre>
@@ -498,7 +498,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
         <div [SYNCSCROLLA]>
             `personen/v2.0.0.json`
             <pre class="include-code">
-                path: examples/bekendeAmsterdammers/personen/v2.0.0.json
+                path: examples/datasets/bekendeAmsterdammers/personen/v2.0.0.json
                 highlight: json
                 line-highlight: 5-6,11,27,33
             </pre>
@@ -506,7 +506,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
         <div [SYNCSCROLLB]>
             `personen/v2.0.1.json`
             <pre class="include-code">
-                path: examples/bekendeAmsterdammers/personen/v2.0.1.json
+                path: examples/datasets/bekendeAmsterdammers/personen/v2.0.1.json
                 highlight: json
                 line-highlight: 5-6,11,27,33
             </pre>
@@ -524,7 +524,7 @@ Zie [[#table-refs]] voor het toevoegen van verschillende versies van een tabel.
     <div style="text-align:center;">
         `personen/dataset.json`
         <pre class="include-code">
-            path: examples/bekendeAmsterdammers/dataset.json
+            path: examples/datasets/bekendeAmsterdammers/dataset.json
             highlight: json
             line-highlight: 1,8-15,33
         </pre>
@@ -646,7 +646,7 @@ Naast bovenstaande attributen mag een [=veld=] uitsluitend de volgende subset va
 <div class=example>
     Voorbeeld van een veld.
     <pre class=include-code>
-        path: examples/bekendeAmsterdammers/personen/v1.2.1.json
+        path: examples/datasets/bekendeAmsterdammers/personen/v1.2.1.json
         highlight: json
         show: 24-29
     </pre>
@@ -958,7 +958,7 @@ Note: Elk veld is nullable tenzij het als `required` property is opgegeven, zie 
     <div class=example>
         Voorbeeld van een geometrie veld.
         <pre class=example class="include-code">
-            path: examples/bekendeAmsterdammers/pleinen/v1.0.0.json
+            path: examples/datasets/bekendeAmsterdammers/pleinen/v1.0.0.json
             highlight: json
             show: 25-29
         </pre>
@@ -978,7 +978,7 @@ Note: Elk veld is nullable tenzij het als `required` property is opgegeven, zie 
         Voorbeeld van een tabel met meerdere geometrie velden. Het veld `"lokatie"` is hier als primaire geometrie
         aangegeven in "{{mainGeometry}}".
         <pre class="include-code">
-            path: examples/bekendeAmsterdammers/pleinen/v1.0.0.json
+            path: examples/datasets/bekendeAmsterdammers/pleinen/v1.0.0.json
             highlight: json
             line-highlight: 0-7,25-34
         </pre>
@@ -1335,7 +1335,7 @@ Het `description` veld is bedoeld voor bijvoorbeeld context (mouseover) menu's b
 <div class=example>
     `title` en `description` van een [=Dataset=].
     <pre class=include-code>
-        path: examples/bekendeAmsterdammers/dataset.json
+        path: examples/datasets/bekendeAmsterdammers/dataset.json
         highlight: json
         show: 4-5
     </pre>
@@ -1344,7 +1344,7 @@ Het `description` veld is bedoeld voor bijvoorbeeld context (mouseover) menu's b
 <div class=example>
     `title` en `description` van een [=Tabel=].
     <pre class=include-code>
-        path: examples/bekendeAmsterdammers/locaties/v1.0.0.json
+        path: examples/datasets/bekendeAmsterdammers/locaties/v1.0.0.json
         highlight: json
         show: 4-5
     </pre>
@@ -1353,7 +1353,7 @@ Het `description` veld is bedoeld voor bijvoorbeeld context (mouseover) menu's b
 <div class=example>
     `title` en `description` in een [=Veld=].
     <pre class=include-code>
-        path: examples/bekendeAmsterdammers/locaties/v1.0.0.json
+        path: examples/datasets/bekendeAmsterdammers/locaties/v1.0.0.json
         highlight: json
         show: 44-45
     </pre>


### PR DESCRIPTION
Examples where moved to examples/datasets but the bikeshed file was not updated.
So the docs would not build. This updates the bikeshed file with the new paths.