### PR TITLE
Draft objectstore syntax

### DIFF
--- a/schema@v1.3.0/dataset.json
+++ b/schema@v1.3.0/dataset.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/dataset@v1.3.0",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "./schema@v1.3.0#/definitions/basicProperties"
+    }
+  ],
+  "required": [
+    "status",
+    "creator",
+    "authorizationGrantor",
+    "owner",
+    "publisher",
+    "auth"
+  ],
+  "properties": {
+    "schema": {
+      "const": "dataset"
+    },
+    "version": {
+      "$ref": "./schema@v1.3.0#/definitions/version"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "beschikbaar",
+        "niet_beschikbaar"
+      ]
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri"
+    },
+    "language": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 3
+    },
+    "accrualPeriodicity": {
+      "type": "string"
+    },
+    "spatialDescription": {
+      "type": "string"
+    },
+    "spatialCoordinates": {
+      "$ref": "https://geojson.org/schema/Geometry.json"
+    },
+    "theme": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "publisher": {
+      "description": "Naam van het datateam.",
+      "type": "string",
+      "minLength": 1
+    },
+    "creator": {
+      "description": "Naam van de bronhouder.",
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "const": "bronhouder onbekend"
+      }
+    },
+    "owner": {
+      "type": "string",
+      "default": "Gemeente Amsterdam",
+      "minLength": 1
+    },
+    "authorizationGrantor": {
+      "type": "string",
+      "minLength": 1
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hasBeginning": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "hasEnd": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "objective": {
+      "type": "string"
+    },
+    "temporalUnit": {
+      "type": "string"
+    },
+    "spatial": {
+      "type": "string"
+    },
+    "legalBasis": {
+      "type": "string"
+    },
+    "contactPoint": {
+      "description": "Person and (optional) e-mail.",
+      "$ref": "./schema@v1.3.0#/definitions/contactPoint",
+      "default": {
+        "name": "datapunt",
+        "email": "datapunt@amsterdam.nl"
+      }
+    },
+    "crs": {
+      "description": "Coordinate reference system",
+      "type": "string",
+      "enum": [
+        "EPSG:28992",
+        "EPSG:4326"
+      ]
+    },
+    "objectstore": {
+      "$ref": "./objectstore@v1.3.0"
+    },
+    "tables": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "./table@v1.3.0"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "$ref": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/schema@v1.3.0/distribution.json
+++ b/schema@v1.3.0/distribution.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/distribution@v1.3.0",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  }
+}

--- a/schema@v1.3.0/meta/auth.json
+++ b/schema@v1.3.0/meta/auth.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/auth@v1.3.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/auth@v1.3.0": true
+  },
+  "$recursiveAnchor": true,
+  "title": "Amsterdam Schema authorization",
+  "properties": {
+    "ams.auth": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  }
+}

--- a/schema@v1.3.0/meta/provenance.json
+++ b/schema@v1.3.0/meta/provenance.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/provenance@v1.3.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/provenance@v1.3.0": true
+  },
+  "$recursiveAnchor": true,
+  "title": "Amsterdam Schema provenance",
+  "properties": {
+    "provenance": {
+      "$comment": "This field can hold provenance data, per dataset, table or field.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
+    }
+  }
+}

--- a/schema@v1.3.0/meta/relation.json
+++ b/schema@v1.3.0/meta/relation.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/relation@v1.3.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/relation@v1.3.0": true
+  },
+  "$recursiveAnchor": true,
+  "properties": {
+    "relation": {
+      "type": "string",
+      "format": "uri-reference"
+    }
+  }
+}

--- a/schema@v1.3.0/meta/unit.json
+++ b/schema@v1.3.0/meta/unit.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/meta/unit@v1.3.0",
+  "$vocabulary": {
+    "https://schemas.data.amsterdam.nl/meta/unit@v1.3.0": true
+  },
+  "$recursiveAnchor": true,
+  "title": "Amsterdam Schema unit",
+  "properties": {
+    "unit": {
+      "type": "string",
+      "$comment": "UCUM strings, see https://ucum.nlm.nih.gov/"
+    }
+  }
+}

