### PR TITLE
Fix symlink to v1.3.0

### DIFF
--- a/src/amsterdam_schema/schema@v1.3.0
+++ b/src/amsterdam_schema/schema@v1.3.0
@@ -1,1 +1,1 @@
-/home/yashar/Documents/projects/amsterdam-schema/schema@v1.3.0
+../../schema@v1.3.0


### PR DESCRIPTION
The symlink inside the `src` directory needs to be a relative symlink.
However, is was an absolute symlink to `/home/yashar`, so the publishing
of the schemas on Azure was failing.