### PR TITLE
Fix identifiers in two brk schemas

### DIFF
--- a/datasets/brk/aantekeningenrechten/v2.1.0.json
+++ b/datasets/brk/aantekeningenrechten/v2.1.0.json
@@ -1,0 +1,96 @@
+{
+  "id": "aantekeningenrechten",
+  "type": "table",
+  "version": "2.1.0",
+  "auth": "BRK/RSN",
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/brk/aantekeningenrechten.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "id",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "neuronId": {
+        "type": "string",
+        "description": "Neuron ID",
+        "provenance": "id"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het aan deze aantekening toegekende landelijk unieke nummer."
+      },
+      "aardCode": {
+        "type": "string",
+        "provenance": "$.aard.code",
+        "description": "De aard van de aantekening. code"
+      },
+      "aardOmschrijving": {
+        "type": "string",
+        "provenance": "$.aard.omschrijving",
+        "description": "De aard van de aantekening. omschrijving"
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Omschrijving bij de aantekening"
+      },
+      "betrokkenTenaamstelling": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:tenaamstellingen",
+        "description": "Identificatie van de betrokken tenaamstelling"
+      },
+      "heeftBetrokkenPersoon": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk:kadastralesubjecten",
+        "description": "Identificatie van het betrokken subject"
+      },
+      "isGebaseerdOpStukdeel": {
+        "type": "string",
+        "relation": "brk:stukdelen",
+        "description": "Identificatie van het betrokken stukdeel"
+      },
+      "einddatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk/dataset.json
+++ b/datasets/brk/dataset.json
@@ -30,16 +30,16 @@
     },
     {
       "id": "tenaamstellingen",
-      "$ref": "tenaamstellingen/v2.0.0",
+      "$ref": "tenaamstellingen/v2.1.0",
       "activeVersions": {
-        "2.0.0": "tenaamstellingen/v2.0.0"
+        "2.1.0": "tenaamstellingen/v2.1.0"
       }
     },
     {
       "id": "aantekeningenrechten",
-      "$ref": "aantekeningenrechten/v2.0.0",
+      "$ref": "aantekeningenrechten/v2.1.0",
       "activeVersions": {
-        "2.0.0": "aantekeningenrechten/v2.0.0"
+        "2.1.0": "aantekeningenrechten/v2.1.0"
       }
     },
     {

--- a/datasets/brk/tenaamstellingen/v2.1.0.json
+++ b/datasets/brk/tenaamstellingen/v2.1.0.json
@@ -1,0 +1,135 @@
+{
+  "id": "tenaamstellingen",
+  "type": "table",
+  "version": "2.1.0",
+  "auth": "BRK/RSN",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/brk/tenaamstellingen.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "volgnummer",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "neuronId": {
+        "type": "string",
+        "description": "Neuron ID",
+        "provenance": "id"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "De identificatie is een uniek nummer aan deze tenaamstelling binnen de kadastrale registratie."
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": ""
+      },
+      "vanKadastraalsubject": {
+        "type": "string",
+        "relation": "brk:kadastralesubjecten",
+        "provenance": "$.vanKadastraalsubject.identificatie",
+        "description": "Het Subject waarvoor deze tenaamstelling geldt."
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "aandeelTeller": {
+        "type": "integer",
+        "provenance": "$.aandeel.teller",
+        "description": "Aandeel in Recht is het aandeel waarvoor een persoon deelneemt in het Recht teller"
+      },
+      "aandeelNoemer": {
+        "type": "integer",
+        "provenance": "$.aandeel.noemer",
+        "description": "Aandeel in Recht is het aandeel waarvoor een persoon deelneemt in het Recht noemer"
+      },
+      "geldtVoorTeller": {
+        "type": "integer",
+        "provenance": "$.geldtVoor.teller",
+        "description": "Twee of meer personen kunnen gezamenlijk een aandeel hebben in een recht, waarbij het afzonderlijke aandeel in het gezamenlijk aandeel niet bekend is (als gezamenlijkAandeel bekend is dan is het individuele aandeel niet bekend en omgekeerd). teller"
+      },
+      "geldtVoorNoemer": {
+        "type": "integer",
+        "provenance": "$.geldtVoor.noemer",
+        "description": "Twee of meer personen kunnen gezamenlijk een aandeel hebben in een recht, waarbij het afzonderlijke aandeel in het gezamenlijk aandeel niet bekend is (als gezamenlijkAandeel bekend is dan is het individuele aandeel niet bekend en omgekeerd). noemer"
+      },
+      "burgerlijkeStaatTenTijdeVanVerkrijgingCode": {
+        "type": "string",
+        "provenance": "$.burgerlijkeStaatTenTijdeVanVerkrijging.code",
+        "description": "De burgerlijke staat is een aanduiding voor de leefvorm van een persoon, zoals deze volgens het brondocument ten tijde van de verkrijging van het recht bestond. Leefvorm van een persoon heeft betrekking op huwelijk c.q. geregistreerd partnerschap. code"
+      },
+      "burgerlijkeStaatTenTijdeVanVerkrijgingOmschrijving": {
+        "type": "string",
+        "provenance": "$.burgerlijkeStaatTenTijdeVanVerkrijging.omschrijving",
+        "description": "De burgerlijke staat is een aanduiding voor de leefvorm van een persoon, zoals deze volgens het brondocument ten tijde van de verkrijging van het recht bestond. Leefvorm van een persoon heeft betrekking op huwelijk c.q. geregistreerd partnerschap. omschrijving"
+      },
+      "verkregenNamensSamenwerkingsverbandCode": {
+        "type": "string",
+        "provenance": "$.verkregenNamensSamenwerkingsverband.code",
+        "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. code"
+      },
+      "verkregenNamensSamenwerkingsverbandOmschrijving": {
+        "type": "string",
+        "provenance": "$.verkregenNamensSamenwerkingsverband.omschrijving",
+        "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. omschrijving"
+      },
+      "inOnderzoek": {
+        "type": "string",
+        "description": ""
+      },
+      "vanZakelijkrecht": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "string"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Het Zakelijk recht waarover deze tenaamstelling gaat."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The aantekeningenrechten and tenaamstellingen have an `id` field
that is the so-called Neuron-ID. However, `id` is reserved
for the AutoNumber PK that Django needs to add when
the table actually has a compound key (Django does not support that).

So, the `id` fields is now renamed to `neuronId`.