### PR TITLE
AB#48090 Yrob/pattern match schema version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,6 @@ repos:
     rev: v3.6.2
     hooks:
       - id: validate-schema
-        args: ['https://schemas.data.amsterdam.nl/schema@v1.1.1#']
+        args: ['https://schemas.data.amsterdam.nl/schema@v1.2.0#']
         files: '/dataset\.json$'
         exclude: "^schema@.+" # exclude meta schemas

--- a/docs/ams-schema-spec.bs
+++ b/docs/ams-schema-spec.bs
@@ -340,7 +340,7 @@ Een [=schema=] object moet in ieder geval de volgende attributen bezitten:
     <tr><td><dfn>properties</dfn>   <td> object
         <td> Collectie van [=veld|velden=] die rijen in de tabel mogen bezitten. Bevat daarnaast een 'schema.$ref' attribuut.
             Veldnamen moeten beginnen met een kleine letter gevolgd door een alfanumerieke reeks en moeten voldoen aan [[#naamgeving]].
-    <tr><td><dfn>properties.schema</dfn>   <td> [[JSON-SCHEMA#ref|§ref]]  <td> [CONST] `{"$ref":"https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"}`
+    <tr><td><dfn>properties.schema</dfn>   <td> [[JSON-SCHEMA#ref|§ref]]  <td> [CONST] `{"$ref":"https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"}`
 </table>
 
 Daarnaast mag een [=schema=] object de volgende attributen bezitten:

--- a/docs/ams-schema-spec.html
+++ b/docs/ams-schema-spec.html
@@ -1490,7 +1490,7 @@ Possible extra rowspan handling
   <meta content="Bikeshed version bb6b91100, updated Mon Jul 12 16:52:37 2021 -0700" name="generator">
   <link href="https://schemas.data.amsterdam.nl/docs/ams-schema-spec.html" rel="canonical">
   <link href="https://data.amsterdam.nl/favicon.png" rel="icon">
-  <meta content="5ca4412f2eb0bf15c23199264d23649d2c76e134" name="document-revision">
+  <meta content="419179a4ecb40c3e7bb86c41ee4769a09d90a951" name="document-revision">
 <style>
     p[data-fill-with="logo"] {
         width: 180px;
@@ -2224,7 +2224,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Amsterdam Schema Specificatie</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2022-04-14">14 April 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Living Standard, <time class="dt-updated" datetime="2022-06-15">15 June 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2746,7 +2746,7 @@ Daarnaast kan aan een tabel meta informatie en autorisatie instellingen worden m
      <tr>
       <td><dfn class="idl-code" data-dfn-for="schema" data-dfn-type="attribute" data-export id="dom-schema-propertiesschema"><code class="highlight">properties<c- p>.</c->schema</code><a class="self-link" href="#dom-schema-propertiesschema"></a></dfn>
       <td> <a href="https://json-schema.org/draft/2020-12/json-schema-core.html#ref">§ref</a>
-      <td> <em>constant</em> <code class="highlight"><c- p>{</c-><c- u>"$ref"</c-><c- o>:</c-><c- u>"https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"</c-><c- p>}</c-></code>
+      <td> <em>constant</em> <code class="highlight"><c- p>{</c-><c- u>"$ref"</c-><c- o>:</c-><c- u>"https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"</c-><c- p>}</c-></code>
    </table>
    <p>Daarnaast mag een <a data-link-type="dfn" href="#schema" id="ref-for-schema③">schema</a> object de volgende attributen bezitten:</p>
    <table class="dfn-table">

--- a/schema@v1.2.0/row-meta-schema.json
+++ b/schema@v1.2.0/row-meta-schema.json
@@ -196,7 +196,7 @@
               "type": "string"
             },
             "$ref": {
-              "const": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
+              "pattern": "^(https://schemas\\.data\\.amsterdam\\.nl/schema@v1)(\\.[0-9]){2}(#/definitions/schema)"
             }
           }
         }


### PR DESCRIPTION
* Use schema version 1.2.0 in pre-commit validator
* Make 1.2.0 backwards compatible with previous minor versions.
    
    Replaces the constant in schema->$ref with a pattern match
    that allows a dataset to use a different minor version than
    that being used by the validator.
    So long as a dataset is compatible with the new version in
    every other respect the lag in minor version is allowed.
    (minor versions should be backwards compatible anyway)