### PR TITLE
extra table to leidingeninfractructure

### DIFF
--- a/datasets/leidingeninfrastructuur/bovengrondsekabels/v1.0.0.json
+++ b/datasets/leidingeninfrastructuur/bovengrondsekabels/v1.0.0.json
@@ -12,7 +12,6 @@
       "schema",
       "id"
     ],
-    "mainGeometry": "geometrie",
     "display": "id",
     "properties": {
       "id": {

--- a/datasets/leidingeninfrastructuur/dataset.json
+++ b/datasets/leidingeninfrastructuur/dataset.json
@@ -48,6 +48,13 @@
       "activeVersions": {
         "1.0.0": "mantelbuizen/v1.0.0"
       }
+    },
+    {
+      "id": "punten",
+      "$ref": "punten/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "punten/v1.0.0"
+      }
     }
   ]
 }

--- a/datasets/leidingeninfrastructuur/ondergrondsekabels/v1.0.0.json
+++ b/datasets/leidingeninfrastructuur/ondergrondsekabels/v1.0.0.json
@@ -12,7 +12,6 @@
       "schema",
       "id"
     ],
-    "mainGeometry": "geometrie",
     "display": "id",
     "properties": {
       "id": {

--- a/datasets/leidingeninfrastructuur/punten/v1.0.0.json
+++ b/datasets/leidingeninfrastructuur/punten/v1.0.0.json
@@ -1,9 +1,9 @@
 {
-  "id": "mantelbuizen",
+  "id": "punten",
   "type": "table",
   "version": "1.0.0",
-  "title": "Mantelbuizen",
-  "description": "Locaties en contextuele informatie mantelbuizen.",
+  "title": "Punten",
+  "description": "X en Y locaties informatie ondergrondse kabels.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -16,14 +16,14 @@
     "properties": {
       "id": {
         "type": "integer",
-        "description": "Business-key: unieke aanduiding per voorkomen in tabel Mantelbuizen (bestaande uit Mantelbuizen)."
+        "description": "Business-key: unieke aanduiding per voorkomen punt locatie leiding."
       },
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
       },
       "geometry": {
-        "$ref": "https://geojson.org/schema/MultiPolygon.json",
-        "description": "Vlak-co\u00f6rdinaten van de Mantelbuis (epsg:28992)"
+        "$ref": "https://geojson.org/schema/Point.json",
+        "description": "Punt coordinaat van de leiding (epsg:28992)"
       },
       "inwinningstype": {
         "type": "string",
@@ -39,29 +39,34 @@
       },
       "type": {
         "type": "string",
-        "description": "WIBON Type.",
-        "provenance": "mantelbuistype"
-      },
-      "materiaal": {
-        "type": "string",
-        "description": "Materiaal van de Mantelbuis."
+        "description": "WIBON Type."
       },
       "zichtbaar": {
         "type": "string",
-        "enum": [
-          "ja",
-          "nee"
-        ],
         "description": "Zichtbaar (Ja/Nee)."
+      },
+      "indicatieBovenOnder": {
+        "type": "string",
+        "description": "Indicatie: Boven-/ondergronds.",
+        "provenance": "bovenonder"
       },
       "diepte": {
         "type": "number",
         "unit": "cm",
-        "description": "Diepte in cm. (t.o.v. maaiveld)."
+        "description": "Diepte in cm (t.o.v. maaiveld)."
       },
       "nauwkeurigheidDiepte": {
         "type": "string",
         "description": "Nauwkeurigheid van de diepte."
+      },
+      "hoogte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Hoogte in cm. (t.o.v. maaiveld)"
+      },
+      "nauwkeurigheidHoogte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de hoogte."
       },
       "hoofdcategorie": {
         "type": "string",
@@ -69,22 +74,17 @@
       },
       "eigenaar": {
         "type": "string",
-        "description": "Eigenaar van de Mantelbuis."
+        "description": "Eigenaar van de Kabel."
       },
       "jaarVanAanleg": {
         "type": "integer",
         "description": "Jaar van aanleg van de Kabel.",
         "provenance": "jva"
       },
-      "diameter": {
+      "mutatiedatum": {
         "type": "string",
-        "description": "Diameter van de Mantelbuis.",
-        "provenance": "mantelbuisdiameter"
-      },
-      "lengte": {
-        "type": "number",
-        "unit": "cm",
-        "description": "Lengte van de Mantelbuis."
+        "format": "date-time",
+        "description": "Mutatiedatum record."
       }
     }
   }

