### PR TITLE
Fix mainGeometry in leidingeninfrastructuur

### DIFF
--- a/datasets/leidingeninfrastructuur/bovengrondsekabels/v1.0.1.json
+++ b/datasets/leidingeninfrastructuur/bovengrondsekabels/v1.0.1.json
@@ -1,0 +1,138 @@
+{
+  "id": "bovengrondseKabels",
+  "type": "table",
+  "version": "1.0.0",
+  "title": "Bovengrondse kabels",
+  "description": "Locaties en contextuele informatie bovengrondse kabels.",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "schema",
+      "id"
+    ],
+    "mainGeometry": "geometry",
+    "display": "id",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel leidingeninfrastructuur_kabelsbovengronds (bestaande uit Kabels)."
+      },
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json",
+        "description": "Lijn-co\u00f6rdinaten van de bovengrondse kabel (epsg:28992)"
+      },
+      "inwinningstype": {
+        "type": "string",
+        "description": "Kwaliteit van inwinning."
+      },
+      "thema": {
+        "type": "string",
+        "description": "WIBON Thema."
+      },
+      "klasse": {
+        "type": "string",
+        "description": "WIBON Klasse."
+      },
+      "type": {
+        "type": "string",
+        "description": "WIBON Type."
+      },
+      "zichtbaar": {
+        "type": "string",
+        "description": "Zichtbaar (Ja/Nee)."
+      },
+      "indicatieBovenOnder": {
+        "type": "string",
+        "description": "Indicatie: Boven-/ondergronds.",
+        "provenance": "bovenonder"
+      },
+      "diepte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Diepte in cm (t.o.v. maaiveld)."
+      },
+      "nauwkeurigheidDiepte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de diepte."
+      },
+      "hoogte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Hoogte in cm. (t.o.v. maaiveld)"
+      },
+      "nauwkeurigheidHoogte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de hoogte."
+      },
+      "hoofdcategorie": {
+        "type": "string",
+        "description": "Hoofdcategorie."
+      },
+      "eigenaar": {
+        "type": "string",
+        "description": "Eigenaar van de Kabel."
+      },
+      "jaarVanAanleg": {
+        "type": "integer",
+        "description": "Jaar van aanleg van de Kabel.",
+        "provenance": "jva"
+      },
+      "typeExtra": {
+        "type": "string",
+        "description": "Type extra (AC/DC).",
+        "provenance": "typeextra"
+      },
+      "functie": {
+        "type": "string",
+        "description": "Functie van de Kabel."
+      },
+      "van": {
+        "type": "string",
+        "description": "Van (locatie van de Kabel)."
+      },
+      "tot": {
+        "type": "string",
+        "description": "Tot (locatie van de Kabel)."
+      },
+      "kast": {
+        "type": "string",
+        "description": "Kastnummer waarop de Kabel is aangesloten."
+      },
+      "groep": {
+        "type": "string",
+        "description": "Groepsnummer binnen de Kast waar de Kabel op is aangesloten."
+      },
+      "kabeltype": {
+        "type": "string",
+        "description": "Kabeltype."
+      },
+      "kabeldiameter": {
+        "type": "string",
+        "description": "Kabeldiameter."
+      },
+      "voltage": {
+        "type": "string",
+        "description": "Voltage van de Kabel."
+      },
+      "bouwtype": {
+        "type": "string",
+        "description": "Bouwtype van de Kabel."
+      },
+      "bereikbaar": {
+        "type": "string",
+        "description": "Bereikbaarheid van de Kabel.",
+        "provenance": "bereikbaarheid"
+      },
+      "lengte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Lengte van de Kabel."
+      }
+    }
+  }
+}

--- a/datasets/leidingeninfrastructuur/dataset.json
+++ b/datasets/leidingeninfrastructuur/dataset.json
@@ -30,23 +30,23 @@
     },
     {
       "id": "bovengrondsekabels",
-      "$ref": "bovengrondsekabels/v1.0.0",
+      "$ref": "bovengrondsekabels/v1.0.1",
       "activeVersions": {
-        "1.0.0": "bovengrondsekabels/v1.0.0"
+        "1.0.1": "bovengrondsekabels/v1.0.1"
       }
     },
     {
       "id": "ondergrondsekabels",
-      "$ref": "ondergrondsekabels/v1.0.0",
+      "$ref": "ondergrondsekabels/v1.0.1",
       "activeVersions": {
-        "1.0.0": "ondergrondsekabels/v1.0.0"
+        "1.0.1": "ondergrondsekabels/v1.0.1"
       }
     },
     {
       "id": "mantelbuizen",
-      "$ref": "mantelbuizen/v1.0.0",
+      "$ref": "mantelbuizen/v1.0.1",
       "activeVersions": {
-        "1.0.0": "mantelbuizen/v1.0.0"
+        "1.0.1": "mantelbuizen/v1.0.1"
       }
     }
   ]

