### PR TITLE
Add deprecated attributes to gebieden schema

### DIFF
--- a/datasets/gebieden_azure/bouwblokken/v2.0.0.json
+++ b/datasets/gebieden_azure/bouwblokken/v2.0.0.json
@@ -86,6 +86,28 @@
       "geometrie": {
         "$ref": "https://geojson.org/schema/Polygon.json",
         "description": "Geometrische beschrijving van een object."
+      },
+      "ligtInBrkGemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:gemeentes",
+        "provenance": "$.ligtInGemeente.identificatie",
+        "description": "WORDT VERWIJDERD - De gemeente waar het bouwblok in ligt."
       }
     }
   }

--- a/datasets/gebieden_azure/buurten/v2.0.0.json
+++ b/datasets/gebieden_azure/buurten/v2.0.0.json
@@ -144,6 +144,28 @@
       "geometrie": {
         "$ref": "https://geojson.org/schema/Polygon.json",
         "description": "Geometrische beschrijving van een object."
+      },
+      "ligtInBrkGemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:gemeentes",
+        "provenance": "$.ligtInGemeente.identificatie",
+        "description": "WORDT VERWIJDERD - De gemeente waar de buurt in ligt."
       }
     }
   }

--- a/datasets/gebieden_azure/ggpgebieden/v2.0.0.json
+++ b/datasets/gebieden_azure/ggpgebieden/v2.0.0.json
@@ -100,6 +100,50 @@
       "geometrie": {
         "$ref": "https://geojson.org/schema/Polygon.json",
         "description": "Geometrische beschrijving van een object."
+      },
+      "bestaatUitGebiedenBuurten": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "gebieden:buurten",
+        "provenance": "$.bestaatUitBuurten.identificatie",
+        "description": "WORDT VERWIJDERD - De gebieden waaruit dit ggpgebied bestaat"
+      },
+      "ligtInBrkGemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:gemeentes",
+        "provenance": "$.ligtInGemeente.identificatie",
+        "description": "WORDT VERWIJDERD - De gemeente waar het ggpgebied in ligt."
       }
     }
   }

--- a/datasets/gebieden_azure/ggwgebieden/v2.0.0.json
+++ b/datasets/gebieden_azure/ggwgebieden/v2.0.0.json
@@ -100,6 +100,50 @@
       "geometrie": {
         "$ref": "https://geojson.org/schema/Polygon.json",
         "description": "Geometrische beschrijving van een object."
+      },
+      "bestaatUitGebiedenBuurten": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "gebieden:buurten",
+        "provenance": "$.bestaatUitBuurten.identificatie",
+        "description": "WORDT VERWIJDERD - De gebieden waaruit dit ggwgebied bestaat"
+      },
+      "ligtInBrkGemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:gemeentes",
+        "provenance": "$.ligtInGemeente.identificatie",
+        "description": "WORDT VERWIJDERD - De gemeente waar het ggwgebied in ligt."
       }
     }
   }

--- a/datasets/gebieden_azure/stadsdelen/v2.0.0.json
+++ b/datasets/gebieden_azure/stadsdelen/v2.0.0.json
@@ -76,7 +76,23 @@
         "description": "De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van het object heeft plaatsgevonden."
       },
       "ligtInBrkGemeente": {
-        "type": "string",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
         "relation": "brk:gemeentes",
         "provenance": "$.ligtInGemeente.identificatie",
         "description": "De gemeente waar het stadsdeel in ligt."

--- a/datasets/gebieden_azure/wijken/v2.0.0.json
+++ b/datasets/gebieden_azure/wijken/v2.0.0.json
@@ -124,6 +124,28 @@
       "geometrie": {
         "$ref": "https://geojson.org/schema/Polygon.json",
         "description": "Geometrische beschrijving van een object."
+      },
+      "ligtInBrkGemeente": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:gemeentes",
+        "provenance": "$.ligtInGemeente.identificatie",
+        "description": "WORDT VERWIJDERD - De gemeente waar de wijk in ligt."
       }
     }
   }


### PR DESCRIPTION
For backwards compatibility with GOB Model so that we can still deliver the current products while migrating to Amsterdam Schema.