### PR TITLE
Bump schema-tools to 3.6.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: isort
         args: ['--filter-files']
   - repo: https://github.com/Amsterdam/schema-tools
-    rev: v3.6.2
+    rev: v3.6.7
     hooks:
       - id: validate-schema
         args: ['https://schemas.data.amsterdam.nl/schema@v1.2.0#']


### PR DESCRIPTION
3.6.7 has a better error message in specific cases.