### PR TITLE
Add bandit security linter to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
     hooks:
       - id: black
         language_version: python3.9
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        args: [--quiet]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:


### PR DESCRIPTION
For AB#46681. It reports no issues in this repo.