### PR TITLE
Fix the values in the enum

### DIFF
--- a/datasets/huishoudelijkafval/weging/v2.0.0.json
+++ b/datasets/huishoudelijkafval/weging/v2.0.0.json
@@ -100,11 +100,11 @@
         "type": "integer",
         "provenance": "weging_bediening_code",
         "enum": [
-          "0 - Handmatig",
-          "1 - Automatisch",
-          "3 - onbekend"
+          0,
+          1,
+          3
         ],
-        "description": "Code van de wijze waarop de bediening van de weging heeft plaatsgevonden"
+        "description": "Code van de wijze waarop de bediening van de weging heeft plaatsgevonden. Mogelijke waarden: 0 - Handmatig, 1 - Automatisch, 3 - onbekend."
       },
       "bedieningOmschrijving": {
         "type": "string",


### PR DESCRIPTION
for huishoudelijkafval_waarde.bediening_code

The type of the field is an `integer`, but the values in the enum
were strings. This is not correct and leads to problems during mocking.