### PR TITLE
AB#25433 Synchronize amsterdam schema and GOB model

### DIFF
--- a/datasets/bag/dataset.json
+++ b/datasets/bag/dataset.json
@@ -51,9 +51,9 @@
     },
     {
       "id": "panden",
-      "$ref": "panden/v1.1.0",
+      "$ref": "panden/v1.1.1",
       "activeVersions": {
-        "1.1.0": "panden/v1.1.0"
+        "1.1.1": "panden/v1.1.1"
       }
     },
     {

--- a/datasets/bag/panden/v1.1.1.json
+++ b/datasets/bag/panden/v1.1.1.json
@@ -1,0 +1,187 @@
+{
+  "id": "panden",
+  "type": "table",
+  "version": "1.1.1",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/bag/panden.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "id",
+      "identificatie",
+      "volgnummer"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Landelijke identificerende sleutel."
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "geconstateerd": {
+        "type": "boolean",
+        "description": "Dit geeft aan dat een PAND in de registratie is opgenomen als gevolg van een feitelijke constatering en niet op basis van een regulier brondocument (J/N)."
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Vorm en ligging van het pand in het Nationale Rijksdriehoekstelsel."
+      },
+      "oorspronkelijkBouwjaar": {
+        "type": "integer",
+        "description": "De aanduiding van het jaar waarin een pand oorspronkelijk als bouwkundig gereed is of wordt opgeleverd."
+      },
+      "statusCode": {
+        "type": "integer",
+        "provenance": "$.status.code",
+        "description": "De fase van de levenscyclus van een pand, waarin het betreffende pand zich bevindt. code"
+      },
+      "statusOmschrijving": {
+        "type": "string",
+        "provenance": "$.status.omschrijving",
+        "description": "De fase van de levenscyclus van een pand, waarin het betreffende pand zich bevindt. omschrijving"
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De ingangsdatum van de geldigheid van een bepaalde combinatie van gegevens over een PAND."
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De einddatum van de geldigheid van een bepaalde combinatie van gegevens over een PAND."
+      },
+      "heeftOnderzoeken": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "bag:onderzoeken",
+        "description": "Hiermee wordt aangegeven welke onderzoeken er worden uitgevoerd naar de juistheid van een of meer gegevens van het betreffende object."
+      },
+      "documentdatum": {
+        "type": "string",
+        "format": "date",
+        "description": "De datum waarop het brondocument is vastgesteld."
+      },
+      "documentnummer": {
+        "type": "string",
+        "description": "Het unieke nummer van het brondocument."
+      },
+      "naam": {
+        "type": "string",
+        "description": "Naamgeving van een pand (bv. naam van metrostation of bijzonder gebouw)."
+      },
+      "liggingCode": {
+        "type": "integer",
+        "provenance": "$.ligging.code",
+        "description": "Situering pand met verblijfsobject (vrijstaand, tussenwoning, etc.). code"
+      },
+      "liggingOmschrijving": {
+        "type": "string",
+        "provenance": "$.ligging.omschrijving",
+        "description": "Situering pand met verblijfsobject (vrijstaand, tussenwoning, etc.). omschrijving"
+      },
+      "typeWoonobject": {
+        "type": "string",
+        "description": "E\u00e9n woning, Meerdere woningen."
+      },
+      "ligtInBouwblok": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "gebieden:bouwblokken",
+        "description": "Het bouwblok waarin het pand ligt."
+      },
+      "ligtInBuurt": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "gebieden:buurten",
+        "description": "De buurt waarin het pand ligt."
+      },
+      "aantalBouwlagen": {
+        "type": "integer",
+        "description": "Aantal bouwlagen van een pand."
+      },
+      "hoogsteBouwlaag": {
+        "type": "integer",
+        "description": "Hoogste bouwlaag van een pand."
+      },
+      "laagsteBouwlaag": {
+        "type": "integer",
+        "description": "Laagste bouwlaag van een pand."
+      },
+      "heeftDossier": {
+        "type": "string",
+        "relation": "bag:dossiers",
+        "provenance": "$.heeftDossier.dossier",
+        "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
+      },
+      "bagprocesCode": {
+        "type": "integer",
+        "provenance": "$.bagproces.code",
+        "description": "Functionele handeling die ten grondslag ligt aan de gebeurtenis. code"
+      },
+      "bagprocesOmschrijving": {
+        "type": "string",
+        "provenance": "$.bagproces.omschrijving",
+        "description": "Functionele handeling die ten grondslag ligt aan de gebeurtenis. omschrijving"
+      }
+    },
+    "mainGeometry": "geometrie"
+  }
+}

