### PR TITLE
Fix vastgoed database

### DIFF
--- a/datasets/vastgoed/dataset.json
+++ b/datasets/vastgoed/dataset.json
@@ -53,7 +53,7 @@
             "provenance": "bag identificatie verblijfsobject"
           },
           "verhuurbareEenheidNummer": {
-            "type": "integer",
+            "type": "string",
             "description": "Interne nummering van de verhuurbare eenheid.",
             "provenance": "vhe nr."
           },


### PR DESCRIPTION
The field verhuurbareEenheidNummer was defined as an integer, but in the database it's a string and "numbers" of the form `$main-$sub` occur.