### PR TITLE
new NAP future version for azure

### DIFF
--- a/datasets/nap_azure/dataset.json
+++ b/datasets/nap_azure/dataset.json
@@ -1,0 +1,22 @@
+{
+  "type": "dataset",
+  "id": "nap",
+  "title": "NAP",
+  "status": "niet_beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "owner": "Gemeente Amsterdam",
+  "creator": "bronhouder Basisinformatie",
+  "publisher": "Datateam Basis- en Kernregistraties",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "n.v.t.",
+  "tables": [
+    {
+      "id": "peilmerken",
+      "$ref": "peilmerken/v2.0.0",
+      "activeVersions": {
+        "2.0.0": "peilmerken/v2.0.0"
+      }
+    }
+  ]
+}

--- a/datasets/nap_azure/dataset.json
+++ b/datasets/nap_azure/dataset.json
@@ -5,11 +5,11 @@
   "status": "niet_beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
-  "owner": "Gemeente Amsterdam",
-  "creator": "bronhouder Basisinformatie",
+  "owner": "Basisinformatie",
+  "creator": "Kadaster en Rijkswaterstaat",
   "publisher": "Datateam Basis- en Kernregistraties",
   "auth": "OPENBAAR",
-  "authorizationGrantor": "n.v.t.",
+  "authorizationGrantor": "gebruik.basisinformatie@amsterdam.nl",
   "tables": [
     {
       "id": "peilmerken",

--- a/datasets/nap_azure/peilmerken/v2.0.0.json
+++ b/datasets/nap_azure/peilmerken/v2.0.0.json
@@ -60,7 +60,7 @@
         "description": "Nummer dat Rijkswaterstaat hanteert."
       },
       "geometrie": {
-        "$ref": "https://geojson.org/schema/Geometry.json",
+        "$ref": "https://geojson.org/schema/Point.json",
         "description": "Geometrische ligging van de meetbout"
       },
       "statusCode": {
@@ -78,7 +78,7 @@
         "format": "date",
         "description": "Vervaldatum van het peilmerk."
       },
-      "ligtInBouwblok": {
+      "ligtInGebiedenBouwblok": {
         "type": "object",
         "properties": {
           "identificatie": {

--- a/datasets/nap_azure/peilmerken/v2.0.0.json
+++ b/datasets/nap_azure/peilmerken/v2.0.0.json
@@ -91,6 +91,11 @@
         "relation": "gebieden:bouwblokken",
         "description": "Het bouwblok waarbinnen het peilmerk ligt"
       },
+       "einddatumCyclus": {
+        "type": "string",
+        "format": "date",
+        "description": "Einddatum van de cyclus, eventueel in combinatie met het kenmerk Status"
+      },
       "publiceerbaar": {
         "type": "boolean",
         "description": "Publiceerbaar ja of nee"

--- a/datasets/nap_azure/peilmerken/v2.0.0.json
+++ b/datasets/nap_azure/peilmerken/v2.0.0.json
@@ -1,0 +1,100 @@
+{
+  "id": "peilmerken",
+  "type": "table",
+  "version": "2.0.0",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "mainGeometry": "geometrie",
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het peilmerknummer van het peilmerk."
+      },
+      "hoogteTovNap": {
+        "type": "number",
+        "description": "Hoogte van het peilmerk t.o.v. NAP"
+      },
+      "jaar": {
+        "type": "integer",
+        "description": "Het jaar van waterpassing, behorende bij de hoogte."
+      },
+      "merkCode": {
+        "type": "string",
+        "provenance": "$.merk.code",
+        "description": "Merk van het referentiepunt code"
+      },
+      "merkOmschrijving": {
+        "type": "string",
+        "provenance": "$.merk.omschrijving",
+        "description": "Merk van het referentiepunt omschrijving"
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Beschrijving van het object waarin het peilmerk zich bevindt."
+      },
+      "windrichting": {
+        "type": "string",
+        "description": "Windrichting"
+      },
+      "xCoordinaatMuurvlak": {
+        "type": "number",
+        "description": "X-co\u00f6rdinaat muurvlak"
+      },
+      "yCoordinaatMuurvlak": {
+        "type": "number",
+        "description": "Y-co\u00f6rdinaat muurvlak"
+      },
+      "rwsNummer": {
+        "type": "string",
+        "description": "Nummer dat Rijkswaterstaat hanteert."
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/Geometry.json",
+        "description": "Geometrische ligging van de meetbout"
+      },
+      "statusCode": {
+        "type": "integer",
+        "provenance": "$.status.code",
+        "description": "Status van het referentiepunt (1=actueel, 2=niet te meten, 3=vervallen) code"
+      },
+      "statusOmschrijving": {
+        "type": "string",
+        "provenance": "$.status.omschrijving",
+        "description": "Status van het referentiepunt (1=actueel, 2=niet te meten, 3=vervallen) omschrijving"
+      },
+      "vervaldatum": {
+        "type": "string",
+        "format": "date",
+        "description": "Vervaldatum van het peilmerk."
+      },
+      "ligtInBouwblok": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "gebieden:bouwblokken",
+        "description": "Het bouwblok waarbinnen het peilmerk ligt"
+      },
+      "publiceerbaar": {
+        "type": "boolean",
+        "description": "Publiceerbaar ja of nee"
+      }
+    }
+  }
+}

--- a/datasets/nap_azure/peilmerken/v2.0.0.json
+++ b/datasets/nap_azure/peilmerken/v2.0.0.json
@@ -94,9 +94,9 @@
         "relation": "gebieden:bouwblokken",
         "description": "Het bouwblok waarbinnen het peilmerk ligt"
       },
