### PR TITLE
Add `Id` postfix to `bagNummeraanduiding` for afvalwijzer

### DIFF
--- a/datasets/afvalwijzer/dataset.json
+++ b/datasets/afvalwijzer/dataset.json
@@ -195,7 +195,7 @@
             "type": "string",
             "description": "URL die verwijst naar externe of interne websites voor relevante informatie."
           },
-          "bagNummeraanduiding": {
+          "bagNummeraanduidingId": {
             "type": "string",
             "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
             "description": "Identificatie nummeraanduiding"


### PR DESCRIPTION
Field has been changed from a relation to a regular field.
So, `Id` needs to be included, to correct the schema
and make filtering possible.