### PR TITLE
Pin latest schematools (3.0.0)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
-      SCHEMA_URL: https://schemas.data.amsterdam.nl/datasets/
+      SCHEMA_URL: datasets/
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: isort
         args: ['--filter-files']
   - repo: https://github.com/Amsterdam/schema-tools
-    rev: v2.3.1
+    rev: v3.0.0
     hooks:
       - id: validate-schema
         args: ['https://schemas.data.amsterdam.nl/schema@v1.1.1#']


### PR DESCRIPTION
And configure SCHEMA_URL for github actions to be
local filesystem. So that validation is done against
the schemas in the repo.