--- a/datasets/brk/aantekeningenrechten/v2.1.0.json
+++ b/datasets/brk/aantekeningenrechten/v2.1.0.json
@@ -43,21 +43,24 @@
         "description": "Omschrijving bij de aantekening"
       },
       "betrokkenTenaamstelling": {
-        "type": "object",
-        "properties": {
-          "identificatie": {
-            "type": "string"
-          },
-          "volgnummer": {
-            "type": "integer"
-          },
-          "beginGeldigheid": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "eindGeldigheid": {
-            "type": "string",
-            "format": "date-time"
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
           }
         },
         "relation": "brk:tenaamstellingen",

--- a/datasets/brk/dataset.json
+++ b/datasets/brk/dataset.json
@@ -9,16 +9,16 @@
   "tables": [
     {
       "id": "kadastraleobjecten",
-      "$ref": "kadastraleobjecten/v1.1.0",
+      "$ref": "kadastraleobjecten/v1.1.1",
       "activeVersions": {
-        "1.1.0": "kadastraleobjecten/v1.1.0"
+        "1.1.1": "kadastraleobjecten/v1.1.1"
       }
     },
     {
       "id": "zakelijkerechten",
-      "$ref": "zakelijkerechten/v1.1.0",
+      "$ref": "zakelijkerechten/v1.1.1",
       "activeVersions": {
-        "1.1.0": "zakelijkerechten/v1.1.0"
+        "1.1.1": "zakelijkerechten/v1.1.1"
       }
     },
     {
@@ -30,9 +30,9 @@
     },
     {
       "id": "tenaamstellingen",
-      "$ref": "tenaamstellingen/v2.1.0",
+      "$ref": "tenaamstellingen/v2.1.1",
       "activeVersions": {
-        "2.1.0": "tenaamstellingen/v2.1.0"
+        "2.1.1": "tenaamstellingen/v2.1.1"
       }
     },
     {
@@ -51,9 +51,9 @@
     },
     {
       "id": "stukdelen",
-      "$ref": "stukdelen/v2.0.0",
+      "$ref": "stukdelen/v2.0.1",
       "activeVersions": {
-        "2.0.0": "stukdelen/v2.0.0"
+        "2.0.1": "stukdelen/v2.0.1"
       }
     },
     {

--- a/datasets/brk/kadastraleobjecten/v1.1.1.json
+++ b/datasets/brk/kadastraleobjecten/v1.1.1.json
@@ -1,0 +1,292 @@
+{
+  "id": "kadastraleobjecten",
+  "type": "table",
+  "version": "1.1.1",
+  "auth": "BRK/RSN",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/brk/kadastraleobjecten.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "id",
+      "identificatie",
+      "volgnummer"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "id": {
+        "type": "string",
+        "description": "Neuron ID"
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "De unieke aanduiding van een Kadastraal object."
+      },
+      "kadastraleAanduiding": {
+        "type": "string",
+        "description": "De unieke aanduiding van een Kadastraal Object samengesteld uit gemeentecode, kadastrale sectie, perceelnummer, indexletter en indexnummer."
+      },
+      "aangeduidDoorGemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:gemeentes",
+        "description": ""
+      },
+      "aangeduidDoorKadastralegemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:kadastralegemeentes",
+        "description": "De kadastrale gemeente, het eerste gedeelte van de aanduiding van een kadastraal object."
+      },
+      "aangeduidDoorKadastralegemeentecode": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:kadastralegemeentecodes",
+        "description": ""
+      },
+      "aangeduidDoorKadastralesectie": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:kadastralesecties",
+        "description": "De kadastrale sectie, het tweede gedeelte van de aanduiding van een kadastraal object."
+      },
+      "perceelnummer": {
+        "type": "integer",
+        "description": "Een numerieke aanduiding van het kadastrale perceel per sectie, deel van de kadastrale aanduiding van de onroerende zaak."
+      },
+      "indexletter": {
+        "type": "string",
+        "description": "Letter Kadastraal object, dit geeft een indicatie voor het type object. G Grond perceel. A Appartementsrecht"
+      },
+      "indexnummer": {
+        "type": "integer",
+        "description": "Volgnummer van het Appartementsrecht"
+      },
+      "gemeente": {
+        "type": "string",
+        "description": ""
+      },
+      "soortGrootteCode": {
+        "type": "string",
+        "provenance": "$.soortGrootte.code",
+        "description": "Aanduiding van soort grootte code"
+      },
+      "soortGrootteOmschrijving": {
+        "type": "string",
+        "provenance": "$.soortGrootte.omschrijving",
+        "description": "Aanduiding van soort grootte omschrijving"
+      },
+      "grootte": {
+        "type": "number",
+        "description": "De grootte van een kadastraal object is de oppervlakte van het kadastrale perceel. Dit kan bij een deelperceel een geschatte grootte zijn."
+      },
+      "soortCultuurOnbebouwdCode": {
+        "type": "string",
+        "provenance": "$.soortCultuurOnbebouwd.code",
+        "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notari\u00eble akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. code"
+      },
+      "soortCultuurOnbebouwdOmschrijving": {
+        "type": "string",
+        "provenance": "$.soortCultuurOnbebouwd.omschrijving",
+        "description": "De soort cultuur onbebouwd is een aanduiding voor de aard van de meest significante cultuur van het onbebouwde deel van het kadastraal object, weergegeven als \u2018omschrijving kadastraal object\u2019 in Mijn.kadaster.nl Dit kenmerk is in beginsel afgeleid van de notari\u00eble akte, maar kan worden bijgesteld op grond van een verzoek van de eigenaar (of een schriftelijk gevolmachtigde namens de eigenaar)per brief, fax of e-mailbericht. Dit kan afwijken van: het feitelijk gebruik in de WOZ; gebruiksdoel in de BAG; SBI-code in het HR. omschrijving"
+      },
+      "soortCultuurBebouwd": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "omschrijving": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "status": {
+        "type": "string",
+        "description": "Status van het Kadastraal Object ('B' is bestaand)"
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Vorm en ligging van de kadastrale sectie in het stelsel van de Rijksdriehoeksmeting (RD)"
+      },
+      "plaatscoordinaten": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "De aanduiding van een kaartpunt voor de weergave van de identificatie van een perceel (centro\u00efde)"
+      },
+      "perceelnummerRotatie": {
+        "type": "number",
+        "description": "Rotatie van het perceelnummer ten behoeve van afbeelding op de kaart. Perceelnummers worden bijvoorbeeld gekanteld om in een smal perceel te passen"
+      },
+      "perceelnummerVerschuivingX": {
+        "type": "string",
+        "description": "Co\u00f6rdinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden x"
+      },
+      "perceelnummerVerschuivingY": {
+        "type": "string",
+        "description": "Co\u00f6rdinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden y"
+      },
+      "bijpijlingGeometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Vorm en ligging van de bijpijling (de puur grafische lijn tussen het perceel en het perceelnummer)  in het stelsel van de Rijksdriehoeksmeting (RD)"
+      },
+      "indicatieVoorlopigeGeometrie": {
+        "type": "string",
+        "description": "Indicatie of de geometrie (kadastrale grens) voorlopig is of niet J N"
+      },
+      "koopsom": {
+        "type": "integer",
+        "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen."
+      },
+      "koopsomValutacode": {
+        "type": "string",
+        "description": "Aanduiding van de valutasoort gebruikt bij de koop"
+      },
+      "koopjaar": {
+        "type": "string",
+        "description": "Transactiejaar van de aankoop"
+      },
+      "indicatieMeerObjecten": {
+        "type": "string",
+        "description": "Indicatie dat de koopsom betrekking heeft op meer dan 1 kadastraal object"
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "inOnderzoek": {
+        "type": "string",
+        "description": "Als dit veld is gevuld geeft dit de omschrijving waarom dit gegeven in onderzoek staat (art. 7n en 7r Kadasterwet)."
+      },
+      "isOntstaanUitGPerceel": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:kadastraleobjecten",
+        "description": "Dit veld is all\u00e9\u00e9n gevuld wanneer het beschreven kadastrale object een A-perceel betreft."
+      },
+      "heeftEenRelatieMetVerblijfsobject": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "bag:verblijfsobjecten",
+        "description": "Relatie naar verblijfsobject"
+      },
+      "isOntstaanUitKadastraalobject": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:kadastraleobjecten",
+        "description": "Onderliggende percelen. Alleen gevuld wanneer het beschreven kadastrale object een A-perceel betreft."
+      }
+    },
+    "mainGeometry": "geometrie"
+  }
+}

