### PR TITLE
Shortname HftBtrkOpKot -> hftBtrkOpKot

### DIFF
--- a/datasets/brk/aantekeningenkadastraleobjecten/v1.1.0.json
+++ b/datasets/brk/aantekeningenkadastraleobjecten/v1.1.0.json
@@ -82,7 +82,7 @@
         "description": "Identificatie van het betrokken subject"
       },
       "heeftBetrekkingOpKadastraalObject": {
-        "shortname": "HftBtrkOpKot",
+        "shortname": "hftBtrkOpKot",
         "type": "object",
         "properties": {
           "identificatie": {


### PR DESCRIPTION
Shortnames should start with a lowercase char.