### PR TITLE
Add openbaar scope back to parkeervakken

### DIFF
--- a/datasets/parkeervakken/dataset.json
+++ b/datasets/parkeervakken/dataset.json
@@ -8,6 +8,7 @@
   "owner": "Gemeente Amsterdam",
   "creator": "bronhouder onbekend",
   "publisher": "Datateam Mobiliteit",
+  "auth": "OPENBAAR",
   "authorizationGrantor": "n.v.t.",
   "tables": [
     {


### PR DESCRIPTION
removed this for debugging geosearch