--- a/datasets/brk/kadastraleobjecten/v1.1.1.json
+++ b/datasets/brk/kadastraleobjecten/v1.1.1.json
@@ -165,10 +165,12 @@
       },
       "perceelnummerVerschuivingX": {
         "type": "string",
+        "provenance": "$.perceelnummerVerschuiving.x",
         "description": "Co\u00f6rdinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden x"
       },
       "perceelnummerVerschuivingY": {
         "type": "string",
+        "provenance": "$.perceelnummerVerschuiving.y",
         "description": "Co\u00f6rdinaten voor het verschuiven van het perceelnummer op de kaart naar een locatie waar meer ruimte is om het nummer af te beelden y"
       },
       "bijpijlingGeometrie": {

--- a/datasets/brk/stukdelen/v2.0.1.json
+++ b/datasets/brk/stukdelen/v2.0.1.json
@@ -38,10 +38,12 @@
       },
       "bedragTransactieBedrag": {
         "type": "integer",
+        "provenance": "$.bedragTransactie.bedrag",
         "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen. bedrag"
       },
       "bedragTransactieValuta": {
         "type": "string",
+        "provenance": "$.bedragTransactie.valuta",
         "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen. valuta"
       },
       "isBronVoorTenaamstelling": {

--- a/datasets/brk/stukdelen/v2.0.1.json
+++ b/datasets/brk/stukdelen/v2.0.1.json
@@ -1,0 +1,183 @@
+{
+  "id": "stukdelen",
+  "type": "table",
+  "version": "2.0.1",
+  "auth": "BRK/RSN",
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/brk/stukdelen.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": "id",
+    "required": [
+      "schema",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "id": {
+        "type": "string",
+        "description": "Neuron ID"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het door het Kadaster toegekende landelijk unieke nummer aan het stukdeel."
+      },
+      "aardCode": {
+        "type": "string",
+        "provenance": "$.aard.code",
+        "description": "Aanduiding voor de aard van een deel van het ter inschrijving aangeboden stuk (rechtsfeit). code"
+      },
+      "aardOmschrijving": {
+        "type": "string",
+        "provenance": "$.aard.omschrijving",
+        "description": "Aanduiding voor de aard van een deel van het ter inschrijving aangeboden stuk (rechtsfeit). omschrijving"
+      },
+      "bedragTransactieBedrag": {
+        "type": "integer",
+        "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen. bedrag"
+      },
+      "bedragTransactieValuta": {
+        "type": "string",
+        "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen. valuta"
+      },
+      "isBronVoorTenaamstelling": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:tenaamstellingen",
+        "description": "Geeft weer welke tenaamstelling is ontstaan op basis van dit stukdeel"
+      },
+      "isBronVoorAantekeningKadastraalObject": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:aantekeningenkadastraleobjecten",
+        "description": "Geeft weer welke aantekening kadastraal object is ontstaan op basis van dit stukdeel"
+      },
+      "isBronVoorAantekeningRecht": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk:aantekeningenrechten",
+        "description": "Geeft weer welke aantekening recht is ontstaan op basis van dit stukdeel"
+      },
+      "isBronVoorZakelijkRecht": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Geeft weer welk zakelijk recht is ontstaan op basis van dit stukdeel."
+      },
+      "stukidentificatie": {
+        "type": "string",
+        "description": "Het door het Kadaster toegekende landelijk unieke nummer aan het stuk."
+      },
+      "portefeuillenummerAkr": {
+        "type": "string",
+        "description": "Portefeuillenummer toegekend aan het stuk in het AKR-systeem."
+      },
+      "tijdstipAanbiedingStuk": {
+        "type": "string",
+        "description": "Het tijdstip waarop een ter inschrijving aangeboden stuk is ontvangen met inachtneming van de openingstijden en -dagen van het Kadaster. Als tijdstip van inschrijving geldt het tijdstip van aanbieding van de voor de inschrijving vereiste stukken."
+      },
+      "reeks": {
+        "type": "string",
+        "description": "Verwijzing naar de oorspronkelijke (mogelijk tussentijds vervallen) Kadastervestiging waar het stuk oorspronkelijk is ingeschreven."
+      },
+      "volgnummerStuk": {
+        "type": "integer",
+        "description": "Volgnummer van het stuk."
+      },
+      "registercodeStukCode": {
+        "type": "string",
+        "provenance": "$.registercodeStuk.code",
+        "description": "Het soort register, aangeduid met een code. code"
+      },
+      "registercodeStukOmschrijving": {
+        "type": "string",
+        "provenance": "$.registercodeStuk.omschrijving",
+        "description": "Het soort register, aangeduid met een code. omschrijving"
+      },
+      "soortRegisterStukCode": {
+        "type": "string",
+        "provenance": "$.soortRegisterStuk.code",
+        "description": "Het register waarvan een ter inschrijving aangeboden stuk deel uitmaakt. code"
+      },
+      "soortRegisterStukOmschrijving": {
+        "provenance": "$.soortRegisterStuk.omschrijving",
+        "type": "string",
+        "description": "Het register waarvan een ter inschrijving aangeboden stuk deel uitmaakt. omschrijving"
+      },
+      "deelSoortStuk": {
+        "type": "string",
+        "description": "Identificatie van het stuk binnen zijn soort."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk/tenaamstellingen/v2.1.1.json
+++ b/datasets/brk/tenaamstellingen/v2.1.1.json
@@ -1,0 +1,156 @@
+{
+  "id": "tenaamstellingen",
+  "type": "table",
+  "version": "2.1.1",
+  "auth": "BRK/RSN",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/brk/tenaamstellingen.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "volgnummer",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "neuronId": {
+        "type": "string",
+        "description": "Neuron ID",
+        "provenance": "id"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "De identificatie is een uniek nummer aan deze tenaamstelling binnen de kadastrale registratie."
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": ""
+      },
+      "vanKadastraalsubject": {
+        "type": "string",
+        "relation": "brk:kadastralesubjecten",
+        "provenance": "$.vanKadastraalsubject.identificatie",
+        "description": "Het Subject waarvoor deze tenaamstelling geldt."
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "aandeelTeller": {
+        "type": "integer",
+        "provenance": "$.aandeel.teller",
+        "description": "Aandeel in Recht is het aandeel waarvoor een persoon deelneemt in het Recht teller"
+      },
+      "aandeelNoemer": {
+        "type": "integer",
+        "provenance": "$.aandeel.noemer",
+        "description": "Aandeel in Recht is het aandeel waarvoor een persoon deelneemt in het Recht noemer"
+      },
+      "geldtVoorTeller": {
+        "type": "integer",
+        "provenance": "$.geldtVoor.teller",
+        "description": "Twee of meer personen kunnen gezamenlijk een aandeel hebben in een recht, waarbij het afzonderlijke aandeel in het gezamenlijk aandeel niet bekend is (als gezamenlijkAandeel bekend is dan is het individuele aandeel niet bekend en omgekeerd). teller"
+      },
+      "geldtVoorNoemer": {
+        "type": "integer",
+        "provenance": "$.geldtVoor.noemer",
+        "description": "Twee of meer personen kunnen gezamenlijk een aandeel hebben in een recht, waarbij het afzonderlijke aandeel in het gezamenlijk aandeel niet bekend is (als gezamenlijkAandeel bekend is dan is het individuele aandeel niet bekend en omgekeerd). noemer"
+      },
+      "burgerlijkeStaatTenTijdeVanVerkrijgingCode": {
+        "type": "string",
+        "provenance": "$.burgerlijkeStaatTenTijdeVanVerkrijging.code",
+        "description": "De burgerlijke staat is een aanduiding voor de leefvorm van een persoon, zoals deze volgens het brondocument ten tijde van de verkrijging van het recht bestond. Leefvorm van een persoon heeft betrekking op huwelijk c.q. geregistreerd partnerschap. code"
+      },
+      "burgerlijkeStaatTenTijdeVanVerkrijgingOmschrijving": {
+        "type": "string",
+        "provenance": "$.burgerlijkeStaatTenTijdeVanVerkrijging.omschrijving",
+        "description": "De burgerlijke staat is een aanduiding voor de leefvorm van een persoon, zoals deze volgens het brondocument ten tijde van de verkrijging van het recht bestond. Leefvorm van een persoon heeft betrekking op huwelijk c.q. geregistreerd partnerschap. omschrijving"
+      },
+      "verkregenNamensSamenwerkingsverbandCode": {
+        "type": "string",
+        "provenance": "$.verkregenNamensSamenwerkingsverband.code",
+        "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. code"
+      },
+      "verkregenNamensSamenwerkingsverbandOmschrijving": {
+        "type": "string",
+        "provenance": "$.verkregenNamensSamenwerkingsverband.omschrijving",
+        "description": "De aard van het samenwerkingsverband (zoals Maatschap, VOF of CV) namens welke een natuurlijk persoon deze tenaamstelling heeft verkregen. omschrijving"
+      },
+      "inOnderzoek": {
+        "type": "string",
+        "description": ""
+      },
+      "vanZakelijkrecht": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "string"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Het Zakelijk recht waarover deze tenaamstelling gaat."
+      },
+      "isGebaseerdOpStukdeel": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "string"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:stukdelen",
+        "description": "Het Stukdeel waar deze tenaamstelling op gebaseerd is."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk/tenaamstellingen/v2.1.1.json
+++ b/datasets/brk/tenaamstellingen/v2.1.1.json
@@ -130,17 +130,6 @@
         "properties": {
           "identificatie": {
             "type": "string"
-          },
-          "volgnummer": {
-            "type": "string"
-          },
-          "beginGeldigheid": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "eindGeldigheid": {
-            "type": "string",
-            "format": "date-time"
           }
         },
         "relation": "brk:stukdelen",

--- a/datasets/brk/zakelijkerechten/v1.1.1.json
+++ b/datasets/brk/zakelijkerechten/v1.1.1.json
@@ -1,0 +1,243 @@
+{
+  "id": "zakelijkerechten",
+  "type": "table",
+  "version": "1.1.1",
+  "auth": "BRK/RSN",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/brk/zakelijkerechten.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "id",
+      "identificatie",
+      "volgnummer"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "De Kadaster identificatie is een door het Kadaster toegekende landelijk uniek nummer aan dit zakelijk recht binnen de kadastrale registratie."
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "belastZakelijkerechten": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Dit zakelijk recht belast de volgende Aardzakelijkrechten"
+      },
+      "belastMetZakelijkerechten": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Dit zakelijk recht is belast met de volgende Aardzakelijkrechten"
+      },
+      "ontstaanUitZakelijkerechten": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Als deze waarde is gevuld, dan is dit recht ontstaan uit een appartementssplitsing, die hier met zijn identificerende kenmerk aangegeven wordt (VVE)"
+      },
+      "ontstaanUitAppartementsrechtsplitsingVve": {
+        "shortname": "ontstaanUitApptrechtsplitsingVve",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:kadastralesubjecten",
+        "description": "Als deze waarde is gevuld, dan is dit recht betrokken bij een appartementssplitsing, die hier met zijn identificerende kenmerk aangegeven wordt (VVE)"
+      },
+      "betrokkenBijZakelijkerechten": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "string"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:zakelijkerechten",
+        "description": "Als deze waarde is gevuld, dan is dit recht ontstaan uit een appartementssplitsing, die hier met zijn identificerende kenmerk aangegeven wordt (VVE)"
+      },
+      "betrokkenBijAppartementsrechtsplitsingVve": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:kadastralesubjecten",
+        "description": "VVE Subject betrokken bij Appartementsrechtsplitsing"
+      },
+      "isBeperktTot": {
+        "type": "integer",
+        "description": "Is beperkt tot tenaamstelling, dat wil zeggen is beperkt tot een subject"
+      },
+      "rustOpKadastraalobject": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "string"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:kadastraleobjecten",
+        "description": "Het kadastraal object en volgnummer waarop het zakelijk recht rust"
+      },
+      "appartementsrechtsplitsingidentificatie": {
+        "type": "string",
+        "description": "De identificatie van de appartementsrechtsplitsing"
+      },
+      "appartementsrechtsplitsingtypeCode": {
+        "type": "string",
+        "provenance": "$.appartementsrechtsplitsingtype.code",
+        "description": "Het type appartementsrechtsplitsing. De mogelijke waarden zijn: hoofdsplitsing of ondersplitsing of splitsing afkoop erfpacht. code"
+      },
+      "appartementsrechtsplitsingtypeOmschrijving": {
+        "type": "string",
+        "provenance": "$.appartementsrechtsplitsingtype.omschrijving",
+        "description": "Het type appartementsrechtsplitsing. De mogelijke waarden zijn: hoofdsplitsing of ondersplitsing of splitsing afkoop erfpacht. omschrijving"
+      },
+      "einddatumAppartementsrechtsplitsing": {
+        "type": "string",
+        "description": "Einddatum van de appartementsrechtsplitsing"
+      },
+      "indicatieActueelAppartementsrechtsplitsing": {
+        "type": "string",
+        "description": "Indicatie van de actualiteit van de appartementsrechtsplitsing"
+      },
+      "aardZakelijkRechtCode": {
+        "type": "string",
+        "provenance": "$.aardZakelijkRecht.code",
+        "description": "De aard van het zakelijk recht code"
+      },
+      "aardZakelijkRechtOmschrijving": {
+        "type": "string",
+        "provenance": "$.aardZakelijkRecht.omschrijving",
+        "description": "De aard van het zakelijk recht omschrijving"
+      },
+      "akrAardZakelijkRecht": {
+        "type": "string",
+        "description": "De AKR code van de aard van het zakelijk recht"
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/hr/dataset.json
+++ b/datasets/hr/dataset.json
@@ -16,16 +16,16 @@
     },
     {
       "id": "locaties",
-      "$ref": "locaties/v1.0.0",
+      "$ref": "locaties/v1.0.1",
       "activeVersions": {
-        "1.0.0": "locaties/v1.0.0"
+        "1.0.1": "locaties/v1.0.1"
       }
     },
     {
       "id": "vestigingen",
-      "$ref": "vestigingen/v1.0.0",
+      "$ref": "vestigingen/v2.0.0",
       "activeVersions": {
-        "1.0.0": "vestigingen/v1.0.0"
+        "2.0.0": "vestigingen/v2.0.0"
       }
     },
     {

--- a/datasets/hr/locaties/v1.0.1.json
+++ b/datasets/hr/locaties/v1.0.1.json
@@ -1,0 +1,181 @@
+{
+  "id": "locaties",
+  "type": "table",
+  "version": "1.0.1",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/hr/locaties.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "identificatie",
+      "volgnummer"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Attribuut om deze locatie uniek te identificeren."
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": ""
+      },
+      "tijdstipRegistratie": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de locatie bij de KvK in het handelsregister is geregistreerd."
+      },
+      "datumAanvang": {
+        "type": "string",
+        "provenance": "$.datumAanvang.formatted",
+        "description": "De datum waarbij de locatie is ontstaan."
+      },
+      "datumEinde": {
+        "type": "string",
+        "provenance": "$.datumEinde.formatted",
+        "description": "De datum waarbij de locatie is be\u00ebindigd."
+      },
+      "afgeschermd": {
+        "type": "boolean",
+        "description": "Geeft aan of het adres afgeschermd is of niet."
+      },
+      "toevoegingAdres": {
+        "type": "string",
+        "description": "Vrije tekst om een Adres nader aan te kunnen duiden. Het gaat hier bijvoorbeeld om bedrijfsverzamelgebouwen waarbij meerdere vestigingen op hetzelfde adres zitten en waarbij onderscheid gemaakt kan worden door een extra omschrijving van de locatie. Ook een locatieOmschrijving en aanduidingBijHuisnummer uit de BRP wordt hiermee doorgegeven."
+      },
+      "volledigAdres": {
+        "type": "string",
+        "description": "Samengesteld adres dat wordt afgeleid van de overige adresgegevens."
+      },
+      "heeftNummeraanduiding": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:nummeraanduidingen",
+        "description": "Met welk adres heeft de locatie een relatie."
+      },
+      "heeftVerblijfsobject": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:verblijfsobjecten",
+        "description": "Met welke verblijfsobject heeft de locatie een relatie."
+      },
+      "heeftLigplaats": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:ligplaatsen",
+        "description": "Met welke ligplaats heeft de locatie een relatie."
+      },
+      "heeftStandplaats": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:standplaatsen",
+        "description": "Met welke standplaats heeft de locatie een relatie."
+      },
+      "straatnaam": {
+        "type": "string",
+        "description": "De straat van het binnenlandse adres."
+      },
+      "huisnummer": {
+        "type": "integer",
+        "description": "Het huisnummer van het adres."
+      },
+      "huisletter": {
+        "type": "string",
+        "description": "De huisletter van het binnenlandse adres die die door de gemeente is toegekend aan het huisnummer."
+      },
+      "huisnummerToevoeging": {
+        "type": "string",
+        "description": "Een toevoeging van het huisnummer van het binnenlandse adres."
+      },
+      "postbusnummer": {
+        "type": "string",
+        "description": "Het nummer van de postbus behorende bij het binnenlandse adres."
+      },
+      "postcode": {
+        "type": "string",
+        "description": "De postcode van het binnenlandse adres, waarbij minimaal de vier cijfers bekend zijn."
+      },
+      "plaats": {
+        "type": "string",
+        "description": "De plaatsaanduiding van het binnenlandse adres. Dit komt overeen met het gemeentedeel in de basisregistratie personen."
+      },
+      "straatHuisnummerBuitenland": {
+        "type": "string",
+        "description": "Het straat/huisnummer is een combinatie van de straat en het huisnummer van het buitenlandse adres."
+      },
+      "postcodePlaatsBuitenland": {
+        "type": "string",
+        "description": "De postcode/woonplaats is de combinatie van een eventuele postcode en woonplaats van het buitenlandse adres."
+      },
+      "regioBuitenland": {
+        "type": "string",
+        "description": "Regio is een deel van het land (streek, provincie, etc.) van het buitenlandse adres."
+      },
+      "landBuitenland": {
+        "type": "string",
+        "description": "De naam van het land waar het adres zich bevindt."
+      }
+    }
+  }
+}

