### PR TITLE
Omgevingswet: beheerkrt-cbs_grid -> refdb: corr bk

### DIFF
--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -32,6 +32,10 @@
             "type": "string",
             "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-100-vlak)."
           },
+          "bkCbsGrid100Asd": {
+            "type": "string",
+            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-100-vlak)."
+          },
           "rasterActief": {
             "type": "boolean",
             "description": "Indicatie of het BKT-CBS-grid-100-vlak als actief wordt aangemerkt door Stadswerken / Apptimize."
@@ -158,6 +162,10 @@
           },
           "id": {
             "provenance": "bk_cbs_grid_10_asd",
+            "type": "string",
+            "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak)."
+          },
+          "bkCbsGrid10Asd": {
             "type": "string",
             "description": "Business-key: unieke aanduiding record (BKT-CBS-grid-10-vlak)."
           },


### PR DESCRIPTION
Hallo collega (Yashar?),
   Hierbij de nieuwe verbeterde versie van de Beheerkaart-CBS_grid-tabellen raster_100 en -10. In beide tabellen zit nu net als in de brontabel in onze Vastgoed-db een tweede kolom tussengevoegd genaamd bkCbsGrid10(0)Asd met dezelfde waarden als de eerste kolom ID, waardoor tijdens het geautomatiseerde push-verversen van deze net nieuwe tabellen in jullie RefDB vanuit onze Vastgoed-db wel alle kolommen worden herkend en de insert dus wel goed gaat. Zou moeten gaan :-).
   Als je akkoord gaat, kun je dan deze tabellen opnieuw aanmaken, en controleren of de tabel- en kolom-commentaren daarbij ook meekomen?
   Dank, groet, Raymond