### PR TITLE
Add Haal Centraal BAG

### DIFF
--- a/datasets/haalcentraal/bag/dataset.json
+++ b/datasets/haalcentraal/bag/dataset.json
@@ -1,0 +1,395 @@
+{
+  "type": "dataset",
+  "id": "haalcentraalbag",
+  "title": "BAG van Haal Centraal",
+  "status": "beschikbaar",
+  "description": "Deze dataset maakt de Haal Centraal BAG API toegankelijk. De velden zijn gebaseerd op het schema van Haal Centraal.",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "adressen",
+      "type": "table",
+      "version": "0.0.1",
+      "description": "Het adres is de benaming van een locatie bestaande uit straatnaam, huisnummer, (mogelijk met huisletter, huisnummertoevoeging, postcode) en woonplaatsnaam. Dit is de vereenvoudigde samenstelling van de offici\ufffdle naamgeving gebaseerd op woonplaats, openbare ruimte en nummeraanduiding.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "nummeraanduidingIdentificatie",
+        "display": "nummeraanduidingIdentificatie",
+        "required": [
+          "schema",
+          "straat",
+          "huisnummer",
+          "huisletter",
+          "huisnummertoevoeging",
+          "postcode",
+          "woonplaats",
+          "adresregel1",
+          "adresregel2",
+          "korteNaam",
+          "nummeraanduidingIdentificatie",
+          "openbareRuimteIdentificatie",
+          "woonplaatsIdentificatie",
+          "adresseerbaarObjectIdentificatie",
+          "pandIdentificaties",
+          "isNevenadres",
+          "geconstateerd"
+        ],
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "nummeraanduidingIdentificatie": {
+            "type": "string",
+            "description": "Fungeert ook als identificatie van het adres."
+          },
+          "straat": {
+            "type": "string",
+            "description": "Een naam die door de gemeente aan een openbare ruimte is gegeven."
+          },
+          "huisnummer": {
+            "type": "integer",
+            "description": "Een nummer dat door de gemeente aan een adresseerbaar object is gegeven."
+          },
+          "huisletter": {
+            "type": "string",
+            "description": "Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven."
+          },
+          "huisnummertoevoeging": {
+            "type": "string",
+            "description": "Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven."
+          },
+          "postcode": {
+            "type": "string",
+            "description": "De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort."
+          },
+          "woonplaats": {
+            "type": "string",
+            "description": "Een woonplaats is een gedeelte van het grondgebied van de gemeente met een naam."
+          },
+          "adresregel1": {
+            "type": "string",
+            "description": "De eerste regel van het adres zoals deze gebruikt kan worden in postadressering."
+          },
+          "adresregel2": {
+            "type": "string",
+            "description": "De tweede regel van het adres zoals deze gebruikt kan worden in postadressering."
+          },
+          "korteNaam": {
+            "type": "string",
+            "description": "De offici\ufffdle openbareruimtenaam of een verkorte versie. Beide hebben maximaal 24 tekens."
+          },
+          "openbareRuimteIdentificatie": {
+            "type": "string"
+          },
+          "woonplaatsIdentificatie": {
+            "type": "string"
+          },
+          "adresseerbaarObjectIdentificatie": {
+            "type": "string"
+          },
+          "pandIdentificaties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Identificatie(s) van het pand of de panden waar het verblijfsobject deel van is."
+          },
+          "isNevenadres": {
+            "type": "boolean",
+            "description": "Indicatie dat dit adres een nevenadres is van een adresseerbaar object. Het adres is een hoofdadres als deze indicatie niet wordt meegeleverd."
+          },
+          "geconstateerd": {
+            "type": "boolean",
+            "description": "Indicatie dat dit adres in de registratie is opgenomen door een feitelijke constatering, zonder dat er sprake was van een brondocument/vergunning. Het adres is mogelijk illegaal."
+          },
+          "mogelijkOnjuist": {
+            "type": "object",
+            "description": "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting.",
+            "properties": {
+              "adresregel1": {
+                "type": "boolean"
+              },
+              "adresregel2": {
+                "type": "boolean"
+              },
+              "korteNaam": {
+                "type": "boolean"
+              },
+              "straat": {
+                "type": "boolean"
+              },
+              "huisnummer": {
+                "type": "boolean"
+              },
+              "huisletter": {
+                "type": "boolean"
+              },
+              "huisnummertoevoeging": {
+                "type": "boolean"
+              },
+              "postcode": {
+                "type": "boolean"
+              },
+              "woonplaats": {
+                "type": "boolean"
+              },
+              "nummeraanduidingIdentificatie": {
+                "type": "boolean"
+              },
+              "openbareRuimteIdentificatie": {
+                "type": "boolean"
+              },
+              "woonplaatsIdentificatie": {
+                "type": "boolean"
+              },
+              "toelichting": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "adresseerbareobjecten",
+      "type": "table",
+      "version": "0.0.1",
+      "description": "Een adresseerbaarobject is een standplaats, ligplaats of verblijfsobject.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "identificatie",
+        "mainGeometry": "geometrie",
+        "display": "identificatie",
+        "required": [
+          "schema",
+          "identificatie",
+          "domein",
+          "type",
+          "documentdatum",
+          "gebruiksdoelen",
+          "geconstateerd",
+          "geometrie",
+          "pandIdentificaties",
+          "nummeraanduidingIdentificaties",
+          "oppervlakte",
+          "status"
+        ],
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Dit is de identificatie van een verblijfsobject, standplaats of ligplaats."
+          },
+          "domein": {
+            "type": "string",
+            "description": "Het domein waartoe de identificatie behoort."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "verblijfsobject",
+              "standplaats",
+              "ligplaats"
+            ]
+          },
+          "documentdatum": {
+            "type": "string",
+            "format": "date",
+            "description": "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
+          },
+          "documentnummer": {
+            "type": "string",
+            "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegestaan."
+          },
+          "gebruiksdoelen": {
+            "type": "string",
+            "enum": [
+              "woonfunctie",
+              "bijeenkomstfunctie",
+              "celfunctie",
+              "gezondheidszorgfunctie",
+              "industriefunctie",
+              "kantoorfunctie",
+              "logiesfunctie",
+              "onderwijsfunctie",
+              "sportfunctie",
+              "winkelfunctie",
+              "overige gebruiksfunctie"
+            ]
+          },
+          "geconstateerd": {
+            "type": "boolean",
+            "description": "Indicatie dat een standplaats, ligplaats of verblijfsobject in de registratie is opgenomen door een feitelijke constatering, zonder dat er een brondocument aan ten grondslag ligt. Het adresseerbaar object is mogelijk illegaal."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Een samengesteld geometriegegevenstype waarbij wordt afgedwongen dat voor de geometrie een keuze gemaakt moet worden tussen een punt of een vlak."
+          },
+          "pandIdentificaties": {
+            "type": "array",
+            "description": "Identificatie(s) van het pand of de panden waar het verblijfsobject deel van is.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "nummeraanduidingIdentificaties": {
+            "type": "array",
+            "description": "Identificatie(s) van de hoofd- en nevenadressen van de standplaats, ligplaats of verblijfsobject.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "nummeraanduidingIdentificatie": {
+                  "type": "string"
+                },
+                "isNevenadres": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "oppervlakte": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Plaats aangewezen",
+              "Verblijfsobject gevormd",
+              "Verblijfsobject in gebruik (niet ingemeten)",
+              "Verblijfsobject in gebruik",
+              "Verbouwing verblijfsobject",
+              "Verblijfsobject buiten gebruik"
+            ]
+          },
+          "mogelijkOnjuist": {
+            "type": "object",
+            "description": "Wanneer true is de waarde mogelijk onjuist en wordt juistheid op dit moment onderzocht. Zie toelichting.",
+            "properties": {
+              "gebruiksdoelen": {
+                "type": "boolean"
+              },
+              "geometrie": {
+                "type": "boolean"
+              },
+              "nummeraanduidingIdentificaties": {
+                "type": "boolean"
+              },
+              "pandIdentificaties": {
+                "type": "boolean"
+              },
+              "oppervlakte": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "boolean"
+              },
+              "toelichting": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "panden",
+      "type": "table",
+      "version": "0.0.1",
+      "description": "Een pand is een bouwkundige, constructief zelfstandige eenheid die direct en duurzaam met de aarde is verbonden en betreedbaar en afsluitbaar is.",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "identificatie",
+        "mainGeometry": "geometrie",
+        "display": "identificatie",
+        "required": [
+          "schema",
+          "identificatie",
+          "domein",
+          "geometrie",
+          "oorspronkelijkBouwjaar",
+          "status",
+          "geconstateerd",
+          "documentdatum",
+          "documentnummer",
+          "adresseerbaarObjectIdentificaties",
+          "nummeraanduidingIdentificaties"
+        ],
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "De unieke aanduiding van een pand. Elk pand waarvan gegevens zijn opgenomen in de BAG wordt uniek aangeduid door middel van een identificatiecode."
+          },
+          "domein": {
+            "type": "string",
+            "description": "Het domein waartoe de identificatie behoort."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Polygon.json"
+          },
+          "oorspronkelijkBouwjaar": {
+            "type": "integer",
+            "description": "Het jaar waarin een pand oorspronkelijk als bouwkundig gereed is opgeleverd. Door de gemeente wordt een inschatting gemaakt van het bouwjaar, en aangepast als het pand wordt opgeleverd. Wijzigingen aan een pand na oplevering leiden niet tot wijziging van het bouwjaar."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "Bouwvergunning verleend",
+              "Bouw gestart",
+              "Pand in gebruik (niet ingemeten)",
+              "Pand in gebruik",
+              "Verbouwing pand",
+              "Sloopvergunning verleend",
+              "Pand buiten gebruik"
+            ]
+          },
+          "geconstateerd": {
+            "type": "boolean",
+            "description": "Indicatie dat het pand in de registratie is opgenomen door een feitelijke constatering, zonder dat er sprake was van een brondocument/vergunning. Het pand is mogelijk illegaal."
+          },
+          "documentdatum": {
+            "type": "string",
+            "format": "date",
+            "description": "De vaststellingsdatum van het brondocument dat de basis is voor opname, wijziging of een verwijdering van een object."
+          },
+          "documentnummer": {
+            "type": "string",
+            "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente. Alle karakters uit de MES-1 karakterset zijn toegestaan."
+          },
+          "adresseerbaarObjectIdentificaties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "nummeraanduidingIdentificaties": {
+            "type": "array",
+            "description": "Identificatie(s) van de hoofd- en nevenadressen van het pand.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "nummeraanduidingIdentificatie": {
+                  "type": "string"
+                },
+                "isNevenadres": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is for a proxy, so I did SKIP=validate-schema when the only
remaining error was

        datasets/haalcentraal/bag/dataset.json: [PsqlIdentifierLengthValidator] Inferred PostgreSQL table name 'haalcentraalbag_adresseerbareobjecten_nummeraanduiding_identificaties' is '6' characters too long. Maximum table name length is '63'.