--- a/datasets/hr/vestigingen/v2.0.0.json
+++ b/datasets/hr/vestigingen/v2.0.0.json
@@ -1,0 +1,223 @@
+{
+  "id": "vestigingen",
+  "type": "table",
+  "version": "2.0.0",
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/hr/vestigingen.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": "vestigingsnummer",
+    "required": [
+      "schema",
+      "vestigingsnummer"
+    ],
+    "display": "vestigingsnummer",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "vestigingsnummer": {
+        "type": "string",
+        "description": "Betreft het identificerende gegeven voor de vestiging."
+      },
+      "tijdstipRegistratie": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de vestiging bij de KvK in het handelsregister is geregistreerd."
+      },
+      "datumAanvang": {
+        "type": "string",
+        "format": "date",
+        "provenance": "$.datumAanvang.formatted",
+        "description": "De datum waarbij de vestiging is ontstaan."
+      },
+      "datumEinde": {
+        "type": "string",
+        "format": "date",
+        "provenance": "$.datumEinde.formatted",
+        "description": "De datum waarbij de vestiging is be\u00ebindigd."
+      },
+      "datumVoortzetting": {
+        "type": "string",
+        "format": "date",
+        "provenance": "$.datumVoortzetting.formatted",
+        "description": "Datum voortzetting van de vestiging."
+      },
+      "isCommercieleVestiging": {
+        "type": "boolean",
+        "description": "Geeft aan of dit een commerci\u00eble vestiging betreft. Als false, dan een niet-commerci\u00eble vestiging."
+      },
+      "eersteHandelsnaam": {
+        "type": "string",
+        "description": "De eerste-handelsnaam betreft een samengesteld veld over de vestiging. Als het een niet-commerci\u00eble vestiging betreft is dit de naam, als het een commerciele vestiging betreft is dit de eerste handelsnaam."
+      },
+      "heeftAlsPostadres": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "hr:locaties",
+        "description": "Het geregistreerde postadres behorende bij de vestiging."
+      },
+      "heeftAlsBezoekadres": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "hr:locaties",
+        "description": "Het geregistreerde bezoekadres behorende bij de vestiging."
+      },
+      "communicatienummer": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "toegangscode": {
+              "type": "integer"
+            },
+            "nummer": {
+              "type": "string"
+            },
+            "soort": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Communicatienummer is het telefoon- of faxnummer. Zowel het netnummer als het abonneenummer worden teruggegeven in het nummer. De internationale toegangscode van het land waarop het nummer (telefoon of fax) betrekking heeft staat in het veld toegangscode."
+      },
+      "domeinnaam": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "naam": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "De domeinnaam is de naam waaronder de betrokkene zaken doet of informatie verschaft op het internet, het internetadres (URL)"
+      },
+      "emailadres": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "naam": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "Het e-mail adres dat de betrokkene open heeft gesteld voor communicatie."
+      },
+      "naam": {
+        "type": "string",
+        "description": "De naam van de niet-commerci\u00eble vestiging."
+      },
+      "verkorteNaam": {
+        "type": "string",
+        "description": "De administratieve naam van de niet-commerci\u00eble vestiging in het handelsregister indien de naam langer is dan 45 karakters."
+      },
+      "ookGenoemd": {
+        "type": "string",
+        "description": "Een andere naam waaronder de vereniging stichtingen en vereniging van eigenaars ook bekend is."
+      },
+      "handeltOnderHandelsnamen": {
+        "shortname": "handeltOnderHn",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "omschrijving": {
+              "type": "string"
+            },
+            "tijdstipRegistratie": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "datumAanvangHandelsnaam": {
+              "type": "string"
+            },
+            "datumEindeHandelsnaam": {
+              "type": "string"
+            },
+            "volgorde": {
+              "type": "integer"
+            }
+          }
+        },
+        "description": "Een handelsnaam is een naam waaronder de commerci\u00eble vestiging handelt. Een vestiging mag meerdere handelsnamen hebben. omschrijving"
+      },
+      "totaalWerkzamePersonen": {
+        "type": "integer",
+        "description": "Het totaal aantal werkzame personen bij de onderneming "
+      },
+      "voltijdWerkzamePersonen": {
+        "type": "integer",
+        "description": "Het aantal voltijd (meer dan 15 uur per week) werkzame personen bij de onderneming "
+      },
+      "deeltijdWerkzamePersonen": {
+        "type": "integer",
+        "description": "Het aantal deeltijd (kleiner of gelijk aan 15 uur per week) werkzame personen bij de onderneming"
+      },
+      "importeert": {
+        "type": "boolean",
+        "description": "Indicatie of de commerci\u00eble activiteit Import betreft."
+      },
+      "exporteert": {
+        "type": "boolean",
+        "description": "Indicatie of de commerci\u00eble activiteit Export betreft."
+      },
+      "activiteitenOmschrijving": {
+        "type": "string",
+        "description": "De omschrijving van de activiteiten die de vestiging uitoefent. De beschrijving bevat de nadere aanduiding van de commerci\u00eble activiteiten of de nadere aanduiding van de niet-commerci\u00eble activiteiten."
+      },
+      "heeftSbiActiviteiten": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "sbiActiviteitNummer": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "hr:sbiactiviteiten",
+        "description": "SBI Activiteiten die bij deze commerci\u00eble of niet commerci\u00eble vestiging horen."
+      },
+      "isOvergegaanInVestiging": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "vestigingsnummer": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "hr:vestigingen",
+        "description": "Dit legt de relatie van de afgesloten vestiging met de samengevoegde vestiging."
+      },
+      "isEenUitoefeningVan": {
+        "type": "object",
+        "properties": {
+          "kvknummer": {
+            "type": "string"
+          }
+        },
+        "relation": "hr:maatschappelijkeactiviteiten",
+        "description": "Maatschappelijke activiteit die bij deze vestiging hoort."
+      }
+    }
+  }
+}

