### PR TITLE
Add reasonsNonPublic to v1.2.0 and v1.3.0

### DIFF
--- a/schema@v1.1.1/schema.json
+++ b/schema@v1.1.1/schema.json
@@ -48,6 +48,7 @@
           "$ref": "#/definitions/type"
         },
         "reasonsNonPublic": {
+          "minItems": 1,
           "type": "array",
           "items": {
             "$ref": "./schema@v1.1.1#/definitions/nonPubReason"

--- a/schema@v1.2.0/schema.json
+++ b/schema@v1.2.0/schema.json
@@ -46,6 +46,13 @@
         },
         "type": {
           "$ref": "#/definitions/type"
+        },
+        "reasonsNonPublic": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "./schema@v1.1.1#/definitions/nonPubReason"
+          }
         }
       }
     },
@@ -69,6 +76,27 @@
       "enum": [
         "dataset",
         "table"
+      ]
+    },
+    "nonPubReason": {
+      "type": "string",
+      "description": "Reden voor niet openbaarmaking. Obv uitzonderingen in Hoofdstuk 5 Woo.",
+      "enum": [
+        "5.1 1a: Gevaar voor eenheid van de Kroon",
+        "5.1 1b: Gevaar voor staatsveiligheid",
+        "5.1 1c: Bevat persoonsgegevens",
+        "5.1 2a: Zwaarwegend belang: internationale betrekkingen",
+        "5.1 2b: Zwaarwegende economische of financi\u00eble belangen van publiekrechtelijke lichamen (bevat geen mileu-informatie)",
+        "5.1 2b: Zwaarwegende economische of financi\u00eble belangen van publiekrechtelijke lichamen (bevat mileu-informatie met betrekking op handelingen met een vertrouwelijk karakter)",
+        "5.1 2c: Zwaarwegend belang: opsporing en vervolging van strafbare feiten",
+        "5.1 2d: Zwaarwegend belang: inspectie, controle en toezicht door bestuursorganen",
+        "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer",
+        "5.1 2f: Zwaarwegend belang: vertrouwelijke of concurrentiegevoelige bedrijfs- en fabricagegegevens",
+        "5.1 2g: Zwaarwegend belang: bescherming van het milieu waarop deze informatie betrekking heeft",
+        "5.1 2h: Zwaarwegend belang: beveiliging van personen en bedrijven en het voorkomen van sabotage",
+        "5.2 1: Bevat persoonlijke beleidsopvattingen (bevat geen milieu-informatie)",
+        "5.2 3: Zwaarwegend belang: persoonlijke beleidsopvattingen (bevat milieu-informatie)",
+        "nader te bepalen"
       ]
     },
     "schema": {

--- a/schema@v1.3.0/schema.json
+++ b/schema@v1.3.0/schema.json
@@ -46,6 +46,13 @@
         },
         "type": {
           "$ref": "#/definitions/type"
+        },
+        "reasonsNonPublic": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "./schema@v1.3.0#/definitions/nonPubReason"
+          }
         }
       }
     },
@@ -69,6 +76,27 @@
       "enum": [
         "dataset",
         "table"
+      ]
+    },
+    "nonPubReason": {
+      "type": "string",
+      "description": "Reden voor niet openbaarmaking. Obv uitzonderingen in Hoofdstuk 5 Woo.",
+      "enum": [
+        "5.1 1a: Gevaar voor eenheid van de Kroon",
+        "5.1 1b: Gevaar voor staatsveiligheid",
+        "5.1 1c: Bevat persoonsgegevens",
+        "5.1 2a: Zwaarwegend belang: internationale betrekkingen",
+        "5.1 2b: Zwaarwegende economische of financi\u00eble belangen van publiekrechtelijke lichamen (bevat geen mileu-informatie)",
+        "5.1 2b: Zwaarwegende economische of financi\u00eble belangen van publiekrechtelijke lichamen (bevat mileu-informatie met betrekking op handelingen met een vertrouwelijk karakter)",
+        "5.1 2c: Zwaarwegend belang: opsporing en vervolging van strafbare feiten",
+        "5.1 2d: Zwaarwegend belang: inspectie, controle en toezicht door bestuursorganen",
+        "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer",
+        "5.1 2f: Zwaarwegend belang: vertrouwelijke of concurrentiegevoelige bedrijfs- en fabricagegegevens",
+        "5.1 2g: Zwaarwegend belang: bescherming van het milieu waarop deze informatie betrekking heeft",
+        "5.1 2h: Zwaarwegend belang: beveiliging van personen en bedrijven en het voorkomen van sabotage",
+        "5.2 1: Bevat persoonlijke beleidsopvattingen (bevat geen milieu-informatie)",
+        "5.2 3: Zwaarwegend belang: persoonlijke beleidsopvattingen (bevat milieu-informatie)",
+        "nader te bepalen"
       ]
     },
     "schema": {


### PR DESCRIPTION
Add reasonsNonPublic to v1.2.0 and v1.3.0

Some time ago the reasonsNonPublic field  
was added to version 1.1.1 of the meta-schema, 
but was omitted in 1.2.0 or 1.3.0 by mistake.

This commit will add this feature to the later versions as well.
And enforce that at least 1 item is added to the reasonsNonPublic array.