### PR TITLE
[AB#30003] Camelcase field names that contain spaces

### DIFF
--- a/datasets/asbestdaken/dataset.json
+++ b/datasets/asbestdaken/dataset.json
@@ -5,6 +5,13 @@
   "status": "niet_beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
+  "authorizationGrantor": "n.v.t.",
+  "owner": "Gemeente Amsterdam",
+  "publisher": "datapunt@amsterdam.nl",
+  "contactPoint": {
+    "name": "",
+    "email": "datapunt@amsterdam.nl"
+  },
   "tables": [
     {
       "id": "daken",
@@ -51,7 +58,7 @@
             "type": "string",
             "description": "Bestemming"
           },
-          "asbest verdacht": {
+          "asbestVerdacht": {
             "type": "boolean",
             "description": "Asbest Verdacht"
           },

--- a/datasets/blackspots/dataset.json
+++ b/datasets/blackspots/dataset.json
@@ -7,6 +7,13 @@
   "auth": "FP/MDW",
   "version": "0.0.2",
   "crs": "EPSG:4326",
+  "owner": "Gemeente Amsterdam",
+  "publisher": "datapunt@amsterdam.nl",
+  "authorizationGrantor": "n.v.t.",
+  "contactPoint": {
+    "name": "",
+    "email": "datapunt@amsterdam.nl"
+  },
   "tables": [
     {
       "id": "blackspots",
@@ -66,7 +73,7 @@
             "type": "string",
             "format": "date"
           },
-          "eind uitvoering": {
+          "eindUitvoering": {
             "type": "string",
             "format": "date"
           },

--- a/datasets/fietspaaltjes/dataset.json
+++ b/datasets/fietspaaltjes/dataset.json
@@ -5,6 +5,13 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
+  "authorizationGrantor": "n.v.t.",
+  "owner": "Gemeente Amsterdam",
+  "publisher": "datapunt@amsterdam.nl",
+  "contactPoint": {
+    "name": "",
+    "email": "datapunt@amsterdam.nl"
+  },
   "tables": [
     {
       "id": "fietspaaltjes",
@@ -38,10 +45,10 @@
           "area": {
             "type": "string"
           },
-          "score 2013": {
+          "score2013": {
             "type": "string"
           },
-          "score current": {
+          "scoreCurrent": {
             "type": "string"
           },
           "count": {


### PR DESCRIPTION
Found by

    git grep '".* .*":' datasets/

which now reports no results.

The camelcase names produce the same row/field names as the old ones:

    >>> toCamelCase("asbest verdacht") == toCamelCase("asbestVerdacht")
    True
    >>> to_snake_case("asbest verdacht") == to_snake_case("asbestVerdacht")
    True

    >>> toCamelCase("score 2013") == toCamelCase("score2013")
    True
    >>> to_snake_case("score 2013") == to_snake_case("score2013")
    True

and similarly for "eind uitvoering" and "score current".