### PR TITLE
Fix invalid format in `gebieden.buuten.beginGeldigheid`

### DIFF
--- a/datasets/gebieden/buurten/v1.1.2.json
+++ b/datasets/gebieden/buurten/v1.1.2.json
@@ -54,12 +54,12 @@
       },
       "beginGeldigheid": {
         "type": "string",
-        "format": "datetime",
+        "format": "date-time",
         "description": "De datum waarop het object is gecre\u00eberd."
       },
       "eindGeldigheid": {
         "type": "string",
-        "format": "datetime",
+        "format": "date-time",
         "description": "De datum waarop het object is komen te vervallen."
       },
       "documentdatum": {


### PR DESCRIPTION
Using `datetime` instead of `date-time` crashes the DSO API
with a KeyError and is not validated it seems.