--- a/datasets/meetbouten/dataset.json
+++ b/datasets/meetbouten/dataset.json
@@ -22,9 +22,9 @@
     },
     {
       "id": "referentiepunten",
-      "$ref": "referentiepunten/v1.1.0",
+      "$ref": "referentiepunten/v1.1.1",
       "activeVersions": {
-        "1.1.0": "referentiepunten/v1.1.0"
+        "1.1.1": "referentiepunten/v1.1.1"
       }
     },
     {

--- a/datasets/meetbouten/referentiepunten/v1.1.1.json
+++ b/datasets/meetbouten/referentiepunten/v1.1.1.json
@@ -1,0 +1,179 @@
+{
+  "id": "referentiepunten",
+  "type": "table",
+  "version": "1.1.1",
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/meetbouten/referentiepunten.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "mainGeometry": "geometrie",
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Unieke identificatie van de meting"
+      },
+      "nabijNummeraanduiding": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "bag:nummeraanduidingen",
+        "description": "Een adres in de nabijheid van het referentiepunt"
+      },
+      "locatie": {
+        "type": "string",
+        "description": "Beschrijving van de locatie van het referentiepunt bijv 'nabij noordoostelijke gevelhoek'."
+      },
+      "hoogteTovNap": {
+        "type": "number",
+        "description": "Hoogte van het referentiepunt t.o.v. NAP"
+      },
+      "datum": {
+        "type": "string",
+        "format": "date",
+        "description": "Datum van plaatsing van het referentiepunt."
+      },
+      "statusCode": {
+        "type": "string",
+        "description": "Status van het referentiepunt (1=actueel, 2=niet te meten, 3=vervallen) code",
+        "provenance": "$.status.code"
+      },
+      "statusOmschrijving": {
+        "type": "string",
+        "description": "Status van het referentiepunt (1=actueel, 2=niet te meten, 3=vervallen) omschrijving",
+        "provenance": "$.status.omschrijving"
+      },
+      "vervaldatum": {
+        "type": "string",
+        "format": "date",
+        "description": "Vervaldatum van het referentiepunt."
+      },
+      "merkCode": {
+        "type": "string",
+        "description": "Merk van het referentiepunt code",
+        "provenance": "$.merk.code"
+      },
+      "merkOmschrijving": {
+        "type": "string",
+        "description": "Merk van het referentiepunt omschrijving",
+        "provenance": "$.merk.omschrijving"
+      },
+      "xCoordinaatMuurvlak": {
+        "type": "number",
+        "description": "X-co\u00f6rdinaat muurvlak"
+      },
+      "yCoordinaatMuurvlak": {
+        "type": "number",
+        "description": "Y-co\u00f6rdinaat muurvlak"
+      },
+      "windrichting": {
+        "type": "string",
+        "description": "Windrichting"
+      },
+      "ligtInBouwblok": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "relation": "gebieden:bouwblokken",
+        "description": "Het bouwblok waarbinnen het referentiepunt ligt"
+      },
+      "ligtInBuurt": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "relation": "gebieden:buurten",
+        "description": "De buurt waarbinnen het referentiepunt ligt"
+      },
+      "ligtInStadsdeel": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        "relation": "gebieden:stadsdelen",
+        "description": "Het stadsdeel waarbinnen het referentiepunt ligt"
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Geometrische ligging van de meetbout"
+      },
+      "isNapPeilmerk": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "nap:peilmerken",
+        "description": "Het NAP-peilmerk dat het referentiepunt kan zijn."
+      },
+      "publiceerbaar": {
+        "type": "boolean",
+        "description": "Publiceerbaar ja of nee"
+      }
+    }
+  }
+}

