### PR TITLE
[NEW] wegenbestand dataset

### DIFF
--- a/datasets/wegenbestand/dataset.json
+++ b/datasets/wegenbestand/dataset.json
@@ -1,0 +1,54 @@
+{
+  "id": "wegenbestand",
+  "type": "dataset",
+  "authorizationGrantor": "n.v.t.",
+  "theme": [
+    "verkeer"
+  ],
+  "homepage": "https://data.amsterdam.nl",
+  "owner": "Gemeente Amsterdam, bereikbaarheidsthermometer Amsterdam",
+  "dateModified": "2022-02-09T00:00:00+01:00",
+  "spatialDescription": "Gemeente Amsterdam",
+  "version": "1.0.0",
+  "default_version": "1.0.0",
+  "title": "Wegenbestand gemeente Amsterdam",
+  "language": "nl",
+  "dateCreated": "2022-02-09T00:00:00+01:00",
+  "license": "Creative Commons, Naamsvermelding",
+  "hasBeginning": "2022-02-09T00:00:00+01:00",
+  "accrualPeriodicity": "dagelijks",
+  "publisher": "datapunt@amsterdam.nl",
+  "contactPoint": {
+    "name": "bereikbaarheidsthermometer Amsterdam",
+    "email": "bereikbaarheidsthermometer@amsterdam.nl"
+  },
+  "description": "Aangewezen wegen voor vrachtverkeer met gevaarlijkestoffen of valt onder de categorie zwaar verkeer.",
+  "status": "beschikbaar",
+  "keywords": [
+    "bereikbaarheid",
+    "routes",
+    "gevaarlijkestoffen",
+    "tunnels",
+    "vrachtroutes",
+    "zwaarverkeer",
+    "verkeerzones"
+  ],
+  "crs": "EPSG:28992",
+  "objective": "Publiceren van de hoofdroutes voor vrachtverkeer met gevaarlijkestoffen of valt onder de categorie zwaar verkeer voor de doelgroep.",
+  "tables": [
+    {
+      "id": "routesGevaarlijkeStoffen",
+      "$ref": "routesGevaarlijkeStoffen/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "routesGevaarlijkeStoffen/v1.0.0"
+      }
+    },
+    {
+      "id": "tunnelsGevaarlijkeStoffen",
+      "$ref": "tunnelsGevaarlijkeStoffen/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "tunnelsGevaarlijkeStoffen/v1.0.0"
+      }
+    }
+  ]
+}

