### PR TITLE
Add github codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# Someone from team dataservices has to approve a
+# review when someone opens a pull request.
+*       @Amsterdam/dataservices


### PR DESCRIPTION
Add the dataservices github team as default codeowners on the repository.
Someone from this team will have to approve a pull request, before it
can be merged.

See this for more info on [codeowners](https://github.blog/2017-07-06-introducing-code-owners/)