### PR TITLE
AB#44431 creator required in metaschema

### DIFF
--- a/schema@v1.1.1/dataset.json
+++ b/schema@v1.1.1/dataset.json
@@ -10,6 +10,7 @@
   "required": [
     "tables",
     "status",
+    "creator",
     "authorizationGrantor",
     "owner",
     "publisher",

--- a/schema@v1.1.1/dataset.json
+++ b/schema@v1.1.1/dataset.json
@@ -56,18 +56,25 @@
     },
     "publisher": {
       "description": "Naam van het datateam.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "creator": {
       "description": "Naam van de bronhouder.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "const": "bronhouder onbekend"
+      }
     },
     "owner": {
       "type": "string",
-      "default": "Gemeente Amsterdam"
+      "default": "Gemeente Amsterdam",
+      "minLength": 1
     },
     "authorizationGrantor": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "keywords": {
       "type": "array",

--- a/schema@v1.2.0/dataset.json
+++ b/schema@v1.2.0/dataset.json
@@ -11,6 +11,7 @@
     "tables",
     "status",
     "contactPoint",
+    "creator",
     "authorizationGrantor",
     "owner",
     "publisher",

--- a/schema@v1.2.0/dataset.json
+++ b/schema@v1.2.0/dataset.json
@@ -56,15 +56,27 @@
       }
     },
     "publisher": {
+      "description": "Naam van het datateam.",
       "type": "string",
-      "const": "datapunt@amsterdam.nl"
+      "const": "datapunt@amsterdam.nl",
+      "minLength": 1
+    },
+    "creator": {
+      "description": "Naam van de bronhouder.",
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "const": "bronhouder onbekend"
+      }
     },
     "owner": {
       "type": "string",
-      "default": "Gemeente Amsterdam"
+      "default": "Gemeente Amsterdam",
+      "minLength": 1
     },
     "authorizationGrantor": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "keywords": {
       "type": "array",


### PR DESCRIPTION
Add structural validation in the jsonschema definitions.

- make `creator` required
- add `"minLength": 1` for the required fields
- do not allow "bronhouder onbekend" for `creator`, forcing committers to change this value