--- a/datasets/wegenbestand/routesGevaarlijkeStoffen/v1.0.0.json
+++ b/datasets/wegenbestand/routesGevaarlijkeStoffen/v1.0.0.json
@@ -1,0 +1,32 @@
+{
+  "id": "routesGevaarlijkeStoffen",
+  "version": "1.0.0",
+  "type": "table",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "schema"
+    ],
+    "display": "title",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json"
+      },
+      "id": {
+        "type": "integer"
+      },
+      "title": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/datasets/wegenbestand/tunnelsGevaarlijkeStoffen/v1.0.0.json
+++ b/datasets/wegenbestand/tunnelsGevaarlijkeStoffen/v1.0.0.json
@@ -1,0 +1,35 @@
+{
+  "id": "tunnelsGevaarlijkeStoffen",
+  "version": "1.0.0",
+  "type": "table",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "schema"
+    ],
+    "display": "title",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/Point.json"
+      },
+      "id": {
+        "type": "integer"
+      },
+      "title": {
+        "type": "string"
+      },
+      "categorie": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/datasets/wegenbestand/zoneZwaarVerkeer/binnen/v1.0.0.json
+++ b/datasets/wegenbestand/zoneZwaarVerkeer/binnen/v1.0.0.json
@@ -1,0 +1,132 @@
+{
+  "id": "binnen",
+  "version": "1.0.0",
+  "type": "table",
+  "title": "Wegen waarvoor voertuigen langer dan 10 meter met deelbare lading een ontheffing aanvragen",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "schema"
+    ],
+    "display": "name",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json"
+      },
+      "id": {
+        "type": "integer",
+        "description": "unieke identificatie van het record."
+      },
+      "linknummer": {
+        "type": "integer",
+        "provenance": "linknr",
+        "description": "unieke identificatie voor elke opgedeelde wegennetwerk object."
+      },
+      "straatnaam": {
+        "type": "string",
+        "provenance": "name",
+        "description": "straatnaam die van toepassing is op wegennetwerk object."
+      },
+      "target": {
+        "type": "integer",
+        "description": "nummer van target node van edge."
+      },
+      "source": {
+        "type": "integer",
+        "description": "nummer van source node van edge."
+      },
+      "lengte": {
+        "type": "number",
+        "description": "lengte van de link in meters."
+      },
+      "tijdskostenBeginEind": {
+        "type": "number",
+        "provenance": "cost",
+        "description": "tijdskosten om van begin naar eind van link te gaan in seconden."
+      },
+      "tijdskostenEindBegin": {
+        "type": "number",
+        "provenance": "reverseCost",
+        "description": "tijdskosten om van eind naar begin van link te gaan in seconden."
+      },
+      "indicatieZoneAmsterdam": {
+        "type": "boolean",
+        "provenance": "zoneAmsterdam",
+        "description": "indicator of link valt binnen of grotendeels binnen de gemeente Amsterdam."
+      },
+      "indicatieZoneMilieu": {
+        "type": "boolean",
+        "provenance": "zoneMilieu",
+        "description": "indicator Verkeersbesluit milieuzone Amsterdam (Staatscourant 2020, 32736)."
+      },
+      "indicatiezoneZwaarVerkeer": {
+        "type": "string",
+        "provenance": "zoneZzv",
+        "description": "indicator Verkeersbesluit Zone Zwaar Verkeer Amsterdam (Staatscourant 2021, 24726)."
+      },
+      "wegFunctie": {
+        "type": "integer",
+        "provenance": "frc",
+        "description": "functional road class; geeft de functie van weg."
+      },
+      "beleidskaderAuto": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "beleidskaderOv": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "beleidskaderFiets": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "wettelijkeSnelheid": {
+        "type": "integer",
+        "description": "wettelijke Snelheid die toegestaan is op weg. Bij verschillende waarde voor de 2 rijrichtingen gaat het om maximum."
+      },
+      "tunnelCategorie": {
+        "type": "string",
+        "description": "een Europese categorisering voor tunnels met betrekking op het vervoer van gevaarlijke stoffen."
+      },
+      "tunnelNaam": {
+        "type": "string",
+        "description": "naam van de tunnel."
+      },
+      "percLijnInPolygoonWeg": {
+        "type": "number",
+        "description": "welke % van 'lijn lengte' binnen BGT polygonen liggen met een van de volgende functies: ('rijbaan regionale weg','rijbaan autoweg','OV-baan','rijbaan autosnelweg','woonerf','rijbaan lokale weg')."
+      },
+      "laadLosRegime": {
+        "type": "string",
+        "description": "het type laden-en-lossen regime."
+      },
+      "laadLosVenstertijden": {
+        "type": "string",
+        "description": "toegestane tijdsperioden voor laden-en-lossen."
+      },
+      "wegbeheerder": {
+        "type": "string",
+        "description": "wegbeheerder die hoort bij de weg."
+      },
+      "rijrichting": {
+        "type": "integer",
+        "description": "toegestane auto rijrichtingen van de weg."
+      },
+      "gevaarlijkeStoffenRoute": {
+        "type": "boolean",
+        "description": "indicator voor een route voor transport van routeplichtige gevaarlijke stoffen."
+      },
+      "laadLosVerbodStilTeStaanTijden": {
+        "type": "string",
+        "description": "dagen en tijden voor verbod laden-en-lossen en stilstaan."
+      }
+    }
+  }
+}

