### PR TITLE
Fix type of volgnummer in wozdeelobjecten relations

### DIFF
--- a/datasets/woz/wozdeelobjecten/v1.0.0.json
+++ b/datasets/woz/wozdeelobjecten/v1.0.0.json
@@ -79,7 +79,7 @@
             "type": "string"
           },
           "volgnummer": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "relation": "bag:verblijfsobjecten",
@@ -92,7 +92,7 @@
             "type": "string"
           },
           "volgnummer": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "relation": "bag:ligplaatsen",
@@ -105,7 +105,7 @@
             "type": "string"
           },
           "volgnummer": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "relation": "bag:standplaatsen",
@@ -118,7 +118,7 @@
             "type": "string"
           },
           "volgnummer": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "relation": "bag:panden",


### PR DESCRIPTION
The field `volgnummer` in 1-N relation in wozdeelobjecten
is having the wrong type (string instead of integer).
This leads to loose relations in the models, causing failing imports.