### PR TITLE
AB#28259 Add publishing to an Azure storage account

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bandit
+          - bandit<1.7.3  # pinning, because 1.7.3 is imcompatible, flake8-bandit needs to fix this
           - flake8-bugbear
           - flake8-builtins
           - flake8-comprehensions
@@ -23,7 +24,6 @@ repos:
           - flake8-string-format
           - flake8-blind-except
           - flake8-debugger
-          - flake8-colors
           - flake8-raise
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ package_dir =
 packages = find:
 python_requires = >= 3.8
 install_requires =
+    azure-storage-blob==12.9.0
     click == 8.0.1
     environs==9.3.2
     in_place == 0.5.0
@@ -124,4 +125,4 @@ warn_no_return = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unreachable = True
-warn_unused_ignores = True
+warn_unused_ignores = False


### PR DESCRIPTION
The `publish` cli command now has te ability to write
the schema files to an Azure storage account.

An extra flag `--storage-type` has been added to the command
that has two possible values `swift` (default) and `azure`.

For the (current) swift option, the schemas for ACC and PRD are stored
on the same objectstore. For that reason,  there is a `--dp-env`
flag that can point to ACC or PRD.

For the azure option, the ACC and PRD storage accounts
need to be separate. So, on using the cli, this `--dp-env` should be
empty.

The `--container-prefix` is for the swift option combined
with the `--dp-env` to create the container name.

For azure, this `--container-prefix` should be the full name of the
container. So, the name of this option can be a bit misleading,
it should be changed when the migration to Azure is finished.