--- a/datasets/wegenbestand/zoneZwaarVerkeer/breedOpgezetteWegen/v1.0.0.json
+++ b/datasets/wegenbestand/zoneZwaarVerkeer/breedOpgezetteWegen/v1.0.0.json
@@ -1,0 +1,132 @@
+{
+  "id": "breedOpgezetteWegen",
+  "version": "1.0.0",
+  "type": "table",
+  "title": "Wegen waarvoor voertuigen langer dan 10 meter met deelbare lading een ontheffing aanvragen",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "schema"
+    ],
+    "display": "name",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json"
+      },
+      "id": {
+        "type": "integer",
+        "description": "unieke identificatie van het record."
+      },
+      "linknummer": {
+        "type": "integer",
+        "provenance": "linknr",
+        "description": "unieke identificatie voor elke opgedeelde wegennetwerk object."
+      },
+      "straatnaam": {
+        "type": "string",
+        "provenance": "name",
+        "description": "straatnaam die van toepassing is op wegennetwerk object."
+      },
+      "target": {
+        "type": "integer",
+        "description": "nummer van target node van edge."
+      },
+      "source": {
+        "type": "integer",
+        "description": "nummer van source node van edge."
+      },
+      "lengte": {
+        "type": "number",
+        "description": "lengte van de link in meters."
+      },
+      "tijdskostenBeginEind": {
+        "type": "number",
+        "provenance": "cost",
+        "description": "tijdskosten om van begin naar eind van link te gaan in seconden."
+      },
+      "tijdskostenEindBegin": {
+        "type": "number",
+        "provenance": "reverseCost",
+        "description": "tijdskosten om van eind naar begin van link te gaan in seconden."
+      },
+      "indicatieZoneAmsterdam": {
+        "type": "boolean",
+        "provenance": "zoneAmsterdam",
+        "description": "indicator of link valt binnen of grotendeels binnen de gemeente Amsterdam."
+      },
+      "indicatieZoneMilieu": {
+        "type": "boolean",
+        "provenance": "zoneMilieu",
+        "description": "indicator Verkeersbesluit milieuzone Amsterdam (Staatscourant 2020, 32736)."
+      },
+      "indicatiezoneZwaarVerkeer": {
+        "type": "string",
+        "provenance": "zoneZzv",
+        "description": "indicator Verkeersbesluit Zone Zwaar Verkeer Amsterdam (Staatscourant 2021, 24726)."
+      },
+      "wegFunctie": {
+        "type": "integer",
+        "provenance": "frc",
+        "description": "functional road class; geeft de functie van weg."
+      },
+      "beleidskaderAuto": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "beleidskaderOv": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "beleidskaderFiets": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "wettelijkeSnelheid": {
+        "type": "integer",
+        "description": "wettelijke Snelheid die toegestaan is op weg. Bij verschillende waarde voor de 2 rijrichtingen gaat het om maximum."
+      },
+      "tunnelCategorie": {
+        "type": "string",
+        "description": "een Europese categorisering voor tunnels met betrekking op het vervoer van gevaarlijke stoffen."
+      },
+      "tunnelNaam": {
+        "type": "string",
+        "description": "naam van de tunnel."
+      },
+      "percLijnInPolygoonWeg": {
+        "type": "number",
+        "description": "welke % van 'lijn lengte' binnen BGT polygonen liggen met een van de volgende functies: ('rijbaan regionale weg','rijbaan autoweg','OV-baan','rijbaan autosnelweg','woonerf','rijbaan lokale weg')."
+      },
+      "laadLosRegime": {
+        "type": "string",
+        "description": "het type laden-en-lossen regime."
+      },
+      "laadLosVenstertijden": {
+        "type": "string",
+        "description": "toegestane tijdsperioden voor laden-en-lossen."
+      },
+      "wegbeheerder": {
+        "type": "string",
+        "description": "wegbeheerder die hoort bij de weg."
+      },
+      "rijrichting": {
+        "type": "integer",
+        "description": "toegestane auto rijrichtingen van de weg."
+      },
+      "gevaarlijkeStoffenRoute": {
+        "type": "boolean",
+        "description": "indicator voor een route voor transport van routeplichtige gevaarlijke stoffen."
+      },
+      "laadLosVerbodStilTeStaanTijden": {
+        "type": "string",
+        "description": "dagen en tijden voor verbod laden-en-lossen en stilstaan."
+      }
+    }
+  }
+}

