### PR TITLE
Fix name patterns; introduces schema 1.2.0

### DIFF
--- a/datasets/covid19/alcoholverkoopverbod/v1.0.0.json
+++ b/datasets/covid19/alcoholverkoopverbod/v1.0.0.json
@@ -14,7 +14,7 @@
     "display": "naam",
     "properties": {
       "schema": {
-        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
       },
       "id": {
         "type": "integer",

--- a/datasets/covid19/gebiedsverbod/v1.0.0.json
+++ b/datasets/covid19/gebiedsverbod/v1.0.0.json
@@ -14,7 +14,7 @@
     "display": "naam",
     "properties": {
       "schema": {
-        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
       },
       "id": {
         "type": "integer",

--- a/datasets/covid19/mondmaskerverplichting/v1.0.0.json
+++ b/datasets/covid19/mondmaskerverplichting/v1.0.0.json
@@ -14,7 +14,7 @@
     "display": "naam",
     "properties": {
       "schema": {
-        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
       },
       "id": {
         "type": "integer",

--- a/datasets/covid19/straatartiestverbod/v1.0.0.json
+++ b/datasets/covid19/straatartiestverbod/v1.0.0.json
@@ -14,7 +14,7 @@
     "display": "naam",
     "properties": {
       "schema": {
-        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
       },
       "id": {
         "type": "integer",

--- a/docs/ams-schema-spec.bs
+++ b/docs/ams-schema-spec.bs
@@ -327,7 +327,7 @@ Een [=schema=] object moet in ieder geval de volgende attributen bezitten:
             Voor afnemers die een samenvattende titel van een object willen tonen. Default: gelijk aan {{schema/identifier}}.
     <tr><td><dfn>properties</dfn>   <td> object
         <td> Collectie van [=veld|velden=] die rijen in de tabel mogen bezitten. Bevat daarnaast een 'schema.$ref' attribuut.
-            Veldnamen moeten beginnen met een kleine letter gevolgd door een alphanummerieke reeks en moeten voldoen aan [[#naamgeving]].
+            Veldnamen moeten beginnen met een kleine letter gevolgd door een alfanumerieke reeks en moeten voldoen aan [[#naamgeving]].
     <tr><td><dfn>properties.schema</dfn>   <td> [[JSON-SCHEMA#ref|§ref]]  <td> [CONST] `{"$ref":"https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"}`
 </table>
 
@@ -1517,7 +1517,7 @@ Attribuuttypen {#attr-types}
 <table class="dfn-table">
     <tr><td><dfn typedef export lt=id|id-type>identifier</dfn>
         <td> string
-        <td> Een unieke identifier in de vorm van één of meer letters, startend met een kleine letter en eventueel gevolgd door een cijferreeks voorafgegaan door een underscore '_'.
+        <td> Een unieke identifier in de vorm van één of meer letters, startend met een kleine letter en eventueel gevolgd door een cijferreeks.
     <tr><td><dfn typedef export>date-time</dfn>
         <td> (string)
         <td> Een als datetime geformatteerde string. Conform [[json-schema-validation#rfc.section.7.3.1]].

--- a/docs/ams-schema-spec.html
+++ b/docs/ams-schema-spec.html
@@ -1487,10 +1487,10 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 2e3c4c68b, updated Fri Jan 14 14:49:00 2022 -0800" name="generator">
+  <meta content="Bikeshed version d7036035b, updated Fri Oct 8 17:07:11 2021 -0700" name="generator">
   <link href="https://schemas.data.amsterdam.nl/docs/ams-schema-spec.html" rel="canonical">
   <link href="https://data.amsterdam.nl/favicon.png" rel="icon">
-  <meta content="f3f69ad030b99cc43db36d6f8fcbbc763b627219" name="document-revision">
+  <meta content="cc5ac313a724f965a9b44cac71bf466d14122858" name="document-revision">
 <style>
     p[data-fill-with="logo"] {
         width: 180px;
@@ -2234,7 +2234,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Amsterdam Schema Specificatie</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2022-03-01">1 March 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2022-03-02">2 March 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2610,7 +2610,7 @@ Actieve versies zijn alle versies die actief worden onderhouden en ondersteund.<
 in een eigen map moeten staan waarvan de naam gelijk is aan de tabel id.
 De bestandsnaam van een tabel definite bestand <strong>zou</strong> gelijk moeten zijn aan het versienummer van de tabel voorafgegaan door 'v' met een '.json' extensie.
 Het pad gezien vanuit de locatie van het dataset bestand <strong>zou</strong> dus de volgende vorm moeten hebben:</p>
-<pre class="language-bash highlight">&lt;tabelid>/v&lt;major>.&lt;minor>.&lt;patch>.json
+<pre class="language-bash highlight">    &lt;tabelid>/v&lt;major>.&lt;minor>.&lt;patch>.json
 </pre>
    <p><strong class="advisement"> Van deze bestandsnaam en padstructuur moet niet worden afgeweken behalve als daar een zwaarwegende reden voor is.</strong></p>
    <div class="example hide-lines" id="example-7a31c51e" onclick="this.classList.toggle(&apos;hide-lines&apos;);this.classList.toggle(&apos;unhide-lines&apos;);">
@@ -2729,7 +2729,7 @@ Daarnaast kan aan een tabel meta informatie en autorisatie instellingen worden m
       <td><dfn class="idl-code" data-dfn-for="schema" data-dfn-type="attribute" data-export id="dom-schema-properties"><code class="highlight">properties</code><a class="self-link" href="#dom-schema-properties"></a></dfn>
       <td> object
       <td> Collectie van <a data-link-type="dfn" href="#veld" id="ref-for-veld②">velden</a> die rijen in de tabel mogen bezitten. Bevat daarnaast een 'schema.$ref' attribuut.
-            Veldnamen moeten beginnen met een kleine letter gevolgd door een alphanummerieke reeks en moeten voldoen aan <a href="#naamgeving">§ 5 Naamgeving</a>.
+            Veldnamen moeten beginnen met een kleine letter gevolgd door een alfanumerieke reeks en moeten voldoen aan <a href="#naamgeving">§ 5 Naamgeving</a>.
      <tr>
       <td><dfn class="idl-code" data-dfn-for="schema" data-dfn-type="attribute" data-export id="dom-schema-propertiesschema"><code class="highlight">properties<c- p>.</c->schema</code><a class="self-link" href="#dom-schema-propertiesschema"></a></dfn>
       <td> <a href="https://json-schema.org/draft/2020-12/json-schema-core.html#ref">§ref</a>
@@ -2785,12 +2785,12 @@ Een object in de tabel is geldig binnen het gesloten interval ["beginGeldigheid"
    <p>Als een tabel niet temporeel is kan het <a data-link-type="dfn" href="#temporal-object" id="ref-for-temporal-object②">temporal object</a> worden weggelaten.</p>
    <div class="example" id="example-f91888dd">
     <a class="self-link" href="#example-f91888dd"></a> Voorbeeld van een temporal object.
-<pre class="language-json highlight"><c- f>"temporal"</c-><c- p>:</c-> <c- p>{</c->
-    <c- f>"identifier"</c-><c- p>:</c-> <c- u>"volgnummer"</c-><c- p>,</c->
-    <c- f>"dimensions"</c-><c- p>:</c-> <c- p>{</c->
-        <c- f>"geldigOp"</c-><c- p>:</c-> <c- p>[</c-><c- u>"beginGeldigheid"</c-><c- p>,</c-> <c- u>"eindGeldigheid"</c-><c- p>]</c->
-    <c- p>}</c->
-<c- p>}</c->
+<pre class="language-json highlight">        <c- f>"temporal"</c-><c- p>:</c-> <c- p>{</c->
+            <c- f>"identifier"</c-><c- p>:</c-> <c- u>"volgnummer"</c-><c- p>,</c->
+            <c- f>"dimensions"</c-><c- p>:</c-> <c- p>{</c->
+                <c- f>"geldigOp"</c-><c- p>:</c-> <c- p>[</c-><c- u>"beginGeldigheid"</c-><c- p>,</c-> <c- u>"eindGeldigheid"</c-><c- p>]</c->
+            <c- p>}</c->
+        <c- p>}</c->
 </pre>
    </div>
    <h3 class="heading settled" data-level="3.5" id="versioning"><span class="secno">3.5. </span><span class="content">Versionering</span><a class="self-link" href="#versioning"></a></h3>
@@ -3732,7 +3732,7 @@ Scope <code class="highlight"><c- u>"LEVEL/A"</c-></code> heeft dataset level au
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export data-lt="id|id-type" id="typedefdef-id"><code class="highlight">identifier</code></dfn>
       <td> string
-      <td> Een unieke identifier in de vorm van één of meer letters, startend met een kleine letter en eventueel gevolgd door een cijferreeks voorafgegaan door een underscore '_'.
+      <td> Een unieke identifier in de vorm van één of meer letters, startend met een kleine letter en eventueel gevolgd door een cijferreeks.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-date-time"><code class="highlight">date<c- o>-</c->time</code></dfn>
       <td> (string)

--- a/schema
+++ b/schema
@@ -1,1 +1,1 @@
-schema@v1.1.1
+schema@v1.2.0

--- a/schema@v1.2.0/dataset.json
+++ b/schema@v1.2.0/dataset.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/dataset@v1.2.0",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "./schema@v1.2.0#/definitions/basicProperties"
+    }
+  ],
+  "required": [
+    "tables",
+    "status",
+    "contactPoint",
+    "authorizationGrantor",
+    "owner",
+    "publisher"
+  ],
+  "properties": {
+    "schema": {
+      "const": "dataset"
+    },
+    "version": {
+      "$ref": "./schema@v1.2.0#/definitions/version"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "beschikbaar",
+        "niet_beschikbaar"
+      ]
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "language": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 3
+    },
+    "accrualPeriodicity": {
+      "type": "string"
+    },
+    "spatialDescription": {
+      "type": "string"
+    },
+    "spatialCoordinates": {
+      "$ref": "https://geojson.org/schema/Geometry.json"
+    },
+    "theme": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "publisher": {
+      "type": "string",
+      "const": "datapunt@amsterdam.nl"
+    },
+    "owner": {
+      "type": "string",
+      "default": "Gemeente Amsterdam"
+    },
+    "authorizationGrantor": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hasBeginning": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "hasEnd": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "objective": {
+      "type": "string"
+    },
+    "temporalUnit": {
+      "type": "string"
+    },
+    "spatial": {
+      "type": "string"
+    },
+    "legalBasis": {
+      "type": "string"
+    },
+    "contactPoint": {
+      "description": "Person and (optional) e-mail.",
+      "$ref": "./schema@v1.2.0#/definitions/contactPoint"
+    },
+    "crs": {
+      "description": "Coordinate reference system",
+      "type": "string",
+      "enum": [
+        "EPSG:28992",
+        "EPSG:4326"
+      ]
+    },
+    "tables": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "./table@v1.2.0"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "$ref": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schema@v1.2.0/meta/auth.json
+++ b/schema@v1.2.0/meta/auth.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/auth@v1.2.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/auth@v1.2.0": true
+  },
+  "$recursiveAnchor": true,
+  "title": "Amsterdam Schema authorization",
+  "properties": {
+    "ams.auth": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/schema@v1.2.0/meta/provenance.json
+++ b/schema@v1.2.0/meta/provenance.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/provenance@v1.2.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/provenance@v1.2.0": true
+  },
+  "$recursiveAnchor": true,
+  "title": "Amsterdam Schema provenance",
+  "properties": {
+    "provenance": {
+      "$comment": "This field can hold provenance data, per dataset, table or field.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    }
+  }
+}

--- a/schema@v1.2.0/meta/relation.json
+++ b/schema@v1.2.0/meta/relation.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/relation@v1.2.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/relation@v1.2.0": true
+  },
+  "$recursiveAnchor": true,
+  "properties": {
+    "relation": {
+      "type": "string",
+      "format": "uri-reference"
+    }
+  }
+}

--- a/schema@v1.2.0/meta/unit.json
+++ b/schema@v1.2.0/meta/unit.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/unit@v1.2.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/unit@v1.2.0": true
+  },
+  "$recursiveAnchor": true,
+  "title": "Amsterdam Schema unit",
+  "properties": {
+    "unit": {
+      "type": "string",
+      "$comment": "UCUM strings, see https://ucum.nlm.nih.gov/"
+    }
+  }
+}

--- a/schema@v1.2.0/row-meta-schema.json
+++ b/schema@v1.2.0/row-meta-schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/row-meta-schema@v1.2.0",
+  "definitions": {
+    "rootProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/auth"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "shortname": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/rootProperty"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "integer"
+        },
+        "multipleOf": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "contentEncoding": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[a-z][A-Za-z0-9]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/rootProperty"
+          }
+        },
+        "enum": {
+          "type": "array"
+        },
+        "format": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v1.2.0#properties/provenance"
+        },
+        "relation": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "unit": {
+          "type": [
+            "string",
+            "object"
+          ],
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes"
+            }
+          }
+        },
+        {
+          "required": [
+            "$ref"
+          ],
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "enum": [
+                "https://geojson.org/schema/Geometry.json",
+                "https://geojson.org/schema/MultiPolygon.json",
+                "https://geojson.org/schema/Polygon.json",
+                "https://geojson.org/schema/Point.json",
+                "https://geojson.org/schema/MultiLineString.json",
+                "https://geojson.org/schema/LineString.json",
+                "https://geojson.org/schema/MultiPoint.json"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "$schema",
+    "type",
+    "properties",
+    "required",
+    "display"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "const": "http://json-schema.org/draft-07/schema#"
+    },
+    "$id": {
+      "type": "string"
+    },
+    "additionalProperties": {
+      "const": false
+    },
+    "type": {
+      "const": "object"
+    },
+    "required": {
+      "allOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "contains": {
+            "const": "schema"
+          }
+        }
+      ]
+    },
+    "display": {
+      "type": "string"
+    },
+    "additionalRelations": {
+      "type": "object"
+    },
+    "mainGeometry": {
+      "type": "string"
+    },
+    "identifier": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "properties": {
+      "type": "object",
+      "required": [
+        "schema"
+      ],
+      "propertyNames": {
+        "pattern": "^[a-z][A-Za-z0-9]*$"
+      },
+      "properties": {
+        "schema": {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "$ref": {
+              "const": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/rootProperty"
+      }
+    }
+  }
+}

--- a/schema@v1.2.0/schema.json
+++ b/schema@v1.2.0/schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/schema@v1.2.0#",
+  "title": "Amsterdam Schema",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/core": true,
+    "https://schemas.data.amsterdam.nl/meta/auth@v1.2.0": false,
+    "https://schemas.data.amsterdam.nl/meta/units@v1.2.0": false,
+    "https://schemas.data.amsterdam.nl/meta/relation@v1.2.0": false,
+    "https://schemas.data.amsterdam.nl/meta/provenance@v1.2.0": false
+  },
+  "$recursiveAnchor": true,
+  "definitions": {
+    "basicProperties": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "auth": {
+          "$ref": "#/definitions/auth"
+        },
+        "dateCreated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "dateModified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "license": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v1.2.0#properties/provenance"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        }
+      }
+    },
+    "idString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][A-Za-z]*[0-9]*$"
+    },
+    "id": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/idString"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "dataset",
+        "table"
+      ]
+    },
+    "schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "year": {
+      "type": "integer"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(\\d+\\.)(\\d+\\.)?(\\d+)$"
+    },
+    "contactPoint": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "auth": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "$ref": "./dataset@v1.2.0"
+        },
+        {
+          "$ref": "./table@v1.2.0"
+        },
+        {
+          "$ref": "./row-meta-schema@v1.2.0"
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "dataset"
+          }
+        }
+      },
+      "then": {
+        "$ref": "./dataset@v1.2.0"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "table"
+          }
+        }
+      },
+      "then": {
+        "$ref": "./table@v1.2.0"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "$comment": "JSON Schema metaschemas for row data are JSON Schemas with type = object",
+            "const": "object"
+          }
+        }
+      },
+      "then": {
+        "$ref": "./row-meta-schema@v1.2.0"
+      }
+    }
+  ]
+}

--- a/schema@v1.2.0/table.json
+++ b/schema@v1.2.0/table.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/table@v1.2.0",
+  "type": "object",
+  "temporal": {
+    "type": "object",
+    "required": [
+      "identifier",
+      "dimensions"
+    ],
+    "identifier": "string",
+    "unit": "string",
+    "dimensions": {
+      "type": "object",
+      "geldigOp": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "./schema@v1.2.0#/definitions/basicProperties"
+    }
+  ],
+  "required": [
+    "schema",
+    "version"
+  ],
+  "properties": {
+    "type": {
+      "const": "table"
+    },
+    "shortname": {
+      "type": "string"
+    },
+    "schema": {
+      "oneOf": [
+        {
+          "$ref": "./row-meta-schema@v1.2.0"
+        },
+        {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Property names were changed from

    "^[a-z][ A-Za-z0-9]*$"

to

    "^[a-z][A-Za-z0-9]*$"

Dataset names were changed from

    "^[a-z][A-Za-z]*(?:_[0-9]+)?$"

to

    "^[a-z][A-Za-z]*[0-9]*$"

Both match existing practice.

The only dataset using this new version is currently covid19, which wouldn't validate because its id had to be changed to fix a database issue.

For [AB#38455](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/38455).