--- a/datasets/nap/dataset.json
+++ b/datasets/nap/dataset.json
@@ -8,9 +8,9 @@
   "tables": [
     {
       "id": "peilmerken",
-      "$ref": "peilmerken/v1.0.0",
+      "$ref": "peilmerken/v1.0.1",
       "activeVersions": {
-        "1.0.0": "peilmerken/v1.0.0"
+        "1.0.1": "peilmerken/v1.0.1"
       }
     }
   ]

--- a/datasets/nap/peilmerken/v1.0.1.json
+++ b/datasets/nap/peilmerken/v1.0.1.json
@@ -1,0 +1,101 @@
+{
+  "id": "peilmerken",
+  "type": "table",
+  "version": "1.0.1",
+  "schema": {
+    "$id": "https://github.com/Amsterdam/schemas/nap/peilmerken.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "mainGeometry": "geometrie",
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het peilmerknummer van het peilmerk."
+      },
+      "hoogteTovNap": {
+        "type": "number",
+        "description": "Hoogte van het peilmerk t.o.v. NAP"
+      },
+      "jaar": {
+        "type": "integer",
+        "description": "Het jaar van waterpassing, behorende bij de hoogte."
+      },
+      "merkCode": {
+        "type": "string",
+        "provenance": "$.merk.code",
+        "description": "Merk van het referentiepunt code"
+      },
+      "merkOmschrijving": {
+        "type": "string",
+        "provenance": "$.merk.omschrijving",
+        "description": "Merk van het referentiepunt omschrijving"
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Beschrijving van het object waarin het peilmerk zich bevindt."
+      },
+      "windrichting": {
+        "type": "string",
+        "description": "Windrichting"
+      },
+      "xCoordinaatMuurvlak": {
+        "type": "number",
+        "description": "X-co\u00f6rdinaat muurvlak"
+      },
+      "yCoordinaatMuurvlak": {
+        "type": "number",
+        "description": "Y-co\u00f6rdinaat muurvlak"
+      },
+      "rwsNummer": {
+        "type": "string",
+        "description": "Nummer dat Rijkswaterstaat hanteert."
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Geometrische ligging van de meetbout"
+      },
+      "statusCode": {
+        "type": "integer",
+        "provenance": "$.status.code",
+        "description": "Status van het referentiepunt (1=actueel, 2=niet te meten, 3=vervallen) code"
+      },
+      "statusOmschrijving": {
+        "type": "string",
+        "provenance": "$.status.omschrijving",
+        "description": "Status van het referentiepunt (1=actueel, 2=niet te meten, 3=vervallen) omschrijving"
+      },
+      "vervaldatum": {
+        "type": "string",
+        "format": "date",
+        "description": "Vervaldatum van het peilmerk."
+      },
+      "ligtInBouwblok": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "gebieden:bouwblokken",
+        "description": "Het bouwblok waarbinnen het peilmerk ligt"
+      },
+      "publiceerbaar": {
+        "type": "boolean",
+        "description": "Publiceerbaar ja of nee"
+      }
+    }
+  }
+}


### PR DESCRIPTION
See explanation in the commit messages.

Because we create new amsterdam schema files for new versions, git diff cannot be used to see the changes.
Diffing is only possible by checking out this PR and doing a regular `diff` on the latest/previous schema files.