### PR TITLE
idstring supports numbers prefixed with underscore

### DIFF
--- a/docs/ams-schema-spec.bs
+++ b/docs/ams-schema-spec.bs
@@ -1515,7 +1515,7 @@ Attribuut typen {#attr-types}
 <table class="dfn-table">
     <tr><td><dfn typedef export lt=id|id-type>identifier</dfn>
         <td> (string | integer)
-        <td> Een unieke identifier in de vorm van een integer of een alphanumerieke reeks, startend met een lowercase letter.
+        <td> Een unieke identifier in de vorm van één of meer letters, startend met een lowercase letter eventueel gevolgd door een cijferreeks voorafgegaan door een underscore '_'.
     <tr><td><dfn typedef export>date-time</dfn>
         <td> (string)
         <td> Een als datetime geformatteerde string. Conform [[json-schema-validation#rfc.section.7.3.1]].

--- a/docs/ams-schema-spec.html
+++ b/docs/ams-schema-spec.html
@@ -1490,7 +1490,7 @@ Possible extra rowspan handling
   <meta content="Bikeshed version bb6b91100, updated Mon Jul 12 16:52:37 2021 -0700" name="generator">
   <link href="https://schemas.data.amsterdam.nl/docs/ams-schema-spec.html" rel="canonical">
   <link href="https://data.amsterdam.nl/favicon.png" rel="icon">
-  <meta content="01153b34e8c1141c6a138c52de1ad6ef171c6a22" name="document-revision">
+  <meta content="fa6ba350ca9707e8da640dbcbdfca464c75bb64f" name="document-revision">
 <style>
     p[data-fill-with="logo"] {
         width: 180px;
@@ -2224,7 +2224,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Amsterdam Schema Specificatie</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2021-11-17">17 November 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2021-11-29">29 November 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3715,7 +3715,7 @@ Scope <code class="highlight"><c- u>"LEVEL/A"</c-></code> heeft dataset level au
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export data-lt="id|id-type" id="typedefdef-id"><code class="highlight">identifier</code></dfn>
       <td> (string | integer)
-      <td> Een unieke identifier in de vorm van een integer of een alphanumerieke reeks, startend met een lowercase letter.
+      <td> Een unieke identifier in de vorm van één of meer letters, startend met een lowercase letter eventueel gevolgd door een cijferreeks voorafgegaan door een underscore '_'.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-date-time"><code class="highlight">date<c- o>-</c->time</code></dfn>
       <td> (string)

--- a/schema@v1.1.1/schema.json
+++ b/schema@v1.1.1/schema.json
@@ -52,7 +52,7 @@
     "idString": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[a-z][ A-Za-z0-9]*$"
+      "pattern": "^[a-z][A-Za-z]*(?:_[0-9]+)?$"
     },
     "id": {
       "oneOf": [


### PR DESCRIPTION
Changed the idstring validation regex to match camelcase
strings optionally followed by an underscore and number sequence.

Having numbers in an id field without underscores before it keeps causing bugs downstream.
This seems the easiest solution.
