### PR TITLE
Ab#37522 rename contact info

### DIFF
--- a/datasets/aardgasvrijezones/dataset.json
+++ b/datasets/aardgasvrijezones/dataset.json
@@ -10,13 +10,10 @@
     "Aardgasvrij",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
+  "creator": "bronhouder onbekend",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
   "keywords": [
     "aardgasvrij"
   ],

--- a/datasets/afvalwijzer/dataset.json
+++ b/datasets/afvalwijzer/dataset.json
@@ -14,7 +14,8 @@
   "dateCreated": "2022-01-01T00:00:00+01:00",
   "license": "Creative Commons, Naamsvermelding",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beeldschoon",
   "description": "Overzicht van de ophaalinformatie per fractie en per locatie",
   "status": "beschikbaar",
   "keywords": [
@@ -28,10 +29,6 @@
   "crs": "EPSG:28992",
   "objective": "De bewoner en ondernemer in staat te stellen om zich voor iedere fractie te informeren over de ophaaldata, -locaties en wijzes van aanbieden",
   "temporalUnit": "",
-  "contactPoint": {
-    "name": "Datateam Beeldschoon",
-    "email": ""
-  },
   "tables": [
     {
       "id": "afvalwijzer",

--- a/datasets/anpr/dataset.json
+++ b/datasets/anpr/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "publisher": "Datateam Mobiliteit",
+  "creator": "bronhouder onbekend",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/asbestdaken/dataset.json
+++ b/datasets/asbestdaken/dataset.json
@@ -7,11 +7,8 @@
   "crs": "EPSG:28992",
   "authorizationGrantor": "n.v.t.",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "publisher": "Datateam Stedelijke Ontwikkeling",
+  "creator": "bronhouder onbekend",
   "tables": [
     {
       "id": "daken",

--- a/datasets/bag/dataset.json
+++ b/datasets/bag/dataset.json
@@ -7,11 +7,8 @@
   "crs": "EPSG:28992",
   "identifier": "identificatie",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "publisher": "Datateam Basis- en Kernregistraties",
+  "creator": "bronhouder onbekend",
   "authorizationGrantor": "OIS",
   "tables": [
     {

--- a/datasets/basiskaart/dataset.json
+++ b/datasets/basiskaart/dataset.json
@@ -6,13 +6,10 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "publisher": "Datateam Basis- en Kernregistraties",
+  "creator": "bronhouder onbekend",
   "keywords": [
     "GBT",
     "KBK",

--- a/datasets/bbga/dataset.json
+++ b/datasets/bbga/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:4326",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basisstatistiek",
-    "email": ""
-  },
+  "publisher": "Datateam Basisstatistiek",
+  "creator": "bronhouder onbekend",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/bedrijveninvesteringszones/dataset.json
+++ b/datasets/bedrijveninvesteringszones/dataset.json
@@ -10,13 +10,10 @@
     "Bedrijveninvesteringszones",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "keywords": [
     "bedrijveninvesteringszones"
   ],

--- a/datasets/beheerkaart/basis/dataset.json
+++ b/datasets/beheerkaart/basis/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "publisher": "Datateam Stedelijke Ontwikkeling",
+  "creator": "bronhouder onbekend",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/beheerkaart/cbs_grid/dataset.json
+++ b/datasets/beheerkaart/cbs_grid/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/belastingen/dataset.json
+++ b/datasets/belastingen/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/beschermdestadsdorpsgezichten/dataset.json
+++ b/datasets/beschermdestadsdorpsgezichten/dataset.json
@@ -12,10 +12,8 @@
   "version": "1.0.0",
   "objective": "Het doel van de beschermde status is om de karakteristieke, ruimtelijke kwaliteit van een plek ook in de toekomst te handhaven. Door het beschikbaar stellen van deze gegevens kan gecontroleerd worden of een specifieke locatie binnen een beschermd gebied valt. Dit is bijvoorbeeld van belang bij de toetsing van een vergunningsplicht voor werkzaamheden die het gezicht kunnen aantasten.",
   "temporalUnit": "uren",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "accrualPeriodicity": "wekelijks",
   "spatialDescription": "Gemeente Amsterdam",
   "theme": [
@@ -23,7 +21,6 @@
     "Duurzaamheid en milieu",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam, Stadswerken",
   "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende de beschermde stads- en dorpsgezichten.",
   "keywords": [

--- a/datasets/blackspots/dataset.json
+++ b/datasets/blackspots/dataset.json
@@ -8,12 +8,9 @@
   "version": "0.0.2",
   "crs": "EPSG:4326",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
   "authorizationGrantor": "n.v.t.",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "tables": [
     {
       "id": "blackspots",

--- a/datasets/bodem/dataset.json
+++ b/datasets/bodem/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/bor_inspecties/dataset.json
+++ b/datasets/bor_inspecties/dataset.json
@@ -18,7 +18,6 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2017-01-29T00:00:00+01:00",
   "accrualPeriodicity": "maandelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "description": "Binnen de Gemeente Amsterdam wordt op verschillende niveaus inspecties uitgevoerd door verschillende directies en partijen. Bijvoorbeeld inspecties voor het dagelijkse onderhoud of technische inspecties voor vervangingsplannen.  Soms met een gelijke- methodiek en andere momenten een andere methodiek (CROW, NEN, etc.). Onder de dataset \u201cinspecties\u201d vind je diverse inspectie tabellen",
   "status": "beschikbaar",
   "keywords": [
@@ -31,10 +30,8 @@
   "crs": "EPSG:28992",
   "objective": "Bevat monitoring en inspectie data over de kwaliteit van de openbare ruimte van willekeurige meetlocaties binnen de gemeente Amsterdam (o.a. Weesp). ",
   "temporalUnit": "seconden",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "monitorbeeldkwaliteit",

--- a/datasets/bouwstroompunten/dataset.json
+++ b/datasets/bouwstroompunten/dataset.json
@@ -17,12 +17,9 @@
   "license": "Creative Commons, Naamsvermelding",
   "language": "nl",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
   "authorizationGrantor": "n.v.t.",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "bouwstroompunten",

--- a/datasets/brandkranen/dataset.json
+++ b/datasets/brandkranen/dataset.json
@@ -16,7 +16,6 @@
   "dateCreated": "2021-01-01T00:00:00+01:00",
   "license": "Creative Commons, Naamsvermelding",
   "accrualPeriodicity": "eenmalig",
-  "publisher": "datapunt@amsterdam.nl",
   "description": "De dataset bevat de  brandkranen openbare in de openbare ruimte.",
   "status": "beschikbaar",
   "keywords": [
@@ -26,10 +25,8 @@
   "crs": "EPSG:28992",
   "objective": " ",
   "temporalUnit": "",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "brandkranen",

--- a/datasets/brk/dataset.json
+++ b/datasets/brk/dataset.json
@@ -7,11 +7,8 @@
   "crs": "EPSG:28992",
   "identifier": "identificatie",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "authorizationGrantor": "OIS",
   "tables": [
     {

--- a/datasets/brp/dataset.json
+++ b/datasets/brp/dataset.json
@@ -8,11 +8,9 @@
   "crs": "EPSG:28992",
   "auth": "BRP/R",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
+
   "authorizationGrantor": "OIS",
   "tables": [
     {

--- a/datasets/cmsa/dataset.json
+++ b/datasets/cmsa/dataset.json
@@ -13,13 +13,10 @@
     "IoT",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "keywords": [
     "cmsa",
     "crowd monitoring",

--- a/datasets/corona/dataset.json
+++ b/datasets/corona/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/covid19/dataset.json
+++ b/datasets/covid19/dataset.json
@@ -11,13 +11,10 @@
     "Ruimte en Topografie",
     "Algemene Plaatselijke Verordening"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "keywords": [
     "covid19"
   ],

--- a/datasets/crowdmonitor/dataset.json
+++ b/datasets/crowdmonitor/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:4326",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/deelmobiliteit/dataset.json
+++ b/datasets/deelmobiliteit/dataset.json
@@ -10,13 +10,10 @@
     "deelmobiliteit",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "keywords": [
     "deelmobiliteit"
   ],

--- a/datasets/duurzaamheid/energielabel/dataset.json
+++ b/datasets/duurzaamheid/energielabel/dataset.json
@@ -6,15 +6,12 @@
   "description": "De energielabel per verblijfsobject van de gemeente Amsterdam.",
   "version": "1.0.0",
   "status": "beschikbaar",
-  "contactPoint": {
-    "name": "Datateam Omgevingswet",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Omgevingswet",
   "authorizationGrantor": "Datateam Omgevingswet",
   "theme": [
     "energielabel"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "keywords": [
     "Energielabel"

--- a/datasets/evenementen/dataset.json
+++ b/datasets/evenementen/dataset.json
@@ -10,13 +10,10 @@
     "Evenementen",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "keywords": [
     "evenementen"
   ],

--- a/datasets/explosieven/dataset.json
+++ b/datasets/explosieven/dataset.json
@@ -11,13 +11,11 @@
     "duurzaamheid en milieu",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
+
   "keywords": [
     "bommen",
     "explosies",

--- a/datasets/fietspaaltjes/dataset.json
+++ b/datasets/fietspaaltjes/dataset.json
@@ -7,11 +7,8 @@
   "crs": "EPSG:28992",
   "authorizationGrantor": "n.v.t.",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "fietspaaltjes",

--- a/datasets/financien/dataset.json
+++ b/datasets/financien/dataset.json
@@ -12,7 +12,6 @@
   "owner": "Gemeente Amsterdam",
   "auth": "FP/STURINGSMIDDELEN",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "keywords": [
     "AFS",
     "AMI",
@@ -21,10 +20,8 @@
     "werkorders"
   ],
   "authorizationGrantor": "onbekend",
-  "contactPoint": {
-    "name": "Datateam Financien",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Financien",
   "tables": [
     {
       "id": "grootboek",

--- a/datasets/gebieden/dataset.json
+++ b/datasets/gebieden/dataset.json
@@ -7,11 +7,8 @@
   "identifier": "identificatie",
   "authorizationGrantor": "Basisinformatie",
   "owner": "Gemeente Amsterdam",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
-  "publisher": "datapunt@amsterdam.nl",
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "crs": "EPSG:28992",
   "tables": [
     {

--- a/datasets/geluidszones/dataset.json
+++ b/datasets/geluidszones/dataset.json
@@ -6,13 +6,10 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "keywords": [
     "geluidszones",
     "metro",

--- a/datasets/grex/dataset.json
+++ b/datasets/grex/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:4326",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/haalcentraal/bag/dataset.json
+++ b/datasets/haalcentraal/bag/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/haalcentraal/brk/dataset.json
+++ b/datasets/haalcentraal/brk/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "authorizationGrantor": "OIS",
   "tables": [
     {

--- a/datasets/handelsregister/dataset.json
+++ b/datasets/handelsregister/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "authorizationGrantor": "OIS",
   "tables": [
     {

--- a/datasets/hoofdroutes/dataset.json
+++ b/datasets/hoofdroutes/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/horeca/dataset.json
+++ b/datasets/horeca/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/huishoudelijkafval/dataset.json
+++ b/datasets/huishoudelijkafval/dataset.json
@@ -19,7 +19,6 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2016-01-01T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "description": "Alle locaties van de actieve onder- en bovengronds afvalcontainers en betonputten van de Gemeente Amsterdam. De locaties worden dagelijks bijgewerkt en bevatten de fracties Rest, Papier, Glas, Textiel en Plastic. Naast de objectinformatie zijn ook de weeggegevens beschikbaar.",
   "status": "niet_beschikbaar",
   "keywords": [
@@ -35,10 +34,8 @@
   "crs": "EPSG:28992",
   "objective": "Het doel van deze dataset is het beschikbaar stellen van gegevens voor het ondersteunen van plaatsingsbeleid betreffende ondergrondse afvalcontainers en het ondersteunen van routeoptimalisatie voor afvalinzameling.",
   "temporalUnit": "uren",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "container",

--- a/datasets/indicatoren/dataset.json
+++ b/datasets/indicatoren/dataset.json
@@ -16,7 +16,6 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2018-01-01T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "authorizationGrantor": "n.v.t.",
   "description": "Met deze dataset worden de indicatoren gemeten voor het schoon, heel en veilig houden van de Openbare Ruimte.",
   "status": "beschikbaar",
@@ -36,10 +35,9 @@
   "crs": "EPSG:28992",
   "objective": "Het doel van deze dataset is het monitoren van vastgestelde indicatoren.",
   "temporalUnit": "dagen",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
+
   "tables": [
     {
       "id": "buurt",

--- a/datasets/kwaliteitsmonitorwonen/dataset.json
+++ b/datasets/kwaliteitsmonitorwonen/dataset.json
@@ -5,12 +5,9 @@
   "description": "Per verblijfsobject de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
   "version": "1.0.0",
   "status": "beschikbaar",
-  "publisher": "datapunt@amsterdam.nl",
   "authorizationGrantor": "Datateam Omgevingswet",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "theme": [
     "Wonen"
   ],

--- a/datasets/leidingeninfrastructuur/dataset.json
+++ b/datasets/leidingeninfrastructuur/dataset.json
@@ -9,17 +9,15 @@
   "dateModified": "2022-02-17T00:00:00+01:00",
   "license": "Creative Commons, Naamsvermelding",
   "language": "nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling (ligging), Datateam Beheer en Openbare Ruimte (attributes)",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling (ligging), Datateam Beheer en Openbare Ruimte (attributes)",
+
   "accrualPeriodicity": "dagelijks",
   "spatialDescription": "Gemeente Amsterdam",
   "theme": [
     "leidingeninfrastructuur",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam, Ruimte & Economie",
   "authorizationGrantor": "datateam omgevingswet",
   "keywords": [

--- a/datasets/leidingeninfrastructuur/liggingLijnTotaal/v1.2.0.json
+++ b/datasets/leidingeninfrastructuur/liggingLijnTotaal/v1.2.0.json
@@ -7,15 +7,12 @@
   "description": "Overzicht lijnen infrastructuur op basis van klic meldingen",
   "auth": "FP/MDW",
   "status": "beschikbaar",
-  "contactPoint": {
-    "name": "Datateam Omgevingswet",
-    "email": "datateam.ruimte@amsterdam.nl"
-  },
-  "authorizationGrantor": "Datateam Omgevingswet",
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Omgevingswet",
+  "authorizationGrantor": "datateam.ruimte@amsterdam.nl",
   "theme": [
     "leidingeninfrastructuur"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/datasets/leidingeninfrastructuur/liggingPuntTotaal/v1.2.0.json
+++ b/datasets/leidingeninfrastructuur/liggingPuntTotaal/v1.2.0.json
@@ -7,15 +7,12 @@
   "description": "Overzicht punten infrastructuur op basis van klic meldingen",
   "auth": "FP/MDW",
   "status": "beschikbaar",
-  "contactPoint": {
-    "name": "Datateam Omgevingswet",
-    "email": "datateam.ruimte@amsterdam.nl"
-  },
-  "authorizationGrantor": "Datateam Omgevingswet",
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Omgevingswet",
+  "authorizationGrantor": "datateam.ruimte@amsterdam.nl",
   "theme": [
     "leidingeninfrastructuur"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/datasets/leidingeninfrastructuur/liggingVlakTotaal/v1.2.0.json
+++ b/datasets/leidingeninfrastructuur/liggingVlakTotaal/v1.2.0.json
@@ -7,15 +7,12 @@
   "description": "Overzicht vlakken infrastructuur op basis van klic meldingen",
   "auth": "FP/MDW",
   "status": "beschikbaar",
-  "contactPoint": {
-    "name": "Datateam Omgevingswet",
-    "email": "datateam.ruimte@amsterdam.nl"
-  },
-  "authorizationGrantor": "Datateam Omgevingswet",
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Omgevingswet",
+  "authorizationGrantor": "datateam.ruimte@amsterdam.nl",
   "theme": [
     "leidingeninfrastructuur"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/datasets/meetbouten/dataset.json
+++ b/datasets/meetbouten/dataset.json
@@ -6,11 +6,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/meldingen/dataset.json
+++ b/datasets/meldingen/dataset.json
@@ -17,7 +17,6 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2018-01-01T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "description": "SIA (Signalen Informatievoorziening Amsterdam) meldingen",
   "status": "beschikbaar",
   "keywords": [
@@ -35,10 +34,8 @@
   ],
   "crs": "EPSG:28992",
   "temporalUnit": "dagen",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "meldingenBuurt",

--- a/datasets/milieuzones/dataset.json
+++ b/datasets/milieuzones/dataset.json
@@ -10,13 +10,10 @@
     "milieuzones",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "keywords": [
     "milieuzones"
   ],

--- a/datasets/nap/dataset.json
+++ b/datasets/nap/dataset.json
@@ -6,11 +6,9 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
+
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/ondergrond/dataset.json
+++ b/datasets/ondergrond/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/openbareverlichting/dataset.json
+++ b/datasets/openbareverlichting/dataset.json
@@ -10,13 +10,10 @@
     "Openbare verlichting",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "keywords": [
     "openbare verlichting"
   ],

--- a/datasets/overlastgebieden/dataset.json
+++ b/datasets/overlastgebieden/dataset.json
@@ -17,11 +17,8 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2020-02-09T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "description": "Overlastgebieden Amsterdam.",
   "status": "beschikbaar",
   "keywords": [

--- a/datasets/parkeervakken/dataset.json
+++ b/datasets/parkeervakken/dataset.json
@@ -6,11 +6,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/parkeerzones/dataset.json
+++ b/datasets/parkeerzones/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/precariobelasting/dataset.json
+++ b/datasets/precariobelasting/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/rdw/dataset.json
+++ b/datasets/rdw/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Mobiliteit",
   "authorizationGrantor": "n.v.t.",
   "objective": "Het doel van deze dataset om op basis van een kenteken contextuele informatie op te vragen.",
   "tables": [

--- a/datasets/referentiekalender/dataset.json
+++ b/datasets/referentiekalender/dataset.json
@@ -13,17 +13,14 @@
   ],
   "owner": "Gemeente Amsterdam",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "authorizationGrantor": "n.v.t.",
   "keywords": [
     "kalender",
     "referentie",
     "datum"
   ],
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "datum",

--- a/datasets/rioolnetwerk/dataset.json
+++ b/datasets/rioolnetwerk/dataset.json
@@ -12,16 +12,13 @@
   "version": "0.0.1",
   "objective": "Het doel van deze dataset is het beschikbaarstellen van informatie met betrekking tot rioolleidingen en knopen aan de afenemende partijen binnen gemeente Amsterdam. Inzicht bij graafwerkzaamheden in welke rioolleidingen en rioolknopen waar in de ondergrond zijn.",
   "temporalUnit": "dagen",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "accrualPeriodicity": "maandelijks",
   "spatialDescription": "Gemeente Amsterdam",
   "theme": [
     "Ondergrond"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam, V&OR assetmanager verhardingen",
   "authorizationGrantor": "Assetmanager verhardingen",
   "keywords": [

--- a/datasets/risicozones/dataset.json
+++ b/datasets/risicozones/dataset.json
@@ -6,13 +6,10 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "keywords": [
     "risicozones",
     "bedrijven",

--- a/datasets/schiphol/dataset.json
+++ b/datasets/schiphol/dataset.json
@@ -6,13 +6,11 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
+
   "theme": [
     "schiphol"
   ],

--- a/datasets/spoorlijnen/dataset.json
+++ b/datasets/spoorlijnen/dataset.json
@@ -6,13 +6,10 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "keywords": [
     "spoorlijnen",
     "metro",

--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -6,13 +6,10 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Sociaal",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Sociaal",
   "theme": [
     "sportfaciliteiten en -aanbieders",
     "Ruimte en Topografie"

--- a/datasets/standbedrijven/dataset.json
+++ b/datasets/standbedrijven/dataset.json
@@ -7,12 +7,10 @@
   "title": "stand van de gegevens over bedrijven / vestigingen",
   "description": "stand op \u00e9\u00e9n bepaalde peildatum van gegevens in het domein van bedrijvigheid",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
   "authorizationGrantor": "Onderzoek en Statistiek",
-  "contactPoint": {
-    "name": "Datateam Basisstatistiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basisstatistiek",
+
   "crs": "EPSG:28992",
   "tables": [
     {

--- a/datasets/standvastgoed/dataset.json
+++ b/datasets/standvastgoed/dataset.json
@@ -7,12 +7,9 @@
   "title": "stand van de vastgoedgegevens",
   "description": "stand op \u00e9\u00e9n bepaalde peildatum van gegevens in het vastgoed domein",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "authorizationGrantor": "Onderzoek en Statistiek",
-  "contactPoint": {
-    "name": "Datateam Basisstatistiek",
-    "email": "basisstatistiek.ois@amsterdam.nl"
-  },
+  "authorizationGrantor": "basisstatistiek.ois@amsterdam.nl",
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basisstatistiek",
   "crs": "EPSG:28992",
   "tables": [
     {

--- a/datasets/stroomstoringen/dataset.json
+++ b/datasets/stroomstoringen/dataset.json
@@ -11,10 +11,8 @@
   "status": "beschikbaar",
   "version": "1.0.0",
   "temporalUnit": "nvt",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "accrualPeriodicity": "elke 10 minuten",
   "spatialDescription": "Gemeente Amsterdam",
   "theme": [
@@ -22,7 +20,6 @@
     "electra",
     "storingen"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam, Openbareverlichting V&OR",
   "authorizationGrantor": "Openbareverlichting V&OR",
   "keywords": [

--- a/datasets/touringcars/dataset.json
+++ b/datasets/touringcars/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Mobiliteit",
-    "email": ""
-  },
+  "publisher": "Datateam Mobiliteit",
+  "creator": "bronhouder onbekend",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/varen/dataset.json
+++ b/datasets/varen/dataset.json
@@ -12,16 +12,13 @@
   "version": "0.0.1",
   "objective": "Programma varen heeft de verplichting om openbare informatie waaronder op en afstap plaatsen te publiceren voor de bewoners van Amsterdam en de ketenpartners.",
   "temporalUnit": "nvt",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "accrualPeriodicity": "maandelijks",
   "spatialDescription": "Gemeente Amsterdam",
   "theme": [
     "Verkeer"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam, Toezicht en Handhaving Openbare Ruimte",
   "authorizationGrantor": "Toezicht en Handhaving Openbare Ruimte",
   "keywords": [

--- a/datasets/vastgoed/dataset.json
+++ b/datasets/vastgoed/dataset.json
@@ -10,13 +10,11 @@
     "Vastgoed",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
+
   "keywords": [
     "vastgoed"
   ],

--- a/datasets/veiligeafstanden/dataset.json
+++ b/datasets/veiligeafstanden/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/vergunningen/dataset.json
+++ b/datasets/vergunningen/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Opdrachten",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Opdrachten",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/verkiezingen/dataset.json
+++ b/datasets/verkiezingen/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/verzinkbarepalen/dataset.json
+++ b/datasets/verzinkbarepalen/dataset.json
@@ -10,13 +10,10 @@
     "verzinkbarepalen",
     "Ruimte en Topografie"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "keywords": [
     "verzinkbarepalen"
   ],

--- a/datasets/wagenpark/dataset.json
+++ b/datasets/wagenpark/dataset.json
@@ -20,7 +20,6 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2002-10-31T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "description": "De dataset Wagenparkbeheer bevat stam- en procesgegevens over het Amsterdamse wagenpark (voertuigen en bijbehorend materieel), inclusief gegevens over het onderhoud daarvan. De dataset bestaat uit RDW-plichtige objecten met een kentekennummer (veelal voertuigen) en niet-RDW-plichtige objecten met een eigen Amsterdams identificatienummer (overig materieel). De kenmerken van de objecten zijn gegroepeerd in 6 deeldatasets: materieel (basisgegevens en indien van toepassing ook brandstof- en verbruiksgegevens), financi\u00ebn (financi\u00eble en verzekeringsgegevens), vergunning (vergunning- en ontheffingsgegevens), RDW (gegevens die voortkomen uit het kentekenregister van het Rijksdienst voor Wegverkeer), aeng_kenmerk (kenmerken die speciaal voor Afval&Grondstoffen zijn toegevoegd) en onderhoud (procesgegevens met betrekking tot zowel gepland als ongepland onderhoud en reparaties)",
   "status": "beschikbaar",
   "keywords": [
@@ -37,10 +36,8 @@
   "crs": "EPSG:28992",
   "objective": "Het doel van de dataset Wagenparkbeheer is een goede registratie bij te houden van stam- en procesgegevens over het Amsterdamse Wagenpark en het daarbij behorende onderhoud ter ondersteuning van het beheer van het wagenpark",
   "temporalUnit": "seconden",
-  "contactPoint": {
-    "name": "Datateam Beheer en Openbare Ruimte",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
   "tables": [
     {
       "id": "materieel",

--- a/datasets/wegenbestand/dataset.json
+++ b/datasets/wegenbestand/dataset.json
@@ -17,11 +17,8 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2022-02-09T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Generiek",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Generiek",
   "description": "Aangewezen wegen voor vrachtverkeer met gevaarlijkestoffen of valt onder de categorie zwaar verkeer.",
   "status": "beschikbaar",
   "keywords": [

--- a/datasets/wegenbestand/zoneZwaarVerkeer/dataset.json
+++ b/datasets/wegenbestand/zoneZwaarVerkeer/dataset.json
@@ -17,7 +17,6 @@
   "license": "Creative Commons, Naamsvermelding",
   "hasBeginning": "2022-02-09T00:00:00+01:00",
   "accrualPeriodicity": "dagelijks",
-  "publisher": "datapunt@amsterdam.nl",
   "description": "Wegen die al dan niet vallen onder zwaar verkeer zones waarvoor mogelijk ontheffing moet worden aangevraagd.",
   "status": "beschikbaar",
   "keywords": [
@@ -31,10 +30,8 @@
   ],
   "crs": "EPSG:28992",
   "objective": "Publiceren van zwaar verkeer zones voor de doelgroep.",
-  "contactPoint": {
-    "name": "",
-    "email": "bereikbaarheidsthermometer@amsterdam.nl"
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "bereikbaarheidsthermometer@amsterdam.nl",
   "tables": [
     {
       "id": "binnen",

--- a/datasets/winkelgebieden/dataset.json
+++ b/datasets/winkelgebieden/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basisstatistiek",
-    "email": "basisstatistiek.ois@amsterdam.nl"
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basisstatistiek",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/datasets/wior/dataset.json
+++ b/datasets/wior/dataset.json
@@ -6,13 +6,10 @@
   "license": "public",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
   "authorizationGrantor": "OIS",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "keywords": [
     "wior"
   ],

--- a/datasets/woningbouwplannen/dataset.json
+++ b/datasets/woningbouwplannen/dataset.json
@@ -12,16 +12,13 @@
   "version": "0.0.1",
   "objective": "Doel van de ontsluiting is om de geintereseerden te informeren over de woningbouwplannen in Amsterdam.",
   "temporalUnit": "nvt",
-  "contactPoint": {
-    "name": "Datateam Stedelijke Ontwikkeling",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Stedelijke Ontwikkeling",
   "accrualPeriodicity": "jaarlijks",
   "spatialDescription": "Gemeente Amsterdam",
   "theme": [
     "Wonen"
   ],
-  "publisher": "datapunt@amsterdam.nl",
   "owner": "Gemeente Amsterdam, Grond en Ontwikkeling en Ruimte en Duurzaamheid",
   "authorizationGrantor": "Grond en Ontwikkeling en Ruimte en Duurzaamheid",
   "keywords": [

--- a/datasets/woz/dataset.json
+++ b/datasets/woz/dataset.json
@@ -7,11 +7,8 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "Datateam Basis- en Kernregistraties",
-    "email": ""
-  },
+  "creator": "bronhouder onbekend",
+  "publisher": "Datateam Basis- en Kernregistraties",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {

--- a/docs/ams-schema-spec.bs
+++ b/docs/ams-schema-spec.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: Amsterdam Schema Specificatie
 Shortname: ams-schema-spec
-Revision: 2.0.1
+Revision: 2.1.0
 Status: LS
 URL: https://schemas.data.amsterdam.nl/docs/ams-schema-spec.html
 Repository: Amsterdam/amsterdam-schema
@@ -24,6 +24,8 @@ Text Macro: HIDELINESEXAMPLE class="example hide-lines" onClick="this.classList.
 Text Macro: SYNCSCROLLA class="a" onscroll="let sibling =this.nextElementSibling; sibling.scrollTop=this.scrollTop;sibling.scrollLeft=this.scrollLeft;"
 Text Macro: SYNCSCROLLB class="b" onscroll="let sibling =this.previousElementSibling; sibling.scrollTop=this.scrollTop;sibling.scrollLeft=this.scrollLeft;"
 </pre>
+
+Advisement: De meest recente aanpassing aan deze specificatie is:<br/> [[#lastchange]]
 
 <!--
 ████ ██    ██ ████████ ████████   ███████
@@ -109,11 +111,10 @@ Een <dfn dfn export>dataset</dfn> binnen Amsterdam Schema bestaat uit een JSON b
                     * "beschikbaar"
                     * "niet_beschikbaar"
             </details>
-    <tr><td><dfn>contactPoint</dfn>         <td> {{contact}}
-        <td> Contactgegevens van de persoon of afdeling waar inhoudelijke vragen over de dataset aan gericht moeten worden. Dit is meestal de bronhouder. (Deze gegevens worden publiek zichtbaar.)
-    <tr><td><dfn>authorizationGrantor</dfn> <td> string     <td> Naam van de afdeling verantwoordelijk voor autorisatie op deze dataset. Dit is meestal de bronhouder.
-    <tr><td><dfn>owner</dfn>                <td> string     <td> Eigenaar van de data  Default: `"Gemeente Amsterdam"`
-    <tr><td><dfn>publisher</dfn>            <td> string     <td> [CONST] `"datapunt@amsterdam.nl"` Ontsluiter van de data verantwoordelijk voor technisch beheer. Conform \[DCAT § resource_publisher]([DCATURL]#Property:resource_publisher)
+    <tr><td><dfn>authorizationGrantor</dfn> <td> string     <td> E-mailadres van de afdeling verantwoordelijk voor autorisatie op deze dataset. Dit is meestal de bronhouder. Aan dit adres worden authorisatie verzoeken gericht.
+    <tr><td><dfn>creator</dfn>              <td> string     <td> Team, afdeling of organisatie die de data produceert, meestal de bronhouder. Wanneer data van meerdere bronhouders wordt gecomineerd, wordt hier de opdrachtgever bedoelt.
+    <tr><td><dfn>owner</dfn>                <td> string     <td> Juridisch eigenaar van de data. Bijvoorbeeld `"Gemeente Amsterdam, Directie Wonen"` of `"Centraal Bureau voor de Statistiek"`  Default: `"Gemeente Amsterdam"`
+    <tr><td><dfn>publisher</dfn>            <td> string     <td> Het team verantwoordelijk voor het technisch ontsluiten van de data. Meestal het datateam. Conform \[DCAT § resource_publisher]([DCATURL]#Property:resource_publisher)
     <tr><td><dfn>tables</dfn>   <td> array
         <td> Tabellen in deze dataset. Moet minimaal 1 element bevatten.
             <details>
@@ -125,6 +126,8 @@ Een <dfn dfn export>dataset</dfn> binnen Amsterdam Schema bestaat uit een JSON b
 </table>
 
 Advisement: Let op: Zie [[#naamgeving]] voor de eisen waaraan {{dataset/id}} moet voldoen.
+
+Note: Als een dataset nog niet klaar is voor publicatie, zet de {{dataset/status}} dan op `"niet_beschikbaar"`. Zo wordt de dataset nog niet zichtbaar in doelsystemen.
 
 <div class=example>
     Een minimale dataset definitie. De 'title' en 'description' velden zijn niet verplicht,
@@ -144,6 +147,8 @@ Optionele attributen {#dataset-optional-fields}
 --------------------------------------------------------
 Naast bovenstaande verplichte attributen mag een [=dataset=] ook de volgende eigenschappen bevatten.
 <table dfn-type="attribute" dfn-for=dataset export class="dfn-table">
+    <tr><td><dfn>contactPoint</dfn>         <td> {{contact}}
+        <td> Contactgegevens van de persoon of afdeling verantwoordelijk voor eerstelijns ondersteuning bij deze dataset. Hier kunnen mensen met vragen over de dataset terecht. (Deze gegevens worden publiek zichtbaar.) Wanneer dit veld niet is gegeven, is impliciet de default waarde van toepassing. Default: `{"name": "Datapunt", "email": "datapunt@amsterdam.nl"}`
     <tr><td><dfn>title</dfn>        <td> string     <td> zie [[#omschrijving]] [DCAT § Property:resource_title]([DCATURL]#Property:resource_title)
     <tr><td><dfn>description</dfn>  <td> string     <td> zie [[#omschrijving]] [DCAT § Property:resource_description]([DCATURL]#Property:resource_description)
     <tr><td><dfn>auth</dfn>         <td> string | array <td> geautoriseerde [=scope|scope(s)=]. Default: `"OPENBAAR"` zie [[#autorisatie]]
@@ -243,7 +248,7 @@ Advisement: Van deze bestandsnaam en padstructuur moet niet worden afgeweken beh
     <pre class="include-code">
             path: examples/datasets/bekendeAmsterdammers/dataset.json
             highlight: json
-            line-highlight: 14-27
+            line-highlight: 11-24
         </pre>
 </div>
 
@@ -1546,6 +1551,35 @@ Attribuuttypen {#attr-types}
                 * <dfn>email</dfn> (string) Email adres van het contact
             </ul>
 </table>
+
+<!--
+ ██████  ██     ██    ███    ██    ██  ██████   ████████ ██        ███████   ██████
+██    ██ ██     ██   ██ ██   ███   ██ ██    ██  ██       ██       ██     ██ ██    ██
+██       ██     ██  ██   ██  ████  ██ ██        ██       ██       ██     ██ ██
+██       █████████ ██     ██ ██ ██ ██ ██   ████ ██████   ██       ██     ██ ██   ████
+██       ██     ██ █████████ ██  ████ ██    ██  ██       ██       ██     ██ ██    ██
+██    ██ ██     ██ ██     ██ ██   ███ ██    ██  ██       ██       ██     ██ ██    ██
+ ██████  ██     ██ ██     ██ ██    ██  ██████   ████████ ████████  ███████   ██████
+-->
+Changelog {#changelog}
+==================================================
+Dit is een chronologisch overzicht van aanpassingen aan de amsterdam-schema specificatie.
+Uitsluitend normatieve aanpassingen aan de specificatie worden vermeld. Aanpassingen aan voorbeelden,
+waarschuwingen of uitleg verschijnen dus niet in dit overzicht.
+
+<!-- Allways move the lastchange tag to the latest entry, so the correct entry is linked at the top of the page. -->
+<!-- Include short (one sentence) description, a motivation and bullet list of all changes made in each entry. -->
+
+[2.1.0] Dataset contact gegevens (2022-03-17) {#lastchange}
+------------------------------------------------
+> **Doelstelling**<br/>
+    Meerdere aanpassingen aan dataset velden voor contactgegevens.
+    Met als doel om alle teams en organisaties die een rol hebben bij het ontsluiten van een dataset
+    te vermelden. Zodat vragen over de dataset aan de juiste personen gericht kunnen worden.
+
+* Nieuw optioneel veld {{dataset/creator}} toegevoegd.
+* Het veld {{dataset/publisher}} heeft geen constant waarde meer. En bevat nu de naam van het datateam dat de dataset ontsluit.
+* Het veld {{dataset/contactPoint}} is nu optioneel en bevat een standaard waarde.
 
 
 <!--

--- a/docs/ams-schema-spec.html
+++ b/docs/ams-schema-spec.html
@@ -12,7 +12,7 @@
  *   - .toc for the Table of Contents (<ol class="toc">)
  *     + <span class="secno"> for the section numbers
  *   - #toc for the Table of Contents (<nav id="toc">)
- *   - ul.index for Indices (<a href="#ref">term</a><span>, in § N.M</span>)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
  *   - table.index for Index Tables (e.g. for properties or elements)
  *
  * Structural Markup
@@ -1487,10 +1487,10 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version d7036035b, updated Fri Oct 8 17:07:11 2021 -0700" name="generator">
+  <meta content="Bikeshed version bb6b91100, updated Mon Jul 12 16:52:37 2021 -0700" name="generator">
   <link href="https://schemas.data.amsterdam.nl/docs/ams-schema-spec.html" rel="canonical">
   <link href="https://data.amsterdam.nl/favicon.png" rel="icon">
-  <meta content="cc5ac313a724f965a9b44cac71bf466d14122858" name="document-revision">
+  <meta content="34ed7e7e807fc0743627d41609ccdd60fc28287f" name="document-revision">
 <style>
     p[data-fill-with="logo"] {
         width: 180px;
@@ -1870,16 +1870,6 @@ figcaption:not(.no-marker)::before {
 
 .dfn-paneled { cursor: pointer; }
 </style>
-<style>/* style-issues */
-
-a[href].issue-return {
-    float: right;
-    float: inline-end;
-    color: var(--issueheading-text);
-    font-weight: bold;
-    text-decoration: none;
-}
-</style>
 <style>/* style-line-highlighting */
 
 :root {
@@ -2234,7 +2224,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Amsterdam Schema Specificatie</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2022-03-02">2 March 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2022-03-17">17 March 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2303,6 +2293,11 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      </ol>
     <li><a href="#attr-types"><span class="secno">7</span> <span class="content">Attribuuttypen</span></a>
     <li>
+     <a href="#changelog"><span class="secno">8</span> <span class="content">Changelog</span></a>
+     <ol class="toc">
+      <li><a href="#lastchange"><span class="secno">8.1</span> <span class="content">[2.1.0] Dataset contact gegevens (2022-03-17)</span></a>
+     </ol>
+    <li>
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
@@ -2317,6 +2312,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    </ol>
   </nav>
   <main>
+   <p><strong class="advisement"> De meest recente aanpassing aan deze specificatie is:<br> <a href="#lastchange">§ 8.1 [2.1.0] Dataset contact gegevens (2022-03-17)</a></strong></p>
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introductie</span><a class="self-link" href="#intro"></a></h2>
    <blockquote>
     <p><strong>Doelstelling</strong><br> Alle data van gemeente Amsterdam binnen één machine verwerkbaar universeel format beschrijven,
@@ -2364,7 +2360,7 @@ Een dataset bevat minstens één tabel.</p>
     <p><strong>Dataset</strong> A collection of data, published or curated by a single agent or identifiable community.
 The notion of dataset in DCAT is broad and inclusive, with the intention of accommodating resource types arising from all communities.
 Data comes in many forms including numbers, text, pixels, imagery, sound and other multi-media, and potentially other types,
-any of which might be collected into a dataset. (From <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-scope">Data Catalog Vocabulary (DCAT) - Version 2 § dcat-scope</a>)</p>
+any of which might be collected into a dataset. (From <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-scope">Data Catalog Vocabulary (DCAT) - Version 2 §dcat-scope</a>)</p>
    </blockquote>
    <h3 class="heading settled" data-level="2.1" id="dataset-mandatory-fields"><span class="secno">2.1. </span><span class="content">Verplichte attributen</span><a class="self-link" href="#dataset-mandatory-fields"></a></h3>
     Een <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="dataset">dataset</dfn> binnen Amsterdam Schema bestaat uit een JSON bestand met in ieder geval de volgende velden:
@@ -2379,7 +2375,7 @@ any of which might be collected into a dataset. (From <a href="https://www.w3.or
       <td> <code class="idl"><a data-link-type="idl" href="#typedefdef-type" id="ref-for-typedefdef-type">schema-type</a></code>
       <td> Type van dit bestand, in dit geval <code class="highlight"><c- u>"dataset"</c-></code>.
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-status"><code class="highlight">status</code><a class="self-link" href="#dom-dataset-status"></a></dfn>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-status"><code class="highlight">status</code></dfn>
       <td> string
       <td>
         Publicatiestatus van de dataset
@@ -2393,21 +2389,21 @@ any of which might be collected into a dataset. (From <a href="https://www.w3.or
         </ul>
        </details>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-contactpoint"><code class="highlight">contactPoint</code><a class="self-link" href="#dom-dataset-contactpoint"></a></dfn>
-      <td> <code class="idl"><a data-link-type="idl" href="#typedefdef-contact" id="ref-for-typedefdef-contact">contact</a></code>
-      <td> Contactgegevens van de persoon of afdeling waar inhoudelijke vragen over de dataset aan gericht moeten worden. Dit is meestal de bronhouder. (Deze gegevens worden publiek zichtbaar.)
-     <tr>
       <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-authorizationgrantor"><code class="highlight">authorizationGrantor</code><a class="self-link" href="#dom-dataset-authorizationgrantor"></a></dfn>
       <td> string
-      <td> Naam van de afdeling verantwoordelijk voor autorisatie op deze dataset. Dit is meestal de bronhouder.
+      <td> E-mailadres van de afdeling verantwoordelijk voor autorisatie op deze dataset. Dit is meestal de bronhouder. Aan dit adres worden authorisatie verzoeken gericht.
+     <tr>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-creator"><code class="highlight">creator</code></dfn>
+      <td> string
+      <td> Team, afdeling of organisatie die de data produceert, meestal de bronhouder. Wanneer data van meerdere bronhouders wordt gecomineerd, wordt hier de opdrachtgever bedoelt.
      <tr>
       <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-owner"><code class="highlight">owner</code><a class="self-link" href="#dom-dataset-owner"></a></dfn>
       <td> string
-      <td> Eigenaar van de data  Default: <code class="highlight"><c- u>"Gemeente Amsterdam"</c-></code>
+      <td> Juridisch eigenaar van de data. Bijvoorbeeld <code class="highlight"><c- u>"Gemeente Amsterdam, Directie Wonen"</c-></code> of <code class="highlight"><c- u>"Centraal Bureau voor de Statistiek"</c-></code> Default: <code class="highlight"><c- u>"Gemeente Amsterdam"</c-></code>
      <tr>
-      <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-publisher"><code class="highlight">publisher</code><a class="self-link" href="#dom-dataset-publisher"></a></dfn>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-publisher"><code class="highlight">publisher</code></dfn>
       <td> string
-      <td> <em>constant</em> <code class="highlight"><c- u>"datapunt@amsterdam.nl"</c-></code> Ontsluiter van de data verantwoordelijk voor technisch beheer. Conform <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:resource_publisher">DCAT § resource_publisher</a>
+      <td> Het team verantwoordelijk voor het technisch ontsluiten van de data. Meestal het datateam. Conform <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:resource_publisher">DCAT § resource_publisher</a>
      <tr>
       <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-tables"><code class="highlight">tables</code><a class="self-link" href="#dom-dataset-tables"></a></dfn>
       <td> array
@@ -2425,8 +2421,9 @@ Zie <a href="#table-refs">§ 2.3 Tabelreferenties</a> voor details.</p>
        </details>
    </table>
    <p><strong class="advisement"> Let op: Zie <a href="#naamgeving">§ 5 Naamgeving</a> voor de eisen waaraan <code class="idl"><a data-link-type="idl" href="#dom-dataset-id" id="ref-for-dom-dataset-id">id</a></code> moet voldoen.</strong></p>
-   <div class="example" id="example-8f54c468">
-    <a class="self-link" href="#example-8f54c468"></a> Een minimale dataset definitie. De 'title' en 'description' velden zijn niet verplicht,
+   <p class="note" role="note"><span>Note:</span> Als een dataset nog niet klaar is voor publicatie, zet de <code class="idl"><a data-link-type="idl" href="#dom-dataset-status" id="ref-for-dom-dataset-status">status</a></code> dan op <code class="highlight"><c- u>"niet_beschikbaar"</c-></code>. Zo wordt de dataset nog niet zichtbaar in doelsystemen.</p>
+   <div class="example" id="example-b0343c19">
+    <a class="self-link" href="#example-b0343c19"></a> Een minimale dataset definitie. De 'title' en 'description' velden zijn niet verplicht,
     maar het is best practice ze toe te voegen.
 <pre class="include-code highlight"><c- p>{</c->
   <c- f>"id"</c-><c- p>:</c-> <c- u>"bekendeAmsterdammers"</c-><c- p>,</c->
@@ -2435,13 +2432,10 @@ Zie <a href="#table-refs">§ 2.3 Tabelreferenties</a> voor details.</p>
   <c- f>"description"</c-><c- p>:</c-> <c- u>"Een collectie van bekende Amsterdammers.\n (Een voorbeeld dataset)"</c-><c- p>,</c->
   <c- f>"version"</c-><c- p>:</c-> <c- u>"1.0.0"</c-><c- p>,</c->
   <c- f>"status"</c-><c- p>:</c-> <c- u>"beschikbaar"</c-><c- p>,</c->
-  <c- f>"contactPoint"</c-><c- p>:</c-> <c- p>{</c->
-    <c- f>"name"</c-><c- p>:</c-> <c- u>"Team Bekende Amsterdammers"</c-><c- p>,</c->
-    <c- f>"email"</c-><c- p>:</c-> <c- u>"tba@amsterdam.nl"</c->
-  <c- p>},</c->
-  <c- f>"authorizationGrantor"</c-><c- p>:</c-> <c- u>"Team Bekende Amsterdammers"</c-><c- p>,</c->
+  <c- f>"publisher"</c-><c- p>:</c-> <c- u>"Team Bekende Amsterdammers"</c-><c- p>,</c->
+  <c- f>"creator"</c-><c- p>:</c-> <c- u>"myBronhouder"</c-><c- p>,</c->
+  <c- f>"authorizationGrantor"</c-><c- p>:</c-> <c- u>"tba@amsterdam.nl"</c-><c- p>,</c->
   <c- f>"owner"</c-><c- p>:</c-> <c- u>"Gemeente Amsterdam"</c-><c- p>,</c->
-  <c- f>"publisher"</c-><c- p>:</c-> <c- u>"datapunt@amsterdam.nl"</c-><c- p>,</c->
   <c- f>"tables"</c-><c- p>:</c-> <c- p>[</c->
     <c- p>{</c->
       <c- f>"$ref"</c-><c- p>:</c-> <c- u>"personen/v1.0.0"</c-><c- p>,</c->
@@ -2459,6 +2453,10 @@ Zie <a href="#table-refs">§ 2.3 Tabelreferenties</a> voor details.</p>
     Naast bovenstaande verplichte attributen mag een <a data-link-type="dfn" href="#dataset" id="ref-for-dataset">dataset</a> ook de volgende eigenschappen bevatten.
    <table class="dfn-table">
     <tbody>
+     <tr>
+      <td><dfn class="dfn-paneled idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-contactpoint"><code class="highlight">contactPoint</code></dfn>
+      <td> <code class="idl"><a data-link-type="idl" href="#typedefdef-contact" id="ref-for-typedefdef-contact">contact</a></code>
+      <td> Contactgegevens van de persoon of afdeling verantwoordelijk voor eerstelijns ondersteuning bij deze dataset. Hier kunnen mensen met vragen over de dataset terecht. (Deze gegevens worden publiek zichtbaar.) Wanneer dit veld niet is gegeven, is impliciet de default waarde van toepassing. Default: <code class="highlight"><c- p>{</c-><c- u>"name"</c-><c- o>:</c-> <c- u>"Datapunt"</c-><c- p>,</c-> <c- u>"email"</c-><c- o>:</c-> <c- u>"datapunt@amsterdam.nl"</c-><c- p>}</c-></code>
      <tr>
       <td><dfn class="idl-code" data-dfn-for="dataset" data-dfn-type="attribute" data-export id="dom-dataset-title"><code class="highlight">title</code><a class="self-link" href="#dom-dataset-title"></a></dfn>
       <td> string
@@ -2567,7 +2565,7 @@ De volgende velden zijn toegestaan:
           <p>"EPSG:4326"</p>
         </ul>
        </details>
-        Zie <a href="https://www.w3.org/TR/sdw-bp/#CRS-background">SDOW best practices § CRS-background</a> voor meer informatie.
+        Zie <a href="https://www.w3.org/TR/sdw-bp/#CRS-background">SDOW best practices §CRS-background</a> voor meer informatie.
    </table>
    <p class="note" role="note"><span>Note:</span> De intentie is dat alle relevante <a data-link-type="biblio" href="#biblio-vocab-dcat-2">DCAT</a> velden te modelleren zijn. Wanneer velden ontbreken
     die wel in de <a data-link-type="biblio" href="#biblio-vocab-dcat-2">DCAT</a> zijn opgenomen, zullen deze worden toegevoegd.</p>
@@ -2576,7 +2574,7 @@ De volgende velden zijn toegestaan:
    <h3 class="heading settled" data-level="2.3" id="table-refs"><span class="secno">2.3. </span><span class="content">Tabelreferenties</span><a class="self-link" href="#table-refs"></a></h3>
     Tabelreferenties zijn verwijzingen naar JSON-bestanden waarin een <a data-link-type="dfn" href="#tabel" id="ref-for-tabel①">tabel</a> gedefinieerd wordt.
 Dit maakt het mogelijk om elke tabel in een dataset in een eigen bestand te definieeren.
-Tabel referenties zijn gebaseerd op <a href="https://json-schema.org/draft/2020-12/json-schema-core.html#ref">JSON Schema § ref</a>.
+Tabel referenties zijn gebaseerd op <a href="https://json-schema.org/draft/2020-12/json-schema-core.html#ref">JSON Schema §ref</a>.
    <p>Een <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="tabel-referentie">tabel referentie</dfn> is een JSON object met in ieder geval de volgende attributen:</p>
    <table class="dfn-table">
     <tbody>
@@ -2613,10 +2611,10 @@ Het pad gezien vanuit de locatie van het dataset bestand <strong>zou</strong> du
 <pre class="language-bash highlight">    &lt;tabelid>/v&lt;major>.&lt;minor>.&lt;patch>.json
 </pre>
    <p><strong class="advisement"> Van deze bestandsnaam en padstructuur moet niet worden afgeweken behalve als daar een zwaarwegende reden voor is.</strong></p>
-   <div class="example hide-lines" id="example-7a31c51e" onclick="this.classList.toggle(&apos;hide-lines&apos;);this.classList.toggle(&apos;unhide-lines&apos;);">
-    <a class="self-link" href="#example-7a31c51e"></a> Voorbeeld van een dataset met twee tabel referenties.
+   <div class="example hide-lines" id="example-a02e7cb6" onclick="this.classList.toggle(&apos;hide-lines&apos;);this.classList.toggle(&apos;unhide-lines&apos;);">
+    <a class="self-link" href="#example-a02e7cb6"></a> Voorbeeld van een dataset met twee tabel referenties.
     <p>Een <code class="highlight">locaties</code> tabel in <code class="highlight"><c- p>.</c-><c- o>/</c->locaties<c- o>/</c->v1<c- mf>.0.0</c-><c- p>.</c->json</code>.<br> En een <code class="highlight">personen</code> tabel in <code class="highlight"><c- p>.</c-><c- o>/</c->personen<c- o>/</c->v2<c- mf>.0.1</c-><c- p>.</c->json</code>, waarvan ook de oudere versie <code class="highlight"><c- mf>1.3.0</c-></code> beschikbaar is.</p>
-<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- p>{</c-></span><span class="line-no"></span><span class="line">  <c- f>"id"</c-><c- p>:</c-> <c- u>"bekendeAmsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"type"</c-><c- p>:</c-> <c- u>"dataset"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"title"</c-><c- p>:</c-> <c- u>"Bekende Amsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"description"</c-><c- p>:</c-> <c- u>"Bekende historische personen die in Amsterdam hebben gewoond.\n (Een voorbeeld dataset)"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"status"</c-><c- p>:</c-> <c- u>"beschikbaar"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"owner"</c-><c- p>:</c-> <c- u>"Gemeente Amsterdam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"publisher"</c-><c- p>:</c-> <c- u>"datapunt@amsterdam.nl"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"contactPoint"</c-><c- p>:</c-> <c- p>{</c-></span><span class="line-no"></span><span class="line">    <c- f>"name"</c-><c- p>:</c-> <c- u>"myDataTeam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- f>"email"</c-><c- p>:</c-> <c- u>"myDataTeam@amsterdam.nl"</c-></span><span class="line-no"></span><span class="line">  <c- p>},</c-></span><span class="line-no"></span><span class="line">  <c- f>"authorizationGrantor"</c-><c- p>:</c-> <c- u>"myDataTeam"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="14"></span><span class="line highlight-line">  <c- f>"tables"</c-><c- p>:</c-> <c- p>[</c-></span><span class="line-no highlight-line" data-line="15"></span><span class="line highlight-line">    <c- p>{</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="17"></span><span class="line highlight-line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"personen"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">      <c- f>"activeVersions"</c-><c- p>:</c-> <c- p>{</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">        <c- f>"1.3.0"</c-><c- p>:</c-> <c- u>"personen/v1.3.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">        <c- f>"2.0.1"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">      <c- p>}</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">    <c- p>},</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">    <c- p>{</c-></span><span class="line-no highlight-line" data-line="24"></span><span class="line highlight-line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"locaties/v1.0.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="25"></span><span class="line highlight-line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"locaties"</c-></span><span class="line-no highlight-line" data-line="26"></span><span class="line highlight-line">    <c- p>}</c-></span><span class="line-no highlight-line" data-line="27"></span><span class="line highlight-line">  <c- p>]</c-></span><span class="line-no"></span><span class="line"><c- p>}</c-></span></pre>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- p>{</c-></span><span class="line-no"></span><span class="line">  <c- f>"id"</c-><c- p>:</c-> <c- u>"bekendeAmsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"type"</c-><c- p>:</c-> <c- u>"dataset"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"title"</c-><c- p>:</c-> <c- u>"Bekende Amsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"description"</c-><c- p>:</c-> <c- u>"Bekende historische personen die in Amsterdam hebben gewoond.\n (Een voorbeeld dataset)"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"status"</c-><c- p>:</c-> <c- u>"beschikbaar"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"owner"</c-><c- p>:</c-> <c- u>"Gemeente Amsterdam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"publisher"</c-><c- p>:</c-> <c- u>"myDataTeam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"creator"</c-><c- p>:</c-> <c- u>"myBronhouder"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"authorizationGrantor"</c-><c- p>:</c-> <c- u>"myDataTeam@amsterdam.nl"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="11"></span><span class="line highlight-line">  <c- f>"tables"</c-><c- p>:</c-> <c- p>[</c-></span><span class="line-no highlight-line" data-line="12"></span><span class="line highlight-line">    <c- p>{</c-></span><span class="line-no highlight-line" data-line="13"></span><span class="line highlight-line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="14"></span><span class="line highlight-line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"personen"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="15"></span><span class="line highlight-line">      <c- f>"activeVersions"</c-><c- p>:</c-> <c- p>{</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">        <c- f>"1.3.0"</c-><c- p>:</c-> <c- u>"personen/v1.3.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="17"></span><span class="line highlight-line">        <c- f>"2.0.1"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">      <c- p>}</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">    <c- p>},</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">    <c- p>{</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"locaties/v1.0.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"locaties"</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">    <c- p>}</c-></span><span class="line-no highlight-line" data-line="24"></span><span class="line highlight-line">  <c- p>]</c-></span><span class="line-no"></span><span class="line"><c- p>}</c-></span></pre>
    </div>
    <h2 class="heading settled" data-level="3" id="tables"><span class="secno">3. </span><span class="content">Tabel</span><a class="self-link" href="#tables"></a></h2>
    <p>Een <a data-link-type="dfn" href="#tabel" id="ref-for-tabel③">tabel</a> definitie bevat het schema waaraan de er toe behorende datarijen moeten voldoen.
@@ -2895,17 +2893,17 @@ of een <code class="idl"><a data-link-type="idl" href="#dom-veld-maximum" id="re
      </div>
     </div>
    </div>
-   <div class="example hide-lines" id="example-1e8beb20" onclick="this.classList.toggle(&apos;hide-lines&apos;);this.classList.toggle(&apos;unhide-lines&apos;);">
-    <a class="self-link" href="#example-1e8beb20"></a> Om de nieuwe versie van de tabel aan de <a data-link-type="dfn" href="#dataset" id="ref-for-dataset④">dataset</a> toe te voegen, moet de <a data-link-type="dfn" href="#tabel-referentie" id="ref-for-tabel-referentie①">tabel referentie</a> in de dataset ook aangepast worden.
+   <div class="example hide-lines" id="example-dd840d8a" onclick="this.classList.toggle(&apos;hide-lines&apos;);this.classList.toggle(&apos;unhide-lines&apos;);">
+    <a class="self-link" href="#example-dd840d8a"></a> Om de nieuwe versie van de tabel aan de <a data-link-type="dfn" href="#dataset" id="ref-for-dataset④">dataset</a> toe te voegen, moet de <a data-link-type="dfn" href="#tabel-referentie" id="ref-for-tabel-referentie①">tabel referentie</a> in de dataset ook aangepast worden.
     De default versie van de tabel is nu "2.0.1".
     <p>In dit geval staat de versie "1.3.0" ook in <code class="idl"><a data-link-type="idl" href="#dom-table-ref-activeversions" id="ref-for-dom-table-ref-activeversions">activeVersions</a></code> zodat de oudere versie van de data ook beschikbaar blijft.
     Dit is optioneel.</p>
     <div style="text-align:center;">
       <code class="highlight">personen<c- o>/</c->dataset<c- p>.</c->json</code>
-<pre class="include-code highlight line-numbered"><span class="line-no highlight-line" data-line="1"></span><span class="line highlight-line"><c- p>{</c-></span><span class="line-no"></span><span class="line">  <c- f>"id"</c-><c- p>:</c-> <c- u>"bekendeAmsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"type"</c-><c- p>:</c-> <c- u>"dataset"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"title"</c-><c- p>:</c-> <c- u>"Bekende Amsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"description"</c-><c- p>:</c-> <c- u>"Bekende historische personen die in Amsterdam hebben gewoond.\n (Een voorbeeld dataset)"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"status"</c-><c- p>:</c-> <c- u>"beschikbaar"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"owner"</c-><c- p>:</c-> <c- u>"Gemeente Amsterdam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"publisher"</c-><c- p>:</c-> <c- u>"datapunt@amsterdam.nl"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"contactPoint"</c-><c- p>:</c-> <c- p>{</c-></span><span class="line-no"></span><span class="line">    <c- f>"name"</c-><c- p>:</c-> <c- u>"myDataTeam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- f>"email"</c-><c- p>:</c-> <c- u>"myDataTeam@amsterdam.nl"</c-></span><span class="line-no"></span><span class="line">  <c- p>},</c-></span><span class="line-no"></span><span class="line">  <c- f>"authorizationGrantor"</c-><c- p>:</c-> <c- u>"myDataTeam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"tables"</c-><c- p>:</c-> <c- p>[</c-></span><span class="line-no highlight-line" data-line="15"></span><span class="line highlight-line">    <c- p>{</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="17"></span><span class="line highlight-line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"personen"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">      <c- f>"activeVersions"</c-><c- p>:</c-> <c- p>{</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">        <c- f>"1.3.0"</c-><c- p>:</c-> <c- u>"personen/v1.3.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">        <c- f>"2.0.1"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">      <c- p>}</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">    <c- p>},</c-></span><span class="line-no"></span><span class="line">    <c- p>{</c-></span><span class="line-no"></span><span class="line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"locaties/v1.0.0"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"locaties"</c-></span><span class="line-no"></span><span class="line">    <c- p>}</c-></span><span class="line-no"></span><span class="line">  <c- p>]</c-></span><span class="line-no"></span><span class="line"><c- p>}</c-></span></pre>
+<pre class="include-code highlight line-numbered"><span class="line-no highlight-line" data-line="1"></span><span class="line highlight-line"><c- p>{</c-></span><span class="line-no"></span><span class="line">  <c- f>"id"</c-><c- p>:</c-> <c- u>"bekendeAmsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"type"</c-><c- p>:</c-> <c- u>"dataset"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"title"</c-><c- p>:</c-> <c- u>"Bekende Amsterdammers"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"description"</c-><c- p>:</c-> <c- u>"Bekende historische personen die in Amsterdam hebben gewoond.\n (Een voorbeeld dataset)"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"status"</c-><c- p>:</c-> <c- u>"beschikbaar"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"owner"</c-><c- p>:</c-> <c- u>"Gemeente Amsterdam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"publisher"</c-><c- p>:</c-> <c- u>"myDataTeam"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"creator"</c-><c- p>:</c-> <c- u>"myBronhouder"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"authorizationGrantor"</c-><c- p>:</c-> <c- u>"myDataTeam@amsterdam.nl"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">  <c- f>"tables"</c-><c- p>:</c-> <c- p>[</c-></span><span class="line-no"></span><span class="line">    <c- p>{</c-></span><span class="line-no"></span><span class="line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-><c- p>,</c-></span><span class="line-no"></span><span class="line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"personen"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="15"></span><span class="line highlight-line">      <c- f>"activeVersions"</c-><c- p>:</c-> <c- p>{</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">        <c- f>"1.3.0"</c-><c- p>:</c-> <c- u>"personen/v1.3.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="17"></span><span class="line highlight-line">        <c- f>"2.0.1"</c-><c- p>:</c-> <c- u>"personen/v2.0.1"</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">      <c- p>}</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">    <c- p>},</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">    <c- p>{</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">      <c- f>"$ref"</c-><c- p>:</c-> <c- u>"locaties/v1.0.0"</c-><c- p>,</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">      <c- f>"id"</c-><c- p>:</c-> <c- u>"locaties"</c-></span><span class="line-no"></span><span class="line">    <c- p>}</c-></span><span class="line-no"></span><span class="line">  <c- p>]</c-></span><span class="line-no"></span><span class="line"><c- p>}</c-></span></pre>
     </div>
    </div>
-   <p class="note" role="note"><span>Note:</span> Deze semantic versioning standaard is geinspireerd door <a data-biblio-display="inline" data-link-type="biblio" href="https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/"><cite>SchemaVer</cite></a> wat weer is gebaseerd op <a data-biblio-display="inline" data-link-type="biblio" href="https://semver.org/"><cite>SemVer</cite></a>.</p>
+   <p class="note" role="note"><span>Note:</span> Deze semantic versioning standaard is geinspireerd door <a data-biblio-display="inline" data-link-type="biblio" href="https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/">SchemaVer</a> wat weer is gebaseerd op <a data-biblio-display="inline" data-link-type="biblio" href="https://semver.org/">SemVer</a>.</p>
    <h2 class="heading settled" data-level="4" id="fields"><span class="secno">4. </span><span class="content">Veld</span><a class="self-link" href="#fields"></a></h2>
     Een veld beschrijft een eigenschap die een rij in de tabel mag of moet (zie <code class="idl"><a data-link-type="idl" href="#dom-schema-required" id="ref-for-dom-schema-required">required</a></code>) bezitten.
 Een <a data-link-type="dfn" href="#veld" id="ref-for-veld⑨">veld</a> is een concrete JSON Schema type definiering waaraan ook meta-informatie kan worden meegegeven.
@@ -2920,7 +2918,7 @@ Een <a data-link-type="dfn" href="#veld" id="ref-for-veld⑨">veld</a> is een co
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="veld" data-dfn-type="attribute" data-export id="dom-veld-type"><code class="highlight">type</code></dfn>
       <td> string
       <td>
-        <a href="#data-types"> Data type</a> van het veld.  Volgens <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.1">JSON Schema § rfc.section.6.1.1</a>. Zie <a href="#data-types">§ 4.3 Data types</a> voor details.
+        <a href="#data-types"> Data type</a> van het veld.  Volgens <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.1">JSON Schema §rfc.section.6.1.1</a>. Zie <a href="#data-types">§ 4.3 Data types</a> voor details.
        <details>
         <summary>Toegestane waarden</summary>
         <ul>
@@ -3058,7 +3056,7 @@ Een <a data-link-type="dfn" href="#veld" id="ref-for-veld⑨">veld</a> is een co
       <td><dfn class="dfn-paneled idl-code" data-dfn-for="veld" data-dfn-type="attribute" data-export id="dom-veld-format"><code class="highlight">format</code></dfn>
       <td> string
       <td>
-        String formats (voor string type) Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3">JSON Schema § rfc.section.7.3</a>.
+        String formats (voor string type) Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3">JSON Schema §rfc.section.7.3</a>.
        <details>
         <summary>Opties</summary>
         <ul>
@@ -3141,7 +3139,7 @@ welke (SQL) data typen gebruikt zouden moeten worden om de JSON Schema typen te 
    <p class="note" role="note"><span>Note:</span> Elk veld is nullable tenzij het als <code class="highlight">required</code> property is opgegeven, zie <code class="idl"><a data-link-type="idl" href="#dom-schema-required" id="ref-for-dom-schema-required①">required</a></code>.</p>
    <h4 class="heading settled" data-level="4.3.1" id="data-types-int"><span class="secno">4.3.1. </span><span class="content">integer</span><a class="self-link" href="#data-types-int"></a></h4>
     Een integer bevat de (decimale representatie van) een 64-bits signed integer.
-    Een integer in Amsterdam Schema heeft dus een range van <code class="highlight"><c- p>[</c-><c- o>-</c-><c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>63</c-><c- p>),</c-> <c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>63</c-><c- p>)</c-><c- o>-</c-><c- mf>1</c-><c- p>]</c-></code>, maar gebruik van getallen buiten het bereik <code class="highlight"><c- p>[</c-><c- o>-</c-><c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>53</c-><c- p>)</c-><c- o>+</c-><c- mf>1</c-><c- p>,</c-> <c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>53</c-><c- p>)</c-><c- o>-</c-><c- mf>1</c-><c- p>]</c-></code> wordt in lijn met <a href="https://datatracker.ietf.org/doc/html/rfc7159#section-6">RFC7159 § section-6</a> afgeraden omdat dit door veelgebruikte doelsystemen (<a data-link-type="biblio" href="#biblio-ieee754">[IEEE754]</a>)
+    Een integer in Amsterdam Schema heeft dus een range van <code class="highlight"><c- p>[</c-><c- o>-</c-><c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>63</c-><c- p>),</c-> <c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>63</c-><c- p>)</c-><c- o>-</c-><c- mf>1</c-><c- p>]</c-></code>, maar gebruik van getallen buiten het bereik <code class="highlight"><c- p>[</c-><c- o>-</c-><c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>53</c-><c- p>)</c-><c- o>+</c-><c- mf>1</c-><c- p>,</c-> <c- p>(</c-><c- mf>2</c-><c- o>^</c-><c- mf>53</c-><c- p>)</c-><c- o>-</c-><c- mf>1</c-><c- p>]</c-></code> wordt in lijn met <a href="https://datatracker.ietf.org/doc/html/rfc7159#section-6">RFC7159 §section-6</a> afgeraden omdat dit door veelgebruikte doelsystemen (<a data-link-type="biblio" href="#biblio-ieee754">[IEEE754]</a>)
     niet wordt ondersteund. Als een <code class="idl"><a data-link-type="idl" href="#dom-veld-maximum" id="ref-for-dom-veld-maximum②">maximum</a></code> en/of <code class="idl"><a data-link-type="idl" href="#dom-veld-minimum" id="ref-for-dom-veld-minimum②">minimum</a></code> buiten de laatst genoemde range is ingesteld wordt een waarschuwing gegeven.
    <div class="example" id="example-0e34422e">
     <a class="self-link" href="#example-0e34422e"></a> Dit veld bevat een 64-bits signed integer, zoals een "BIGINT" in SQL.
@@ -3562,7 +3560,7 @@ en twee <code class="highlight">properties</code> bevatten, met namen en types d
    <p>Het is mogelijk om bij een veld de eenheid mee te geven in het <code class="idl"><a data-link-type="idl" href="#dom-veld-unit" id="ref-for-dom-veld-unit①">unit</a></code> attribuut als meta-informatie voor user interfaces.
 Dit is slechts bedoeld ter informatie van de eindgebruiker,
 er worden dus geen automatische bewerkingen (zoals bijvoorbeeld eenheid conversies) uitgevoerd op basis van dit veld.</p>
-   <p>Voor het definieren van een eenheid wordt standaard een string met de eenheid volgens de <a data-biblio-display="inline" data-link-type="biblio" href="https://unitsofmeasure.org/ucum.html"><cite>The Unified Code for Units of Measure</cite></a> codering gebruikt.</p>
+   <p>Voor het definieren van een eenheid wordt standaard een string met de eenheid volgens de <a data-biblio-display="inline" data-link-type="biblio" href="https://unitsofmeasure.org/ucum.html">The Unified Code for Units of Measure</a> codering gebruikt.</p>
 <pre class="example highlight" id="example-989e57f4"><a class="self-link" href="#example-989e57f4"></a><c- f>"unit"</c-><c- p>:</c-> <c- u>"mm/h"</c->
 </pre>
    <p class="note" role="note"><span>Note:</span> Zie <a href="https://ucum.org/trac/wiki/adoption/common">deze link</a> voor een overzicht van veelgebruikte eenheden in UCUM-format.</p>
@@ -3604,7 +3602,7 @@ aan een strak stramien voldoet.
     <li><dfn data-dfn-type="dfn" data-export data-lt="unique" id="unique">4.<a class="self-link" href="#unique"></a></dfn> uniek zijn binnen hun scope. (respectievelijk: De hele catalogus, de dataset of de tabel)
    </ul>
     De namen van <a data-link-type="dfn" href="#tabel" id="ref-for-tabel①⓪">tabellen</a> (zoals gegeven in <code class="idl"><a data-link-type="idl" href="#dom-tabel-id" id="ref-for-dom-tabel-id②">id</a></code>) en <a data-link-type="dfn" href="#veld" id="ref-for-veld②④">velden</a> worden onderdeel van de URI waarop deze entiteiten ontsloten worden, en moeten daarom aan extra eisen voldoen.
-   <p><dfn data-dfn-type="dfn" data-export data-lt="plural" id="plural">5.<a class="self-link" href="#plural"></a></dfn> Namen van tabellen <strong>moeten</strong> in meervoudsvorm zijn, behalve als sprake is van een enkelvoudige entiteit. Conform <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/#api-54">REST-API Design Rules § api-54</a>.</p>
+   <p><dfn data-dfn-type="dfn" data-export data-lt="plural" id="plural">5.<a class="self-link" href="#plural"></a></dfn> Namen van tabellen <strong>moeten</strong> in meervoudsvorm zijn, behalve als sprake is van een enkelvoudige entiteit. Conform <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/#api-54">REST-API Design Rules §api-54</a>.</p>
    <p><dfn data-dfn-type="dfn" data-export data-lt="noRepeat" id="norepeat">6.<a class="self-link" href="#norepeat"></a></dfn> Namen van velden <strong>moeten</strong> geen herhaling van de tabel naam bevatten. (Dus <strong>niet</strong> <code class="highlight">container<c- p>.</c->containerNummmer</code>, maar <code class="highlight">container<c- p>.</c->nummer</code>.)</p>
    <p class="note" role="note"><span>Note:</span> Gebruik duidelijke en begrijpelijke namen voor zowel datasets, tabellen als velden. De data wordt onsloten op een publieke API,
     dus de naamgeving moet zonder veel uitleg duidelijk zijn voor externe afnemers.</p>
@@ -3736,20 +3734,20 @@ Scope <code class="highlight"><c- u>"LEVEL/A"</c-></code> heeft dataset level au
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-date-time"><code class="highlight">date<c- o>-</c->time</code></dfn>
       <td> (string)
-      <td> Een als datetime geformatteerde string. Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.1">JSON Schema § rfc.section.7.3.1</a>.
+      <td> Een als datetime geformatteerde string. Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.1">JSON Schema §rfc.section.7.3.1</a>.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export data-lt="uri|uri-type" id="typedefdef-uri"><code class="highlight">uri</code></dfn>
       <td> (string)
-      <td> Een als URI geformatteerde string. Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.5">JSON Schema § rfc.section.7.3.5</a>.
+      <td> Een als URI geformatteerde string. Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.5">JSON Schema §rfc.section.7.3.5</a>.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-uri-reference"><code class="highlight">uri<c- o>-</c->reference</code></dfn>
       <td> (string)
-      <td> Een als URI Reference geformatteerde string. Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.5">JSON Schema § rfc.section.7.3.5</a>.
+      <td> Een als URI Reference geformatteerde string. Conform <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.5">JSON Schema §rfc.section.7.3.5</a>.
      <tr>
       <td><dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export data-lt="type|schema-type" id="typedefdef-type"><code class="highlight">schema<c- o>-</c->type</code></dfn>
       <td> (enum-string)
       <td>
-        Het binnen Amsterdam Schema bekende <a data-biblio-display="inline" data-link-type="biblio" href="https://json-schema.org/draft/2020-12/json-schema-core.html"><cite>JSON Schema</cite></a> type waaraan het object voldoet.
+        Het binnen Amsterdam Schema bekende <a data-biblio-display="inline" data-link-type="biblio" href="https://json-schema.org/draft/2020-12/json-schema-core.html">JSON Schema</a> type waaraan het object voldoet.
        <details>
         <summary>Opties</summary>
         <ul>
@@ -3789,233 +3787,252 @@ Scope <code class="highlight"><c- u>"LEVEL/A"</c-></code> heeft dataset level au
          <p><dfn class="idl-code" data-dfn-for="contact" data-dfn-type="attribute" data-noexport id="dom-contact-email"><code class="highlight">email</code><a class="self-link" href="#dom-contact-email"></a></dfn> (string) Email adres van het contact</p>
        </ul>
    </table>
+   <h2 class="heading settled" data-level="8" id="changelog"><span class="secno">8. </span><span class="content">Changelog</span><a class="self-link" href="#changelog"></a></h2>
+    Dit is een chronologisch overzicht van aanpassingen aan de amsterdam-schema specificatie.
+Uitsluitend normatieve aanpassingen aan de specificatie worden vermeld. Aanpassingen aan voorbeelden,
+waarschuwingen of uitleg verschijnen dus niet in dit overzicht.
+   <h3 class="heading settled" data-level="8.1" id="lastchange"><span class="secno">8.1. </span><span class="content">[2.1.0] Dataset contact gegevens (2022-03-17)</span><a class="self-link" href="#lastchange"></a></h3>
+   <blockquote>
+    <p><strong>Doelstelling</strong><br> Meerdere aanpassingen aan dataset velden voor contactgegevens.
+Met als doel om alle teams en organisaties die een rol hebben bij het ontsluiten van een dataset
+te vermelden. Zodat vragen over de dataset aan de juiste personen gericht kunnen worden.</p>
+   </blockquote>
+   <ul>
+    <li data-md>
+     <p>Nieuw optioneel veld <code class="idl"><a data-link-type="idl" href="#dom-dataset-creator" id="ref-for-dom-dataset-creator">creator</a></code> toegevoegd.</p>
+    <li data-md>
+     <p>Het veld <code class="idl"><a data-link-type="idl" href="#dom-dataset-publisher" id="ref-for-dom-dataset-publisher">publisher</a></code> heeft geen constant waarde meer. En bevat nu de naam van het datateam dat de dataset ontsluit.</p>
+    <li data-md>
+     <p>Het veld <code class="idl"><a data-link-type="idl" href="#dom-dataset-contactpoint" id="ref-for-dom-dataset-contactpoint">contactPoint</a></code> is nu optioneel en bevat een standaard waarde.</p>
+   </ul>
    <div style="display:none"> <a data-biblio-display="inline" data-link-type="biblio" href="https://json-schema.org/draft/2020-12/json-schema-validation.html"> </a> <a data-biblio-display="inline" data-link-type="biblio" href="https://www.w3.org/TR/sdw-bp/"> </a> <a data-link-type="biblio" href="#biblio-rest-api-design-rules">[REST-API-DESIGN-RULES]</a> <a data-link-type="biblio" href="#biblio-rfc7159">[RFC7159]</a> <a data-link-type="biblio" href="#biblio-json-schema-string">[json-schema-string]</a> </div>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-dataset-accrualperiodicity">accrualPeriodicity</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-table-ref-activeversions">activeVersions</a><span>, in § 2.3</span>
-   <li><a href="#dom-schema-additionalproperties">additionalProperties</a><span>, in § 3.3</span>
+   <li><a href="#dom-dataset-accrualperiodicity">accrualPeriodicity</a><span>, in §2.2.1</span>
+   <li><a href="#dom-table-ref-activeversions">activeVersions</a><span>, in §2.3</span>
+   <li><a href="#dom-schema-additionalproperties">additionalProperties</a><span>, in §3.3</span>
    <li>
     auth
     <ul>
-     <li><a href="#dom-dataset-auth">attribute for dataset</a><span>, in § 2.2</span>
-     <li><a href="#dom-tabel-auth">attribute for tabel</a><span>, in § 3.2</span>
-     <li><a href="#dom-veld-auth">attribute for veld</a><span>, in § 4.2</span>
-     <li><a href="#auth">definition of</a><span>, in § 6.2</span>
+     <li><a href="#dom-dataset-auth">attribute for dataset</a><span>, in §2.2</span>
+     <li><a href="#dom-tabel-auth">attribute for tabel</a><span>, in §3.2</span>
+     <li><a href="#dom-veld-auth">attribute for veld</a><span>, in §4.2</span>
+     <li><a href="#auth">definition of</a><span>, in §6.2</span>
     </ul>
-   <li><a href="#dom-dataset-authorizationgrantor">authorizationGrantor</a><span>, in § 2.1</span>
-   <li><a href="#camelcase">camelCase</a><span>, in § 5</span>
-   <li><a href="#dom-veld-comment">$comment</a><span>, in § 4.2</span>
-   <li><a href="#typedefdef-contact">contact</a><span>, in § 7</span>
+   <li><a href="#dom-dataset-authorizationgrantor">authorizationGrantor</a><span>, in §2.1</span>
+   <li><a href="#camelcase">camelCase</a><span>, in §5</span>
+   <li><a href="#dom-veld-comment">$comment</a><span>, in §4.2</span>
+   <li><a href="#typedefdef-contact">contact</a><span>, in §7</span>
    <li>
     contactPoint
     <ul>
-     <li><a href="#typedefdef-contact">(typedef)</a><span>, in § 7</span>
-     <li><a href="#dom-dataset-contactpoint">attribute for dataset</a><span>, in § 2.1</span>
+     <li><a href="#typedefdef-contact">(typedef)</a><span>, in §7</span>
+     <li><a href="#dom-dataset-contactpoint">attribute for dataset</a><span>, in §2.2</span>
     </ul>
-   <li><a href="#dom-veld-contentencoding">contentEncoding</a><span>, in § 4.2</span>
-   <li><a href="#dom-dataset-crs">crs</a><span>, in § 2.2.1</span>
-   <li><a href="#dataset">dataset</a><span>, in § 2.1</span>
+   <li><a href="#dom-veld-contentencoding">contentEncoding</a><span>, in §4.2</span>
+   <li><a href="#dom-dataset-creator">creator</a><span>, in §2.1</span>
+   <li><a href="#dom-dataset-crs">crs</a><span>, in §2.2.1</span>
+   <li><a href="#dataset">dataset</a><span>, in §2.1</span>
    <li>
     dateCreated
     <ul>
-     <li><a href="#dom-dataset-datecreated">attribute for dataset</a><span>, in § 2.2.1</span>
-     <li><a href="#dom-tabel-datecreated">attribute for tabel</a><span>, in § 3.2</span>
+     <li><a href="#dom-dataset-datecreated">attribute for dataset</a><span>, in §2.2.1</span>
+     <li><a href="#dom-tabel-datecreated">attribute for tabel</a><span>, in §3.2</span>
     </ul>
    <li>
     dateModified
     <ul>
-     <li><a href="#dom-dataset-datemodified">attribute for dataset</a><span>, in § 2.2.1</span>
-     <li><a href="#dom-tabel-datemodified">attribute for tabel</a><span>, in § 3.2</span>
+     <li><a href="#dom-dataset-datemodified">attribute for dataset</a><span>, in §2.2.1</span>
+     <li><a href="#dom-tabel-datemodified">attribute for tabel</a><span>, in §3.2</span>
     </ul>
-   <li><a href="#typedefdef-date-time">date-time</a><span>, in § 7</span>
+   <li><a href="#typedefdef-date-time">date-time</a><span>, in §7</span>
    <li>
     description
     <ul>
-     <li><a href="#dom-dataset-description">attribute for dataset</a><span>, in § 2.2</span>
-     <li><a href="#dom-tabel-description">attribute for tabel</a><span>, in § 3.2</span>
-     <li><a href="#dom-veld-description">attribute for veld</a><span>, in § 4.2</span>
+     <li><a href="#dom-dataset-description">attribute for dataset</a><span>, in §2.2</span>
+     <li><a href="#dom-tabel-description">attribute for tabel</a><span>, in §3.2</span>
+     <li><a href="#dom-veld-description">attribute for veld</a><span>, in §4.2</span>
     </ul>
-   <li><a href="#dom-temporal-dimensionsgeldigop">dimensions.geldigOp</a><span>, in § 3.4</span>
-   <li><a href="#dom-schema-display">display</a><span>, in § 3.3</span>
-   <li><a href="#dom-contact-email">email</a><span>, in § 7</span>
-   <li><a href="#dom-veld-enum">enum</a><span>, in § 4.2</span>
-   <li><a href="#dom-veld-exclusivemaximum">exclusiveMaximum</a><span>, in § 4.2</span>
-   <li><a href="#dom-veld-format">format</a><span>, in § 4.2</span>
-   <li><a href="#dom-dataset-hasbeginning">hasBeginning</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-hasend">hasEnd</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-homepage">homepage</a><span>, in § 2.2</span>
-   <li><a href="#dom-schema-id">$id</a><span>, in § 3.3</span>
+   <li><a href="#dom-temporal-dimensionsgeldigop">dimensions.geldigOp</a><span>, in §3.4</span>
+   <li><a href="#dom-schema-display">display</a><span>, in §3.3</span>
+   <li><a href="#dom-contact-email">email</a><span>, in §7</span>
+   <li><a href="#dom-veld-enum">enum</a><span>, in §4.2</span>
+   <li><a href="#dom-veld-exclusivemaximum">exclusiveMaximum</a><span>, in §4.2</span>
+   <li><a href="#dom-veld-format">format</a><span>, in §4.2</span>
+   <li><a href="#dom-dataset-hasbeginning">hasBeginning</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-hasend">hasEnd</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-homepage">homepage</a><span>, in §2.2</span>
+   <li><a href="#dom-schema-id">$id</a><span>, in §3.3</span>
    <li>
     id
     <ul>
-     <li><a href="#typedefdef-id">(typedef)</a><span>, in § 7</span>
-     <li><a href="#dom-dataset-id">attribute for dataset</a><span>, in § 2.1</span>
-     <li><a href="#dom-tabel-id">attribute for tabel</a><span>, in § 3.1</span>
-     <li><a href="#dom-table-ref-id">attribute for table-ref</a><span>, in § 2.3</span>
+     <li><a href="#typedefdef-id">(typedef)</a><span>, in §7</span>
+     <li><a href="#dom-dataset-id">attribute for dataset</a><span>, in §2.1</span>
+     <li><a href="#dom-tabel-id">attribute for tabel</a><span>, in §3.1</span>
+     <li><a href="#dom-table-ref-id">attribute for table-ref</a><span>, in §2.3</span>
     </ul>
    <li>
     identifier
     <ul>
-     <li><a href="#dom-schema-identifier">attribute for schema</a><span>, in § 3.3</span>
-     <li><a href="#dom-temporal-identifier">attribute for temporal</a><span>, in § 3.4</span>
+     <li><a href="#dom-schema-identifier">attribute for schema</a><span>, in §3.3</span>
+     <li><a href="#dom-temporal-identifier">attribute for temporal</a><span>, in §3.4</span>
     </ul>
-   <li><a href="#typedefdef-id">id-type</a><span>, in § 7</span>
-   <li><a href="#dom-veld-items">items</a><span>, in § 4.2</span>
-   <li><a href="#dom-dataset-keywords">keywords</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-language">language</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-legalbasis">legalBasis</a><span>, in § 2.2.1</span>
+   <li><a href="#typedefdef-id">id-type</a><span>, in §7</span>
+   <li><a href="#dom-veld-items">items</a><span>, in §4.2</span>
+   <li><a href="#dom-dataset-keywords">keywords</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-language">language</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-legalbasis">legalBasis</a><span>, in §2.2.1</span>
    <li>
     license
     <ul>
-     <li><a href="#dom-dataset-license">attribute for dataset</a><span>, in § 2.2.1</span>
-     <li><a href="#dom-tabel-license">attribute for tabel</a><span>, in § 3.2</span>
+     <li><a href="#dom-dataset-license">attribute for dataset</a><span>, in §2.2.1</span>
+     <li><a href="#dom-tabel-license">attribute for tabel</a><span>, in §3.2</span>
     </ul>
-   <li><a href="#dom-schema-maingeometry">mainGeometry</a><span>, in § 3.3</span>
-   <li><a href="#dom-veld-maximum">maximum</a><span>, in § 4.2</span>
-   <li><a href="#dom-veld-maxlength">maxLength</a><span>, in § 4.2</span>
-   <li><a href="#dom-veld-minimum">minimum</a><span>, in § 4.2</span>
-   <li><a href="#dom-veld-minlength">minLength</a><span>, in § 4.2</span>
-   <li><a href="#dom-veld-multipleof">multipleOf</a><span>, in § 4.2</span>
-   <li><a href="#dom-contact-name">name</a><span>, in § 7</span>
-   <li><a href="#noabrev">noAbrev</a><span>, in § 5</span>
-   <li><a href="#norepeat">noRepeat</a><span>, in § 5</span>
-   <li><a href="#nouns">nouns</a><span>, in § 5</span>
-   <li><a href="#dom-dataset-objective">objective</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-owner">owner</a><span>, in § 2.1</span>
-   <li><a href="#plural">plural</a><span>, in § 5</span>
+   <li><a href="#dom-schema-maingeometry">mainGeometry</a><span>, in §3.3</span>
+   <li><a href="#dom-veld-maximum">maximum</a><span>, in §4.2</span>
+   <li><a href="#dom-veld-maxlength">maxLength</a><span>, in §4.2</span>
+   <li><a href="#dom-veld-minimum">minimum</a><span>, in §4.2</span>
+   <li><a href="#dom-veld-minlength">minLength</a><span>, in §4.2</span>
+   <li><a href="#dom-veld-multipleof">multipleOf</a><span>, in §4.2</span>
+   <li><a href="#dom-contact-name">name</a><span>, in §7</span>
+   <li><a href="#noabrev">noAbrev</a><span>, in §5</span>
+   <li><a href="#norepeat">noRepeat</a><span>, in §5</span>
+   <li><a href="#nouns">nouns</a><span>, in §5</span>
+   <li><a href="#dom-dataset-objective">objective</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-owner">owner</a><span>, in §2.1</span>
+   <li><a href="#plural">plural</a><span>, in §5</span>
    <li>
     properties
     <ul>
-     <li><a href="#dom-schema-properties">attribute for schema</a><span>, in § 3.3</span>
-     <li><a href="#dom-veld-properties">attribute for veld</a><span>, in § 4.2</span>
+     <li><a href="#dom-schema-properties">attribute for schema</a><span>, in §3.3</span>
+     <li><a href="#dom-veld-properties">attribute for veld</a><span>, in §4.2</span>
     </ul>
-   <li><a href="#dom-schema-propertiesschema">properties.schema</a><span>, in § 3.3</span>
+   <li><a href="#dom-schema-propertiesschema">properties.schema</a><span>, in §3.3</span>
    <li>
     provenance
     <ul>
-     <li><a href="#dom-dataset-provenance">attribute for dataset</a><span>, in § 2.2</span>
-     <li><a href="#dom-tabel-provenance">attribute for tabel</a><span>, in § 3.2</span>
-     <li><a href="#dom-veld-provenance">attribute for veld</a><span>, in § 4.2</span>
+     <li><a href="#dom-dataset-provenance">attribute for dataset</a><span>, in §2.2</span>
+     <li><a href="#dom-tabel-provenance">attribute for tabel</a><span>, in §3.2</span>
+     <li><a href="#dom-veld-provenance">attribute for veld</a><span>, in §4.2</span>
     </ul>
-   <li><a href="#dom-dataset-publisher">publisher</a><span>, in § 2.1</span>
+   <li><a href="#dom-dataset-publisher">publisher</a><span>, in §2.1</span>
    <li>
     ref
     <ul>
-     <li><a href="#dom-table-ref-ref">attribute for table-ref</a><span>, in § 2.3</span>
-     <li><a href="#dom-veld-ref">attribute for veld</a><span>, in § 4.1</span>
+     <li><a href="#dom-table-ref-ref">attribute for table-ref</a><span>, in §2.3</span>
+     <li><a href="#dom-veld-ref">attribute for veld</a><span>, in §4.1</span>
     </ul>
-   <li><a href="#dom-veld-relation">relation</a><span>, in § 4.2</span>
-   <li><a href="#dom-schema-required">required</a><span>, in § 3.3</span>
-   <li><a href="#dom-schema-schema">$schema</a><span>, in § 3.3</span>
+   <li><a href="#dom-veld-relation">relation</a><span>, in §4.2</span>
+   <li><a href="#dom-schema-required">required</a><span>, in §3.3</span>
+   <li><a href="#dom-schema-schema">$schema</a><span>, in §3.3</span>
    <li>
     schema
     <ul>
-     <li><a href="#dom-tabel-schema">attribute for tabel</a><span>, in § 3.1</span>
-     <li><a href="#schema">definition of</a><span>, in § 3.3</span>
+     <li><a href="#dom-tabel-schema">attribute for tabel</a><span>, in §3.1</span>
+     <li><a href="#schema">definition of</a><span>, in §3.3</span>
     </ul>
-   <li><a href="#schema">schema-object</a><span>, in § 3.3</span>
-   <li><a href="#typedefdef-type">schema-type</a><span>, in § 7</span>
-   <li><a href="#scope">scope</a><span>, in § 6.2</span>
+   <li><a href="#schema">schema-object</a><span>, in §3.3</span>
+   <li><a href="#typedefdef-type">schema-type</a><span>, in §7</span>
+   <li><a href="#scope">scope</a><span>, in §6.2</span>
    <li>
     shortname
     <ul>
-     <li><a href="#dom-tabel-shortname">attribute for tabel</a><span>, in § 3.2</span>
-     <li><a href="#dom-veld-shortname">attribute for veld</a><span>, in § 4.2</span>
+     <li><a href="#dom-tabel-shortname">attribute for tabel</a><span>, in §3.2</span>
+     <li><a href="#dom-veld-shortname">attribute for veld</a><span>, in §4.2</span>
     </ul>
-   <li><a href="#dom-dataset-spatial">spatial</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-spatialcoordinates">spatialCoordinates</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-spatialdescription">spatialDescription</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-status">status</a><span>, in § 2.1</span>
-   <li><a href="#tabel">tabel</a><span>, in § 3.1</span>
-   <li><a href="#tabel-referentie">tabel referentie</a><span>, in § 2.3</span>
-   <li><a href="#dom-dataset-tables">tables</a><span>, in § 2.1</span>
+   <li><a href="#dom-dataset-spatial">spatial</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-spatialcoordinates">spatialCoordinates</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-spatialdescription">spatialDescription</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-status">status</a><span>, in §2.1</span>
+   <li><a href="#tabel">tabel</a><span>, in §3.1</span>
+   <li><a href="#tabel-referentie">tabel referentie</a><span>, in §2.3</span>
+   <li><a href="#dom-dataset-tables">tables</a><span>, in §2.1</span>
    <li>
     temporal
     <ul>
-     <li><a href="#dom-tabel-temporal">attribute for tabel</a><span>, in § 3.2</span>
-     <li><a href="#temporal-object">definition of</a><span>, in § 3.4</span>
+     <li><a href="#dom-tabel-temporal">attribute for tabel</a><span>, in §3.2</span>
+     <li><a href="#temporal-object">definition of</a><span>, in §3.4</span>
     </ul>
-   <li><a href="#temporal-object">temporal-object</a><span>, in § 3.4</span>
-   <li><a href="#dom-dataset-temporalunit">temporalUnit</a><span>, in § 2.2.1</span>
-   <li><a href="#dom-dataset-theme">theme</a><span>, in § 2.2.1</span>
+   <li><a href="#temporal-object">temporal-object</a><span>, in §3.4</span>
+   <li><a href="#dom-dataset-temporalunit">temporalUnit</a><span>, in §2.2.1</span>
+   <li><a href="#dom-dataset-theme">theme</a><span>, in §2.2.1</span>
    <li>
     title
     <ul>
-     <li><a href="#dom-dataset-title">attribute for dataset</a><span>, in § 2.2</span>
-     <li><a href="#dom-tabel-title">attribute for tabel</a><span>, in § 3.2</span>
-     <li><a href="#dom-veld-title">attribute for veld</a><span>, in § 4.2</span>
+     <li><a href="#dom-dataset-title">attribute for dataset</a><span>, in §2.2</span>
+     <li><a href="#dom-tabel-title">attribute for tabel</a><span>, in §3.2</span>
+     <li><a href="#dom-veld-title">attribute for veld</a><span>, in §4.2</span>
     </ul>
    <li>
     type
     <ul>
-     <li><a href="#typedefdef-type">(typedef)</a><span>, in § 7</span>
-     <li><a href="#dom-dataset-type">attribute for dataset</a><span>, in § 2.1</span>
-     <li><a href="#dom-schema-type">attribute for schema</a><span>, in § 3.3</span>
-     <li><a href="#dom-tabel-type">attribute for tabel</a><span>, in § 3.1</span>
-     <li><a href="#dom-unit-type">attribute for unit</a><span>, in § 4.5</span>
-     <li><a href="#dom-veld-type">attribute for veld</a><span>, in § 4.1</span>
+     <li><a href="#typedefdef-type">(typedef)</a><span>, in §7</span>
+     <li><a href="#dom-dataset-type">attribute for dataset</a><span>, in §2.1</span>
+     <li><a href="#dom-schema-type">attribute for schema</a><span>, in §3.3</span>
+     <li><a href="#dom-tabel-type">attribute for tabel</a><span>, in §3.1</span>
+     <li><a href="#dom-unit-type">attribute for unit</a><span>, in §4.5</span>
+     <li><a href="#dom-veld-type">attribute for veld</a><span>, in §4.1</span>
     </ul>
-   <li><a href="#unique">unique</a><span>, in § 5</span>
-   <li><a href="#dom-veld-unit">unit</a><span>, in § 4.2</span>
+   <li><a href="#unique">unique</a><span>, in §5</span>
+   <li><a href="#dom-veld-unit">unit</a><span>, in §4.2</span>
    <li>
     uri
     <ul>
-     <li><a href="#typedefdef-uri">(typedef)</a><span>, in § 7</span>
-     <li><a href="#dom-veld-uri">attribute for veld</a><span>, in § 4.2</span>
+     <li><a href="#typedefdef-uri">(typedef)</a><span>, in §7</span>
+     <li><a href="#dom-veld-uri">attribute for veld</a><span>, in §4.2</span>
     </ul>
-   <li><a href="#typedefdef-uri-reference">uri-reference</a><span>, in § 7</span>
-   <li><a href="#typedefdef-uri">uri-type</a><span>, in § 7</span>
-   <li><a href="#dom-unit-value">value</a><span>, in § 4.5</span>
-   <li><a href="#veld">veld</a><span>, in § 4.1</span>
+   <li><a href="#typedefdef-uri-reference">uri-reference</a><span>, in §7</span>
+   <li><a href="#typedefdef-uri">uri-type</a><span>, in §7</span>
+   <li><a href="#dom-unit-value">value</a><span>, in §4.5</span>
+   <li><a href="#veld">veld</a><span>, in §4.1</span>
    <li>
     version
     <ul>
-     <li><a href="#typedefdef-version">(typedef)</a><span>, in § 7</span>
-     <li><a href="#dom-dataset-version">attribute for dataset</a><span>, in § 2.2</span>
-     <li><a href="#dom-tabel-version">attribute for tabel</a><span>, in § 3.1</span>
+     <li><a href="#typedefdef-version">(typedef)</a><span>, in §7</span>
+     <li><a href="#dom-dataset-version">attribute for dataset</a><span>, in §2.2</span>
+     <li><a href="#dom-tabel-version">attribute for tabel</a><span>, in §3.1</span>
     </ul>
-   <li><a href="#typedefdef-version">version-string</a><span>, in § 7</span>
+   <li><a href="#typedefdef-version">version-string</a><span>, in §7</span>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-json-schema">[JSON-SCHEMA]
-   <dd><a href="https://json-schema.org/draft/2020-12/json-schema-core.html"><cite>JSON Schema</cite></a>. URL: <a href="https://json-schema.org/draft/2020-12/json-schema-core.html">https://json-schema.org/draft/2020-12/json-schema-core.html</a>
+   <dd><a href="https://json-schema.org/draft/2020-12/json-schema-core.html">JSON Schema</a>. URL: <a href="https://json-schema.org/draft/2020-12/json-schema-core.html">https://json-schema.org/draft/2020-12/json-schema-core.html</a>
    <dt id="biblio-json-schema-validation">[JSON-SCHEMA-VALIDATION]
-   <dd><a href="https://json-schema.org/draft/2020-12/json-schema-validation.html"><cite>JSON Schema</cite></a>. URL: <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html">https://json-schema.org/draft/2020-12/json-schema-validation.html</a>
+   <dd><a href="https://json-schema.org/draft/2020-12/json-schema-validation.html">JSON Schema</a>. URL: <a href="https://json-schema.org/draft/2020-12/json-schema-validation.html">https://json-schema.org/draft/2020-12/json-schema-validation.html</a>
    <dt id="biblio-ucum">[UCUM]
-   <dd><a href="https://unitsofmeasure.org/ucum.html"><cite>The Unified Code for Units of Measure</cite></a>. URL: <a href="https://unitsofmeasure.org/ucum.html">https://unitsofmeasure.org/ucum.html</a>
+   <dd><a href="https://unitsofmeasure.org/ucum.html">The Unified Code for Units of Measure</a>. URL: <a href="https://unitsofmeasure.org/ucum.html">https://unitsofmeasure.org/ucum.html</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-ieee754">[IEEE754]
-   <dd><a href="https://datatracker.ietf.org/doc/html/rfc7159#ref-IEEE754"><cite>IEEE754</cite></a>. URL: <a href="https://datatracker.ietf.org/doc/html/rfc7159#ref-IEEE754">https://datatracker.ietf.org/doc/html/rfc7159#ref-IEEE754</a>
+   <dd><a href="https://datatracker.ietf.org/doc/html/rfc7159#ref-IEEE754">IEEE754</a>. URL: <a href="https://datatracker.ietf.org/doc/html/rfc7159#ref-IEEE754">https://datatracker.ietf.org/doc/html/rfc7159#ref-IEEE754</a>
    <dt id="biblio-iso8601">[ISO8601]
-   <dd><a href="https://www.iso.org/iso-8601-date-and-time-format.html"><cite>ISO8601</cite></a>. URL: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+   <dd><a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO8601</a>. URL: <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
    <dt id="biblio-json-schema-string">[JSON-SCHEMA-STRING]
-   <dd><a href="https://json-schema.org/understanding-json-schema/reference/string.html"><cite>JSON Schema string</cite></a>. URL: <a href="https://json-schema.org/understanding-json-schema/reference/string.html">https://json-schema.org/understanding-json-schema/reference/string.html</a>
+   <dd><a href="https://json-schema.org/understanding-json-schema/reference/string.html">JSON Schema string</a>. URL: <a href="https://json-schema.org/understanding-json-schema/reference/string.html">https://json-schema.org/understanding-json-schema/reference/string.html</a>
    <dt id="biblio-rest-api-design-rules">[REST-API-DESIGN-RULES]
-   <dd><a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/"><cite>REST-API Design Rules</cite></a>. URL: <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/">https://publicatie.centrumvoorstandaarden.nl/api/adr/</a>
+   <dd><a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/">REST-API Design Rules</a>. URL: <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/">https://publicatie.centrumvoorstandaarden.nl/api/adr/</a>
    <dt id="biblio-rfc7159">[RFC7159]
-   <dd><a href="https://datatracker.ietf.org/doc/html/rfc7159"><cite>RFC7159</cite></a>. URL: <a href="https://datatracker.ietf.org/doc/html/rfc7159">https://datatracker.ietf.org/doc/html/rfc7159</a>
+   <dd><a href="https://datatracker.ietf.org/doc/html/rfc7159">RFC7159</a>. URL: <a href="https://datatracker.ietf.org/doc/html/rfc7159">https://datatracker.ietf.org/doc/html/rfc7159</a>
    <dt id="biblio-schemver">[SCHEMVER]
-   <dd><a href="https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/"><cite>SchemaVer</cite></a>. URL: <a href="https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/">https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/</a>
+   <dd><a href="https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/">SchemaVer</a>. URL: <a href="https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/">https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/</a>
    <dt id="biblio-sdw-bp">[SDW-BP]
-   <dd><a href="https://www.w3.org/TR/sdw-bp/"><cite>SDOW best practices</cite></a>. URL: <a href="https://www.w3.org/TR/sdw-bp/">https://www.w3.org/TR/sdw-bp/</a>
+   <dd><a href="https://www.w3.org/TR/sdw-bp/">SDOW best practices</a>. URL: <a href="https://www.w3.org/TR/sdw-bp/">https://www.w3.org/TR/sdw-bp/</a>
    <dt id="biblio-semver">[SEMVER]
-   <dd><a href="https://semver.org/"><cite>SemVer</cite></a>. URL: <a href="https://semver.org/">https://semver.org/</a>
+   <dd><a href="https://semver.org/">SemVer</a>. URL: <a href="https://semver.org/">https://semver.org/</a>
    <dt id="biblio-vocab-dcat-2">[VOCAB-DCAT-2]
-   <dd>Riccardo Albertoni; et al. <a href="https://www.w3.org/TR/vocab-dcat-2/"><cite>Data Catalog Vocabulary (DCAT) - Version 2</cite></a>. 4 February 2020. REC. URL: <a href="https://www.w3.org/TR/vocab-dcat-2/">https://www.w3.org/TR/vocab-dcat-2/</a>
+   <dd>Riccardo Albertoni; et al. <a href="https://www.w3.org/TR/vocab-dcat-2/">Data Catalog Vocabulary (DCAT) - Version 2</a>. 4 February 2020. REC. URL: <a href="https://www.w3.org/TR/vocab-dcat-2/">https://www.w3.org/TR/vocab-dcat-2/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> Niet alle DCAT velden zijn gemodelleerd. Daarnaast zijn komt van sommige velden de naamgeving niet overeen met de DCAT spec. <a class="issue-return" href="#issue-794e3780" title="Jump to section">↵</a></div>
-   <div class="issue"> Sommige velden missen een beschrijving <a class="issue-return" href="#issue-fe7b94ef" title="Jump to section">↵</a></div>
-   <div class="issue"> Het identifier veld moet string zijn. De array optie wordt binnenkort verwijderd. <a class="issue-return" href="#issue-38d85a92" title="Jump to section">↵</a></div>
-   <div class="issue"> Het is onduidelijk of <code class="highlight">unit</code> in een array moet worden meegegeven in het items attribuut  als <code class="highlight">veld<c- p>.</c->items<c- p>.</c->unit</code> of in het hoofd object als <code class="highlight">veld<c- p>.</c->unit</code>. <a class="issue-return" href="#issue-44526bd2" title="Jump to section">↵</a></div>
+   <div class="issue"> Niet alle DCAT velden zijn gemodelleerd. Daarnaast zijn komt van sommige velden de naamgeving niet overeen met de DCAT spec.<a href="#issue-794e3780"> ↵ </a></div>
+   <div class="issue"> Sommige velden missen een beschrijving<a href="#issue-fe7b94ef"> ↵ </a></div>
+   <div class="issue"> Het identifier veld moet string zijn. De array optie wordt binnenkort verwijderd.<a href="#issue-38d85a92"> ↵ </a></div>
+   <div class="issue"> Het is onduidelijk of <code class="highlight">unit</code> in een array moet worden meegegeven in het items attribuut  als <code class="highlight">veld<c- p>.</c->items<c- p>.</c->unit</code> of in het hoofd object als <code class="highlight">veld<c- p>.</c->unit</code>.<a href="#issue-44526bd2"> ↵ </a></div>
   </div>
   <aside class="dfn-panel" data-for="dataset">
    <b><a href="#dataset">#dataset</a></b><b>Referenced in:</b>
@@ -4031,6 +4048,30 @@ Scope <code class="highlight"><c- u>"LEVEL/A"</c-></code> heeft dataset level au
    <b><a href="#dom-dataset-id">#dom-dataset-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dataset-id">2.1. Verplichte attributen</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-dataset-status">
+   <b><a href="#dom-dataset-status">#dom-dataset-status</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-dataset-status">2.1. Verplichte attributen</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-dataset-creator">
+   <b><a href="#dom-dataset-creator">#dom-dataset-creator</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-dataset-creator">8.1. [2.1.0] Dataset contact gegevens (2022-03-17)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-dataset-publisher">
+   <b><a href="#dom-dataset-publisher">#dom-dataset-publisher</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-dataset-publisher">8.1. [2.1.0] Dataset contact gegevens (2022-03-17)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-dataset-contactpoint">
+   <b><a href="#dom-dataset-contactpoint">#dom-dataset-contactpoint</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-dataset-contactpoint">8.1. [2.1.0] Dataset contact gegevens (2022-03-17)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-dataset-crs">
@@ -4352,7 +4393,7 @@ Scope <code class="highlight"><c- u>"LEVEL/A"</c-></code> heeft dataset level au
   <aside class="dfn-panel" data-for="typedefdef-contact">
    <b><a href="#typedefdef-contact">#typedefdef-contact</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-typedefdef-contact">2.1. Verplichte attributen</a>
+    <li><a href="#ref-for-typedefdef-contact">2.2. Optionele attributen</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/docs/examples/datasets/bekendeAmsterdammers/dataset.json
+++ b/docs/examples/datasets/bekendeAmsterdammers/dataset.json
@@ -5,12 +5,9 @@
   "description": "Bekende historische personen die in Amsterdam hebben gewoond.\n (Een voorbeeld dataset)",
   "status": "beschikbaar",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
-  "contactPoint": {
-    "name": "myDataTeam",
-    "email": "myDataTeam@amsterdam.nl"
-  },
-  "authorizationGrantor": "myDataTeam",
+  "publisher": "myDataTeam",
+  "creator": "myBronhouder",
+  "authorizationGrantor": "myDataTeam@amsterdam.nl",
   "tables": [
     {
       "$ref": "personen/v2.0.1",

--- a/docs/examples/datasets/minimaal/dataset.json
+++ b/docs/examples/datasets/minimaal/dataset.json
@@ -5,13 +5,10 @@
   "description": "Een collectie van bekende Amsterdammers.\n (Een voorbeeld dataset)",
   "version": "1.0.0",
   "status": "beschikbaar",
-  "contactPoint": {
-    "name": "Team Bekende Amsterdammers",
-    "email": "tba@amsterdam.nl"
-  },
-  "authorizationGrantor": "Team Bekende Amsterdammers",
+  "publisher": "Team Bekende Amsterdammers",
+  "creator": "myBronhouder",
+  "authorizationGrantor": "tba@amsterdam.nl",
   "owner": "Gemeente Amsterdam",
-  "publisher": "datapunt@amsterdam.nl",
   "tables": [
     {
       "$ref": "personen/v1.0.0",

--- a/schema@v1.1.1/dataset.json
+++ b/schema@v1.1.1/dataset.json
@@ -10,7 +10,6 @@
   "required": [
     "tables",
     "status",
-    "contactPoint",
     "authorizationGrantor",
     "owner",
     "publisher"
@@ -54,8 +53,12 @@
       }
     },
     "publisher": {
-      "type": "string",
-      "const": "datapunt@amsterdam.nl"
+      "description": "Naam van het datateam.",
+      "type": "string"
+    },
+    "creator": {
+      "description": "Naam van de bronhouder.",
+      "type": "string"
     },
     "owner": {
       "type": "string",
@@ -92,7 +95,11 @@
     },
     "contactPoint": {
       "description": "Person and (optional) e-mail.",
-      "$ref": "./schema@v1.1.1#/definitions/contactPoint"
+      "$ref": "./schema@v1.1.1#/definitions/contactPoint",
+      "default": {
+        "name": "datapunt",
+        "email": "datapunt@amsterdam.nl"
+      }
     },
     "crs": {
       "description": "Coordinate reference system",


### PR DESCRIPTION
 [AB#37522](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/37522) Update contact info fields in meta schema

Updates in dataset meta-schema:
* 'contactPoint' optional field
* 'publisher' is string without constant value. (Will now contain name of datateam)
* 'creator' string field is added will contain name of the bronhouder
* 'contactPoint' has a default (implicit) value datapunt@amsterdam.nl.

Updates to specification:
* Added note clarifying use of dataset status
* Updated specification in line with [AB#37522](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/37522)
* Added changelog  section with first entry for this commit ([AB#40200](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/40200))
* Added Advisement about latest change near the top of the page.

Voor preview van de nieuwe spec: https://htmlpreview.github.io/?https://github.com/Amsterdam/amsterdam-schema/blob/9c5f359eff2e401b8a827bb3892e3d1d2d259d2e/docs/ams-schema-spec.html#lastchange

Updates made to all datasets:
* Add 'creator' field for bronhouder
* 'publisher' field contains datateam
* 'contactPoint' is removed