### PR TITLE
Raymond/beheerkaart cbs grid

### DIFF
--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -36,7 +36,7 @@
             "type": "boolean",
             "description": "Indicatie of het BKT-CBS-grid-100-vlak als actief wordt aangemerkt door Stadswerken / Apptimize."
           },
-          "cbsGeometrie_100": {
+          "cbsGeometrie100": {
             "$ref": "https://geojson.org/schema/Polygon.json",
             "description": "Vlak-coördinaten van het BKT-CBS-grid-100-vlak."
           },

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -111,32 +111,27 @@
           "percentageBlauw": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [10-100] kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-100-vlak."
+            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageGrijs": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [10-100] kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-100-vlak."
+            "description": "Percentage kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageGroen": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [10-100] kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-100-vlak."
+            "description": "Percentage kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageOverig": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [10-100] overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-100-vlak."
+            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentagePubliekeRuimte": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Totaal percentage  [10-100] publieke ruimte (>=10%) binnen het BKT-CBS-grid-100-vlak."
+            "description": "Totaal percentage publieke ruimte (>=10%) binnen het BKT-CBS-grid-100-vlak."
           }
         }
       }
@@ -166,9 +161,9 @@
             "type": "string",
             "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak)."
           },
-          "bk_cbs_grid_100_asd": {
+          "bkCbsGrid_100_asd": {
             "type": "string",
-            "description": "Verwijzing naar omvattend BKT-CBS-grid-100-vlak)."
+            "description": "Verwijzing naar omvattend BKT-CBS-grid-100-vlak."
           },
           "rasterActief": {
             "type": "boolean",
@@ -249,32 +244,27 @@
           "percentageBlauw": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [1-100] kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-10-vlak."
+            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentageGrijs": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [1-100] kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-10-vlak."
+            "description": "Percentage kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentageGroen": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [1-100] kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-10-vlak."
+            "description": "Percentage kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentageOverig": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Percentage  [1-100] overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-10-vlak."
+            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentagePubliekeRuimte": {
             "type": "number",
             "minimum": 0,
-            "maximum": 100,
-            "description": "Totaal percentage  [1-100] publieke ruimte (>=1%) binnen het BKT-CBS-grid-10-vlak."
+            "description": "Totaal percentage publieke ruimte (>=1%) binnen het BKT-CBS-grid-10-vlak."
           }
         }
       }

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -3,20 +3,20 @@
   "id": "beheerkaartCbsGrid",
   "title": "beheerkaart cbs grid",
   "status": "beschikbaar",
-  "description": "Integratie van elementen beheerkaart publieke ruimte en landelijk CBSgrid",
+  "description": "Integratie van elementen beheerkaart publieke ruimte en landelijk CBS-grid (vlakken 100x100m2).",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
-      "id": "100",
+      "id": "raster_100",
       "type": "table",
-      "provenance": "bkt_beheerkaart_cbs_grid_100",
-      "description": "tabel met CBSgrids en percentages publieke ruimte op basis van de beheerkaart basis",
+      "provenance": "bkt_beheerkaart_cbs_grid_raster_100",
+      "description": "Tabel met CBS-grid-raster (vlakken 100x100m2) en percentages publieke ruimte (totaal>10%) op basis van de beheerkaart publieke ruimte.",
       "version": "0.0.1",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
-        "mainGeometry": "geometrie",
+        "mainGeometry": "cbs_geometrie_100",
         "additionalProperties": false,
         "required": [
           "schema",
@@ -28,93 +28,233 @@
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
           "id": {
-            "provenance": "bk_bkt_cbs_grid",
-            "description": "Business-key: unieke aanduiding record.",
+            "provenance": "bk_cbs_grid_100_asd",
+            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-100-vlak).",
             "type": "string"
           },