--- a/datasets/wegenbestand/zoneZwaarVerkeer/buiten/v1.0.0.json
+++ b/datasets/wegenbestand/zoneZwaarVerkeer/buiten/v1.0.0.json
@@ -1,0 +1,132 @@
+{
+  "id": "buiten",
+  "version": "1.0.0",
+  "type": "table",
+  "title": "Wegen waarvoor voertuigen langer dan 10 meter met deelbare lading een ontheffing aanvragen",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "id",
+      "schema"
+    ],
+    "display": "name",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json"
+      },
+      "id": {
+        "type": "integer",
+        "description": "unieke identificatie van het record."
+      },
+      "linknummer": {
+        "type": "integer",
+        "provenance": "linknr",
+        "description": "unieke identificatie voor elke opgedeelde wegennetwerk object."
+      },
+      "straatnaam": {
+        "type": "string",
+        "provenance": "name",
+        "description": "straatnaam die van toepassing is op wegennetwerk object."
+      },
+      "target": {
+        "type": "integer",
+        "description": "nummer van target node van edge."
+      },
+      "source": {
+        "type": "integer",
+        "description": "nummer van source node van edge."
+      },
+      "lengte": {
+        "type": "number",
+        "description": "lengte van de link in meters."
+      },
+      "tijdskostenBeginEind": {
+        "type": "number",
+        "provenance": "cost",
+        "description": "tijdskosten om van begin naar eind van link te gaan in seconden."
+      },
+      "tijdskostenEindBegin": {
+        "type": "number",
+        "provenance": "reverseCost",
+        "description": "tijdskosten om van eind naar begin van link te gaan in seconden."
+      },
+      "indicatieZoneAmsterdam": {
+        "type": "boolean",
+        "provenance": "zoneAmsterdam",
+        "description": "indicator of link valt binnen of grotendeels binnen de gemeente Amsterdam."
+      },
+      "indicatieZoneMilieu": {
+        "type": "boolean",
+        "provenance": "zoneMilieu",
+        "description": "indicator Verkeersbesluit milieuzone Amsterdam (Staatscourant 2020, 32736)."
+      },
+      "indicatiezoneZwaarVerkeer": {
+        "type": "string",
+        "provenance": "zoneZzv",
+        "description": "indicator Verkeersbesluit Zone Zwaar Verkeer Amsterdam (Staatscourant 2021, 24726)."
+      },
+      "wegFunctie": {
+        "type": "integer",
+        "provenance": "frc",
+        "description": "functional road class; geeft de functie van weg."
+      },
+      "beleidskaderAuto": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "beleidskaderOv": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "beleidskaderFiets": {
+        "type": "string",
+        "description": "beleidsfunctie van weg conform Beleidskader Verkeersnetten Gemeente Amsterdam, 24 januari 2018."
+      },
+      "wettelijkeSnelheid": {
+        "type": "integer",
+        "description": "wettelijke Snelheid die toegestaan is op weg. Bij verschillende waarde voor de 2 rijrichtingen gaat het om maximum."
+      },
+      "tunnelCategorie": {
+        "type": "string",
+        "description": "een Europese categorisering voor tunnels met betrekking op het vervoer van gevaarlijke stoffen."
+      },
+      "tunnelNaam": {
+        "type": "string",
+        "description": "naam van de tunnel."
+      },
+      "percLijnInPolygoonWeg": {
+        "type": "number",
+        "description": "welke % van 'lijn lengte' binnen BGT polygonen liggen met een van de volgende functies: ('rijbaan regionale weg','rijbaan autoweg','OV-baan','rijbaan autosnelweg','woonerf','rijbaan lokale weg')."
+      },
+      "laadLosRegime": {
+        "type": "string",
+        "description": "het type laden-en-lossen regime."
+      },
+      "laadLosVenstertijden": {
+        "type": "string",
+        "description": "toegestane tijdsperioden voor laden-en-lossen."
+      },
+      "wegbeheerder": {
+        "type": "string",
+        "description": "wegbeheerder die hoort bij de weg."
+      },
+      "rijrichting": {
+        "type": "integer",
+        "description": "toegestane auto rijrichtingen van de weg."
+      },
+      "gevaarlijkeStoffenRoute": {
+        "type": "boolean",
+        "description": "indicator voor een route voor transport van routeplichtige gevaarlijke stoffen."
+      },
+      "laadLosVerbodStilTeStaanTijden": {
+        "type": "string",
+        "description": "dagen en tijden voor verbod laden-en-lossen en stilstaan."
+      }
+    }
+  }
+}

