### PR TITLE
Omgevingswet: behrkrt_cbs_grid_3 verbeter maingeom

### DIFF
--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -16,7 +16,7 @@
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
-        "mainGeometry": "cbsGeometrie_100",
+        "mainGeometry": "cbsGeometrie100",
         "additionalProperties": false,
         "required": [
           "schema",
@@ -145,7 +145,7 @@
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
-        "mainGeometry": "cbsGeometrie_10",
+        "mainGeometry": "cbsGeometrie10",
         "additionalProperties": false,
         "required": [
           "schema",


### PR DESCRIPTION
Hallo Yashar, Lars of andere collega, ik heb de kolomnamen aangeroepen bij main_geometry van de twee tabellen aangepast. Kunnen jullie ernaar kijken en als het OK is mergen en tabellen heraanmaken in de refdb?

Kunnen jullie daar ook de verouderde tabel beheerkaart_cbs_grid_100 verwijderen?

En kunnen jullie misschien mijn 2 verkeerd aangemaakte en overbodige branches 'beheerkaart_cbs_grid_2' verwijderen om verwarring te vorkomen?

Bij voorbaat dank!