-          "geometrie": {
+          "rasterActief": {
+            "type": "boolean",
+            "description": "Indicatie of het BKT-CBS-grid-100-vlak als actief wordt aangemerkt door Stadswerken / Apptimize."
+          },
+          "cbsGeometrie_100": {
             "$ref": "https://geojson.org/schema/Polygon.json",
-            "description": "Vlak-co\u00f6rdinaten van het BKT-CBS-GRID-100-Vlak."
+            "description": "Vlak-coördinaten van het BKT-CBS-grid-100-vlak."
+          },
+          "gemeentenaam": {
+            "type": "string",
+            "description": "Naam van gemeente die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "buurtnaam": {
             "type": "string",
-            "description": "Naam van buurt die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van buurt die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "buurtcode": {
             "type": "string",
-            "description": "Code van buurt die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van buurt die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantbuurt": {
             "type": "string",
-            "description": "Naam van dominante buurt die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van dominante buurt die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantbuurtcode": {
             "type": "string",
-            "description": "Code van dominante buurt die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van dominante buurt die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "wijknaam": {
             "type": "string",
-            "description": "Naam van wijk die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van wijk die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "wijkcode": {
             "type": "string",
-            "description": "Code van wijk die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van wijk die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantwijk": {
             "type": "string",
-            "description": "Naam van dominante wijk die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van dominante wijk die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantwijkcode": {
             "type": "string",
-            "description": "Code van dominante wijk die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van dominante wijk die overlapt met het BKT-CBS-grid-100-vlak."
           },
           "stadsdeelnaam": {
             "type": "string",
-            "description": "Naam van buurt die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van stadsdeel dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "stadsdeelcode": {
             "type": "string",
-            "description": "Code van stadsdeel die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van stadsdeel dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantstadsdeel": {
             "type": "string",
-            "description": "Naam van dominante stadsdeel die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van dominant stadsdeel dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantstadsdeelcode": {
             "type": "string",
-            "description": "Code van dominante stadsdeel die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van dominant stadsdeel dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "ggwGebiedNaam": {
             "type": "string",
-            "description": "Naam van gebiedsgerichtwerken gebied die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "ggwGebiedCode": {
             "type": "string",
-            "description": "Code van gebiedsgerichtwerken gebied die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-100-vlak."
           },
-          "dominantGgwGebiedNaam": {
+          "dominantGgwGebied": {
             "type": "string",
-            "description": "Naam van gebiedsgerichtwerken gebied die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Naam van dominant gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "dominantGgwGebiedcode": {
             "type": "string",
-            "description": "Code van dominant gebiedsgerichtwerken gebied die overlapt met het BKT-CBS-GRID-100-Vlak."
+            "description": "Code van dominant gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-100-vlak."
           },
           "percentageBlauw": {
             "type": "number",
-            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-GRID-100-Vlak"
+            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageGrijs": {
             "type": "number",
-            "description": "Percentage kleur grijs (bgt_wegdeel,bgt_ondersteunend_wegdeel) binnen het BKT-CBS-GRID-100-Vlak."
+            "description": "Percentage kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-100-vlak."
+          },
+          "percentageGroen": {
+            "type": "number",
+            "description": "Percentage kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageOverig": {
             "type": "number",
-            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-GRID-100-Vlak."
+            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentagePubliekeRuimte": {
             "type": "number",
-            "description": "Totaal percentage publieke ruimte binnen het BKT-CBS-GRID-object."
+            "description": "Totaal percentage publieke ruimte binnen het BKT-CBS-grid-100-vlak."
+          }
+        }
+      }
+    },
+    {
+      "id": "raster_10",
+      "type": "table",
+      "provenance": "bkt_beheerkaart_cbs_grid_raster_10",
+      "description": "Tabel met BKT-CBS-grid-raster (vlakken 10x10m2) en percentages publieke ruimte (totaal>1%) op basis van de beheerkaart publieke ruimte.",
+      "version": "0.0.1",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "mainGeometry": "cbs_geometrie_10",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "id"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "provenance": "bk_cbs_grid_10_asd",
+            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak).",
+            "type": "string"
+          },
+          "bk_cbs_grid_100_asd": {
+            "description": "Verwijzing naar omvattend BKT-CBS-grid-100-vlak).",
+            "type": "string"
+          },
+          "rasterActief": {
+            "type": "boolean",
+            "description": "Indicatie of omvattend BKT-CBS-grid-100-vlak als actief wordt aangemerkt door Stadswerken / Apptimize."
+          },
+          "cbsGeometrie_10": {
+            "$ref": "https://geojson.org/schema/Polygon.json",
+            "description": "Vlak-coördinaten van het BKT-CBS-grid-10-vlak."
+          },
+          "gemeentenaam": {
+            "type": "string",
+            "description": "Naam van gemeente die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "buurtnaam": {
+            "type": "string",
+            "description": "Naam van buurt die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "buurtcode": {
+            "type": "string",
+            "description": "Code van buurt die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantbuurt": {
+            "type": "string",
+            "description": "Naam van dominante buurt die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantbuurtcode": {
+            "type": "string",
+            "description": "Code van dominante buurt die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "wijknaam": {
+            "type": "string",
+            "description": "Naam van wijk die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "wijkcode": {
+            "type": "string",
+            "description": "Code van wijk die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantwijk": {
+            "type": "string",
+            "description": "Naam van dominante wijk die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantwijkcode": {
+            "type": "string",
+            "description": "Code van dominante wijk die overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "stadsdeelnaam": {
+            "type": "string",
+            "description": "Naam van stadsdeel dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "stadsdeelcode": {
+            "type": "string",
+            "description": "Code van stadsdeel dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantstadsdeel": {
+            "type": "string",
+            "description": "Naam van dominant stadsdeel dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantstadsdeelcode": {
+            "type": "string",
+            "description": "Code van dominant stadsdeel dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "ggwGebiedNaam": {
+            "type": "string",
+            "description": "Naam van gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "ggwGebiedCode": {
+            "type": "string",
+            "description": "Code van gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantGgwGebied": {
+            "type": "string",
+            "description": "Naam van dominant gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "dominantGgwGebiedcode": {
+            "type": "string",
+            "description": "Code van dominant gebiedsgerichtwerken-gebied dat overlapt met het BKT-CBS-grid-10-vlak."
+          },
+          "percentageBlauw": {
+            "type": "number",
+            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-10-vlak."
+          },
+          "percentageGrijs": {
+            "type": "number",
+            "description": "Percentage kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-10-vlak."
+          },
+          "percentageGroen": {
+            "type": "number",
+            "description": "Percentage kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-10-vlak."
+          },
+          "percentageOverig": {
+            "type": "number",
+            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-10-vlak."
+          },
+          "percentagePubliekeRuimte": {
+            "type": "number",
+            "description": "Totaal percentage publieke ruimte binnen het BKT-CBS-grid-10-vlak."
           }
         }
       }

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -169,7 +169,7 @@
             "type": "boolean",
             "description": "Indicatie of omvattend BKT-CBS-grid-100-vlak als actief wordt aangemerkt door Stadswerken / Apptimize."
           },
-          "cbsGeometrie_10": {
+          "cbsGeometrie10": {
             "$ref": "https://geojson.org/schema/Polygon.json",
             "description": "Vlak-coördinaten van het BKT-CBS-grid-10-vlak."
           },

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -161,7 +161,7 @@
             "type": "string",
             "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak)."
           },
-          "bkCbsGrid_100_asd": {
+          "bkCbsGrid100Asd": {
             "type": "string",
             "description": "Verwijzing naar omvattend BKT-CBS-grid-100-vlak."
           },

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -126,7 +126,7 @@
           },
           "percentagePubliekeRuimte": {
             "type": "number",
-            "description": "Totaal percentage publieke ruimte binnen het BKT-CBS-grid-100-vlak."
+            "description": "Totaal percentage publieke ruimte (>=10%) binnen het BKT-CBS-grid-100-vlak."
           }
         }
       }
@@ -254,7 +254,7 @@
           },
           "percentagePubliekeRuimte": {
             "type": "number",
-            "description": "Totaal percentage publieke ruimte binnen het BKT-CBS-grid-10-vlak."
+            "description": "Totaal percentage publieke ruimte (>=1%) binnen het BKT-CBS-grid-10-vlak."
           }
         }
       }

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -3,7 +3,7 @@
   "id": "beheerkaartCbsGrid",
   "title": "beheerkaart cbs grid",
   "status": "beschikbaar",
-  "description": "Integratie van elementen beheerkaart publieke ruimte en landelijk CBS-grid (vlakken 100x100m2).",
+  "description": "Gegevens t.a.v. de lokale hoeveelheid te beheren publieke ruimte op basis van de beheerkaart publieke ruimte en landelijk (BKT-)CBS-grid (vlakken 100x100m2 of 10x10m2).",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
@@ -11,7 +11,7 @@
       "id": "raster_100",
       "type": "table",
       "provenance": "bkt_beheerkaart_cbs_grid_raster_100",
-      "description": "Tabel met CBS-grid-raster (vlakken 100x100m2) en percentages publieke ruimte (totaal>10%) op basis van de beheerkaart publieke ruimte.",
+      "description": "Tabel met CBS-grid-raster (vlakken 100x100m2) en te beheren percentages publieke ruimte (totaal>=10%) op basis van de beheerkaart publieke ruimte.",
       "version": "0.0.1",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -135,7 +135,7 @@
       "id": "raster_10",
       "type": "table",
       "provenance": "bkt_beheerkaart_cbs_grid_raster_10",
-      "description": "Tabel met BKT-CBS-grid-raster (vlakken 10x10m2) en percentages publieke ruimte (totaal>1%) op basis van de beheerkaart publieke ruimte.",
+      "description": "Tabel met BKT-CBS-grid-raster (vlakken 10x10m2) en te beheren percentages publieke ruimte (totaal>=1%) op basis van de beheerkaart publieke ruimte.",
       "version": "0.0.1",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -16,7 +16,7 @@
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
-        "mainGeometry": "cbs_geometrie_100",
+        "mainGeometry": "cbsGeometrie_100",
         "additionalProperties": false,
         "required": [
           "schema",
@@ -29,8 +29,8 @@
           },
           "id": {
             "provenance": "bk_cbs_grid_100_asd",
-            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-100-vlak).",
-            "type": "string"
+            "type": "string",
+            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-100-vlak)."
           },
           "rasterActief": {
             "type": "boolean",
@@ -110,23 +110,33 @@
           },
           "percentageBlauw": {
             "type": "number",
-            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-100-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [10-100] kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageGrijs": {
             "type": "number",
-            "description": "Percentage kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-100-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [10-100] kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageGroen": {
             "type": "number",
-            "description": "Percentage kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-100-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [10-100] kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentageOverig": {
             "type": "number",
-            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-100-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [10-100] overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-100-vlak."
           },
           "percentagePubliekeRuimte": {
             "type": "number",
-            "description": "Totaal percentage publieke ruimte (>=10%) binnen het BKT-CBS-grid-100-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Totaal percentage  [10-100] publieke ruimte (>=10%) binnen het BKT-CBS-grid-100-vlak."
           }
         }
       }
@@ -140,7 +150,7 @@
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
-        "mainGeometry": "cbs_geometrie_10",
+        "mainGeometry": "cbsGeometrie_10",
         "additionalProperties": false,
         "required": [
           "schema",
@@ -153,12 +163,12 @@
           },
           "id": {
             "provenance": "bk_cbs_grid_10_asd",
-            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak).",
-            "type": "string"
+            "type": "string",
+            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak)."
           },
           "bk_cbs_grid_100_asd": {
-            "description": "Verwijzing naar omvattend BKT-CBS-grid-100-vlak).",
-            "type": "string"
+            "type": "string",
+            "description": "Verwijzing naar omvattend BKT-CBS-grid-100-vlak)."
           },
           "rasterActief": {
             "type": "boolean",
@@ -238,23 +248,33 @@
           },
           "percentageBlauw": {
             "type": "number",
-            "description": "Percentage kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-10-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [1-100] kleur blauw (bgt_waterdeel) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentageGrijs": {
             "type": "number",
-            "description": "Percentage kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-10-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [1-100] kleur grijs (bgt_wegdeel, bgt_ondersteunend_wegdeel) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentageGroen": {
             "type": "number",
-            "description": "Percentage kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-10-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [1-100] kleur groen (bgt_begroeid_terrein) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentageOverig": {
             "type": "number",
-            "description": "Percentage overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-10-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Percentage  [1-100] overig (overige bgt_objectklassen) binnen het BKT-CBS-grid-10-vlak."
           },
           "percentagePubliekeRuimte": {
             "type": "number",
-            "description": "Totaal percentage publieke ruimte (>=1%) binnen het BKT-CBS-grid-10-vlak."
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Totaal percentage  [1-100] publieke ruimte (>=1%) binnen het BKT-CBS-grid-10-vlak."
           }
         }
       }


### PR DESCRIPTION
- Hallo @Yashar  en @Chris van Riel, ik heb een pull-verzoek klaarstaan voor de Amsterdams-schema-dataset Beheerkaart/CBS_grid (raymond/beheerkaart_cbs_grid) met daarin 1 aangepaste tabel 'bkt_beheerkaart_cbs_grid_raster_100' (naam en kolommen gewijzigd) + 1 nieuwe tabel bkt_beheerkaart_cbs_grid_raster_10', veel lijkend op de eerste tabel.
- Kan ik het pull-verzoek indienen vanuit GIT-hub of via kanaal basis_support?
- Kunnen en willen jullie ernaar kijken , ik hoor graag jullie commentaar
- En als jullie akkoord zijn, kunnen jullie dan de databasetabellen in de referentiedatabase-ACC conform Jason-bestand (opnieuw) aanmaken?
- En ik heb nu net de bijbehorende aanpassing aan Vastgoed-release origin/rel_02_18_00 gedaan en gepusht. In principe zelfde als Amsterdams schema, maar zolang DS/DD het Amsterdams schema nog niet heeft aangepast, geeft het een foutmelding op vanuit onze pijplijn verversen van de referentiedatabase.