--- a/schema@v1.3.0/objectstore.json
+++ b/schema@v1.3.0/objectstore.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/objectstore@v1.3.0",
+  "type": "object",
+  "required": [
+    "type",
+    "indexed",
+    "identifier",
+    "accessURL"
+  ],
+  "properties": {
+    "allOf": [
+      {
+        "type": "object",
+        "properties": {
+          "type": {
+            "const": "objectstore"
+          },
+          "identifier": {
+            "type": "string",
+            "minLength": 3,
+            "maxLenth": 24,
+            "pattern": "^[a-z0-9]+$"
+          },
+          "indexed": {
+            "type": "boolean"
+          },
+          "accessURL": {
+            "type": "string",
+            "pattern": "https://[a-z0-9]{3,24}.dfs.core.windows.net"
+          }
+        }
+      },
+      {
+        "$ref": "distribution@v1.3.0"
+      }
+    ]
+  }
+}

--- a/schema@v1.3.0/row-meta-schema.json
+++ b/schema@v1.3.0/row-meta-schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/row-meta-schema@v1.3.0",
+  "definitions": {
+    "rootProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/auth"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "$comment": {
+          "type": "string"
+        },
+        "$ref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "shortname": {
+          "type": "string"
+        },
+        "items": {
+          "$ref": "#/definitions/rootProperty"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "integer"
+        },
+        "multipleOf": {
+          "type": "number"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "contentEncoding": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[a-z][A-Za-z0-9]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/rootProperty"
+          }
+        },
+        "enum": {
+          "type": "array"
+        },
+        "format": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v1.3.0#properties/provenance"
+        },
+        "relation": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "unit": {
+          "type": [
+            "string",
+            "object"
+          ],
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "$ref": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes"
+            }
+          }
+        },
+        {
+          "required": [
+            "$ref"
+          ],
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "enum": [
+                "https://geojson.org/schema/Geometry.json",
+                "https://geojson.org/schema/MultiPolygon.json",
+                "https://geojson.org/schema/Polygon.json",
+                "https://geojson.org/schema/Point.json",
+                "https://geojson.org/schema/MultiLineString.json",
+                "https://geojson.org/schema/LineString.json",
+                "https://geojson.org/schema/MultiPoint.json"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "required": [
+    "$schema",
+    "type",
+    "properties",
+    "required",
+    "display"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "const": "http://json-schema.org/draft-07/schema#"
+    },
+    "$id": {
+      "type": "string"
+    },
+    "additionalProperties": {
+      "const": false
+    },
+    "type": {
+      "const": "object"
+    },
+    "required": {
+      "allOf": [
+        {
+          "type": "array",
+          "minItems": 1,
+          "contains": {
+            "const": "schema"
+          }
+        }
+      ]
+    },
+    "display": {
+      "type": "string"
+    },
+    "additionalRelations": {
+      "type": "object"
+    },
+    "mainGeometry": {
+      "type": "string"
+    },
+    "identifier": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "properties": {
+      "type": "object",
+      "required": [
+        "schema"
+      ],
+      "propertyNames": {
+        "pattern": "^[a-z][A-Za-z0-9]*$"
+      },
+      "properties": {
+        "schema": {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "$ref": {
+              "pattern": "^(https://schemas\\.data\\.amsterdam\\.nl/schema@v1)(\\.[0-9]){2}(#/definitions/schema)"
+            }
+          }
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/rootProperty"
+      }
+    }
+  }
+}