-       "einddatumCyclus": {
+       "datumActueelTot": {
         "type": "string",
-        "format": "date",
+        "format": "date-time",
         "description": "Einddatum van de cyclus, eventueel in combinatie met het kenmerk Status"
       },
       "publiceerbaar": {

--- a/datasets/nap_azure/peilmerken/v2.0.0.json
+++ b/datasets/nap_azure/peilmerken/v2.0.0.json
@@ -23,7 +23,7 @@
       },
       "hoogteTovNap": {
         "type": "number",
-        "multipleOf": 0.01",
+        "multipleOf": 0.01,
         "description": "Hoogte van het peilmerk t.o.v. NAP"
        },
       "jaar": {
@@ -50,12 +50,12 @@
       },
       "xCoordinaatMuurvlak": {
         "type": "number",
-        "multipleOf": 0.01",
+        "multipleOf": 0.01,
         "description": "X-co\u00f6rdinaat muurvlak"
       },
       "yCoordinaatMuurvlak": {
         "type": "number",
-        "multipleOf": 0.01",
+        "multipleOf": 0.01,
         "description": "Y-co\u00f6rdinaat muurvlak"
       },
       "rwsNummer": {

--- a/datasets/nap_azure/peilmerken/v2.0.0.json
+++ b/datasets/nap_azure/peilmerken/v2.0.0.json
@@ -23,8 +23,9 @@
       },
       "hoogteTovNap": {
         "type": "number",
+        "multipleOf": 0.01",
         "description": "Hoogte van het peilmerk t.o.v. NAP"
-      },
+       },
       "jaar": {
         "type": "integer",
         "description": "Het jaar van waterpassing, behorende bij de hoogte."
@@ -49,16 +50,18 @@
       },
       "xCoordinaatMuurvlak": {
         "type": "number",
+        "multipleOf": 0.01",
         "description": "X-co\u00f6rdinaat muurvlak"
       },
       "yCoordinaatMuurvlak": {
         "type": "number",
+        "multipleOf": 0.01",
         "description": "Y-co\u00f6rdinaat muurvlak"
       },
       "rwsNummer": {
         "type": "string",
         "description": "Nummer dat Rijkswaterstaat hanteert."
-      },
+       },
       "geometrie": {
         "$ref": "https://geojson.org/schema/Point.json",
         "description": "Geometrische ligging van de meetbout"


### PR DESCRIPTION
het Amsterdams schema voor kernregistratie Peilmerken is aangepast op basis van het informatiemodel NAP.
Het is nog even voor intern gebruik, nog niet publiceren graag, dank karin