--- a/datasets/leidingeninfrastructuur/punten/v1.0.0.json
+++ b/datasets/leidingeninfrastructuur/punten/v1.0.0.json
@@ -3,7 +3,7 @@
   "type": "table",
   "version": "1.0.0",
   "title": "Punten",
-  "description": "Een Punt is een verbinding tussen 2 of meerdere kabels, eindpunt van een kabel, aardingspunt of opstijgpunt. Mogelijk waarden: (1) Mof - Een Mof is een verbinding tussen 2 of meerdere Aansluitkabels of tussen Hoofdkabel en Aansluitkabel. (2) Hoofdmof - Een Hoofdmof is een verbinding tussen 2 of meerdere Hoofdkabels. (3) Aardingspunt - Een aardingspunt is het punt waar de aarding van de kabel is gesitueerd. (4) Opstijgpunt - Een opstijgpunt is het punt waar de kabel die uit de grond komt in een muurkastje gaat. De Kabel die verticaal onder of boven het Opstijgpunt loopt wordt niet geregistreerd. (5) Eindpunt en (6) Onbekend.",
+  "description": "Een Punt is een verbinding tussen 2 of meerdere kabels, eindpunt van een kabel, aardingspunt of opstijgpunt.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -39,7 +39,15 @@
       },
       "type": {
         "type": "string",
-        "description": "WIBIN type."
+        "enum": [
+          "Mof",
+          "Hoofdmof",
+          "Aardingspunt",
+          "Opstijgpunt",
+          "Eindmof",
+          "Onbekend"
+        ],
+        "description": "WIBIN type. Mogelijk waarden: (1) Mof - Een Mof is een verbinding tussen 2 of meerdere Aansluitkabels of tussen Hoofdkabel en Aansluitkabel. (2) Hoofdmof - Een Hoofdmof is een verbinding tussen 2 of meerdere Hoofdkabels. (3) Aardingspunt - Een aardingspunt is het punt waar de aarding van de kabel is gesitueerd. (4) Opstijgpunt - Een opstijgpunt is het punt waar de kabel die uit de grond komt in een muurkastje gaat. De Kabel die verticaal onder of boven het Opstijgpunt loopt wordt niet geregistreerd. (5) Eindmof en (6) Onbekend."
       },
       "zichtbaar": {
         "type": "string",

--- a/datasets/leidingeninfrastructuur/punten/v1.0.0.json
+++ b/datasets/leidingeninfrastructuur/punten/v1.0.0.json
@@ -3,7 +3,7 @@
   "type": "table",
   "version": "1.0.0",
   "title": "Punten",
-  "description": "X en Y locaties informatie ondergrondse kabels.",
+  "description": "Een Punt is een verbinding tussen 2 of meerdere kabels, eindpunt van een kabel, aardingspunt of opstijgpunt. Mogelijk waarden: (1) Mof - Een Mof is een verbinding tussen 2 of meerdere Aansluitkabels of tussen Hoofdkabel en Aansluitkabel. (2) Hoofdmof - Een Hoofdmof is een verbinding tussen 2 of meerdere Hoofdkabels. (3) Aardingspunt - Een aardingspunt is het punt waar de aarding van de kabel is gesitueerd. (4) Opstijgpunt - Een opstijgpunt is het punt waar de kabel die uit de grond komt in een muurkastje gaat. De Kabel die verticaal onder of boven het Opstijgpunt loopt wordt niet geregistreerd. (5) Eindpunt en (6) Onbekend.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -39,7 +39,7 @@
       },
       "type": {
         "type": "string",
-        "description": "WIBON Type."
+        "description": "WIBIN type."
       },
       "zichtbaar": {
         "type": "string",


### PR DESCRIPTION
The table `punten` was missing. Punten is part of the business terminology. To make it more contextual a comprehensive description was added on the table.