--- a/schema@v1.3.0/schema.json
+++ b/schema@v1.3.0/schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/schema@v1.3.0#",
+  "title": "Amsterdam Schema",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/core": true,
+    "https://schemas.data.amsterdam.nl/meta/auth@v1.3.0": false,
+    "https://schemas.data.amsterdam.nl/meta/units@v1.3.0": false,
+    "https://schemas.data.amsterdam.nl/meta/relation@v1.3.0": false,
+    "https://schemas.data.amsterdam.nl/meta/provenance@v1.3.0": false
+  },
+  "$recursiveAnchor": true,
+  "definitions": {
+    "basicProperties": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "auth": {
+          "$ref": "#/definitions/auth"
+        },
+        "dateCreated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "dateModified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "license": {
+          "type": "string"
+        },
+        "provenance": {
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v1.3.0#properties/provenance"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "type": {
+          "$ref": "#/definitions/type"
+        }
+      }
+    },
+    "idString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z][A-Za-z]*[0-9]*$"
+    },
+    "id": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/idString"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "dataset",
+        "table"
+      ]
+    },
+    "schema": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "year": {
+      "type": "integer"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(\\d+\\.)(\\d+\\.)?(\\d+)$"
+    },
+    "contactPoint": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      }
+    },
+    "auth": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "$ref": "./dataset@v1.3.0"
+        },
+        {
+          "$ref": "./table@v1.3.0"
+        },
+        {
+          "$ref": "./row-meta-schema@v1.3.0"
+        }
+      ]
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "dataset"
+          }
+        }
+      },
+      "then": {
+        "$ref": "./dataset@v1.3.0"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "table"
+          }
+        }
+      },
+      "then": {
+        "$ref": "./table@v1.3.0"
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "$comment": "JSON Schema metaschemas for row data are JSON Schemas with type = object",
+            "const": "object"
+          }
+        }
+      },
+      "then": {
+        "$ref": "./row-meta-schema@v1.3.0"
+      }
+    }
+  ]
+}

--- a/schema@v1.3.0/table.json
+++ b/schema@v1.3.0/table.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.data.amsterdam.nl/table@v1.3.0",
+  "type": "object",
+  "temporal": {
+    "type": "object",
+    "required": [
+      "identifier",
+      "dimensions"
+    ],
+    "identifier": "string",
+    "unit": "string",
+    "dimensions": {
+      "type": "object",
+      "geldigOp": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "./schema@v1.3.0#/definitions/basicProperties"
+    }
+  ],
+  "required": [
+    "schema",
+    "version"
+  ],
+  "properties": {
+    "type": {
+      "const": "table"
+    },
+    "shortname": {
+      "type": "string"
+    },
+    "schema": {
+      "oneOf": [
+        {
+          "$ref": "./row-meta-schema@v1.3.0"
+        },
+        {
+          "type": "object",
+          "required": [
+            "$ref"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "$ref": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The idea is that `dataset` gets an `objectstore` property, which is an additional form of a Distribution in the sense of DCAT. In this context, tables can be considered a different Distribution and the DSO-API a Dataservice. 

`objectstore` points to a subschema "objectstore" that is a combination of fields that we need to determine whether the objectstore should be indexed (i.e. the metadata contains a pointer to a listing of the contents of the objectstore).

#### Notes

* The "identifier" becomes the storage account name (the regex pattern here leaks implementation details which is ugly)
 * A general pointer to the objectstore can and must always be included by reconstructing it from the "identifier". We should only publish the schema after the creation of the associated SA since before this it will be a dead link. Also note that the validation pattern assumes that we use [standard endpoints](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview#standard-endpoints) on the storage account 
 * We can initially use the dataset level "auth" field to determine the required scopes for accessing the objectstore (on top of the generated READ/WRITE groups)
 * Submitters of the schema are curently responsible for guaranteein uniqueness of the "identifier"
 * We can initialize the storage account with a single container which is the dataset name (the syntax currently doesnt support defining multiple containers)
 * For indexed objectstores, the publishing mechanism should inline the index in the schema under the "index" property (?). A schema that was valid before inlining the index will still be valid after since properties not defined in the schema are ignored. We can implement this after the pipeline that creates the sa's has been implemented