--- a/datasets/wegenbestand/zoneZwaarVerkeer/dataset.json
+++ b/datasets/wegenbestand/zoneZwaarVerkeer/dataset.json
@@ -1,0 +1,62 @@
+{
+  "id": "wegenbestandZoneZwaarVerkeer",
+  "type": "dataset",
+  "authorizationGrantor": "n.v.t.",
+  "theme": [
+    "Verkeer"
+  ],
+  "homepage": "https://data.amsterdam.nl",
+  "owner": "Gemeente Amsterdam, bereikbaarheidsthermometer Amsterdam",
+  "dateModified": "2022-02-09T00:00:00+01:00",
+  "spatialDescription": "Gemeente Amsterdam",
+  "version": "1.0.0",
+  "default_version": "1.0.0",
+  "title": "Wegenbestand gemeente Amsterdam",
+  "language": "nl",
+  "dateCreated": "2022-02-09T00:00:00+01:00",
+  "license": "Creative Commons, Naamsvermelding",
+  "hasBeginning": "2022-02-09T00:00:00+01:00",
+  "hasEnd": "",
+  "accrualPeriodicity": "dagelijks",
+  "publisher": "OIS",
+  "description": "Wegen die al dan niet vallen onder zwaar verkeer zones waarvoor mogelijk ontheffing moet worden aangevraagd.",
+  "status": "beschikbaar",
+  "keywords": [
+    "bereikbaarheid",
+    "routes",
+    "gevaarlijkestoffen",
+    "tunnels",
+    "vrachtroutes",
+    "zwaarverkeer",
+    "verkeerzones"
+  ],
+  "crs": "EPSG:28992",
+  "objective": "Publiceren van zwaar verkeer zones voor de doelgroep.",
+  "contactPoint": {
+    "name": "",
+    "email": "bereikbaarheidsthermometer@amsterdam.nl"
+  },
+  "tables": [
+    {
+      "id": "binnen",
+      "$ref": "binnen/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "binnen/v1.0.0"
+      }
+    },
+    {
+      "id": "buiten",
+      "$ref": "buiten/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "buiten/v1.0.0"
+      }
+    },
+    {
+      "id": "breedOpgezetteWegen",
+      "$ref": "breedOpgezetteWegen/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "breedOpgezetteWegen/v1.0.0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The wegenbestand contains data about so called zones zwaar verkeer en consists of roads within that zone, outside that zone and roads that needs a special waiver to be used. These three tables all fall within the main category wegenbestand and subcategory zones zwaar verkeer.

The existing datasets hoofdroutes, like routes and tunnels gevaarlijke stoffen are also placed on the wegenbestand but not under zones zwaar verkeer. They reside on the main level in that perspective.

So the structure is as follows:

v1/wegenbestand/zoneZwaarVerkeer/binnen
v1/wegenbestand/zoneZwaarVerkeer/buiten
v1/wegenbestand/zoneZwaarVerkeer/breed_opgezette_wegen
v1/wegenbestand/tunnels_gevaarlijke_stoffen
v1/wegenbestand/routes_gevaarlijke_stoffen

I explicitly looked at beheerkaart where a 3 level deep structure is also applied. The difference with this one, is there is an intermediary level where some tables fall directly under the wegenbestand (2 level deep instead of 3).

Locally it runs, also with the DSO-API. However the index.json that schemas.data.amsterdam.nl will  use must be like this:

```
"wegenbestandZoneZwaarVerkeer": "wegenbestand/zoneZwaarVerkeer",
"wegenbestand": "wegenbestand",
````

Don't know if that we be constructed properly. 