--- a/datasets/leidingeninfrastructuur/mantelbuizen/v1.0.1.json
+++ b/datasets/leidingeninfrastructuur/mantelbuizen/v1.0.1.json
@@ -1,0 +1,92 @@
+{
+  "id": "mantelbuizen",
+  "type": "table",
+  "version": "1.0.0",
+  "title": "Mantelbuizen",
+  "description": "Locaties en contextuele informatie mantelbuizen.",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "schema",
+      "id"
+    ],
+    "mainGeometry": "geometry",
+    "display": "id",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel Mantelbuizen (bestaande uit Mantelbuizen)."
+      },
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiPolygon.json",
+        "description": "Vlak-co\u00f6rdinaten van de Mantelbuis (epsg:28992)"
+      },
+      "inwinningstype": {
+        "type": "string",
+        "description": "Kwaliteit van inwinning."
+      },
+      "thema": {
+        "type": "string",
+        "description": "WIBON Thema."
+      },
+      "klasse": {
+        "type": "string",
+        "description": "WIBON Klasse."
+      },
+      "type": {
+        "type": "string",
+        "description": "WIBON Type.",
+        "provenance": "mantelbuistype"
+      },
+      "materiaal": {
+        "type": "string",
+        "description": "Materiaal van de Mantelbuis."
+      },
+      "zichtbaar": {
+        "type": "string",
+        "enum": [
+          "ja",
+          "nee"
+        ],
+        "description": "Zichtbaar (Ja/Nee)."
+      },
+      "diepte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Diepte in cm. (t.o.v. maaiveld)."
+      },
+      "nauwkeurigheidDiepte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de diepte."
+      },
+      "hoofdcategorie": {
+        "type": "string",
+        "description": "Hoofdcategorie."
+      },
+      "eigenaar": {
+        "type": "string",
+        "description": "Eigenaar van de Mantelbuis."
+      },
+      "jaarVanAanleg": {
+        "type": "integer",
+        "description": "Jaar van aanleg van de Kabel.",
+        "provenance": "jva"
+      },
+      "diameter": {
+        "type": "string",
+        "description": "Diameter van de Mantelbuis.",
+        "provenance": "mantelbuisdiameter"
+      },
+      "lengte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Lengte van de Mantelbuis."
+      }
+    }
+  }
+}

--- a/datasets/leidingeninfrastructuur/ondergrondsekabels/v1.0.1.json
+++ b/datasets/leidingeninfrastructuur/ondergrondsekabels/v1.0.1.json
@@ -1,0 +1,138 @@
+{
+  "id": "ondergrondseKabels",
+  "type": "table",
+  "version": "1.0.0",
+  "title": "Ondergrondse kabels",
+  "description": "Locaties en contextuele informatie ondergrondse kabels.",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "schema",
+      "id"
+    ],
+    "mainGeometry": "geometry",
+    "display": "id",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel leidingeninfrastructuur_kabelsbovengronds (bestaande uit Kabels)."
+      },
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json",
+        "description": "Lijn-co\u00f6rdinaten van de ondergrondse kabel (epsg:28992)"
+      },
+      "inwinningstype": {
+        "type": "string",
+        "description": "Kwaliteit van inwinning."
+      },
+      "thema": {
+        "type": "string",
+        "description": "WIBON Thema."
+      },
+      "klasse": {
+        "type": "string",
+        "description": "WIBON Klasse."
+      },
+      "type": {
+        "type": "string",
+        "description": "WIBON Type."
+      },
+      "zichtbaar": {
+        "type": "string",
+        "description": "Zichtbaar (Ja/Nee)."
+      },
+      "indicatieBovenOnder": {
+        "type": "string",
+        "description": "Indicatie: Boven-/ondergronds.",
+        "provenance": "bovenonder"
+      },
+      "diepte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Diepte in cm (t.o.v. maaiveld)."
+      },
+      "nauwkeurigheidDiepte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de diepte."
+      },
+      "hoogte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Hoogte in cm. (t.o.v. maaiveld)"
+      },
+      "nauwkeurigheidHoogte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de hoogte."
+      },
+      "hoofdcategorie": {
+        "type": "string",
+        "description": "Hoofdcategorie."
+      },
+      "eigenaar": {
+        "type": "string",
+        "description": "Eigenaar van de Kabel."
+      },
+      "jaarVanAanleg": {
+        "type": "integer",
+        "description": "Jaar van aanleg van de Kabel.",
+        "provenance": "jva"
+      },
+      "typeExtra": {
+        "type": "string",
+        "description": "Type extra (AC/DC).",
+        "provenance": "typeextra"
+      },
+      "functie": {
+        "type": "string",
+        "description": "Functie van de Kabel."
+      },
+      "van": {
+        "type": "string",
+        "description": "Van (locatie van de Kabel)."
+      },
+      "tot": {
+        "type": "string",
+        "description": "Tot (locatie van de Kabel)."
+      },
+      "kast": {
+        "type": "string",
+        "description": "Kastnummer waarop de Kabel is aangesloten."
+      },
+      "groep": {
+        "type": "string",
+        "description": "Groepsnummer binnen de Kast waar de Kabel op is aangesloten."
+      },
+      "kabeltype": {
+        "type": "string",
+        "description": "Kabeltype."
+      },
+      "kabeldiameter": {
+        "type": "string",
+        "description": "Kabeldiameter."
+      },
+      "voltage": {
+        "type": "string",
+        "description": "Voltage van de Kabel."
+      },
+      "bouwtype": {
+        "type": "string",
+        "description": "Bouwtype van de Kabel."
+      },
+      "bereikbaar": {
+        "type": "string",
+        "description": "Bereikbaarheid van de Kabel.",
+        "provenance": "bereikbaarheid"
+      },
+      "lengte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Lengte van de Kabel."
+      }
+    }
+  }
+}


### PR DESCRIPTION
mainGeometry was referring to non existent attribute 'geometrie' in tables:
'bovengrondekabels', 'ondergrondsekabels en 'mantelbuizen'.
 this is corrected to 'geometry'.