### PR TITLE
Change sbiVoorOnderneming to M2M

### DIFF
--- a/datasets/hr/dataset.json
+++ b/datasets/hr/dataset.json
@@ -191,10 +191,13 @@
           },
           "heeftSbiActiviteitenVoorOnderneming": {
             "shortname": "sbiVoorOnderneming",
-            "type": "object",
-            "properties": {
-              "sbiActiviteitNummer": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "sbiActiviteitNummer": {
+                  "type": "string"
+                }
               }
             },
             "relation": "hr:sbiactiviteiten",


### PR DESCRIPTION
The relation heeftSbiActiviteitenVoorOnderneming was defined as 1-N,
but should be a M2M relation.