### PR TITLE
Remove unused imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python:3.8-buster
+FROM amsterdam/python:3.9-buster
 MAINTAINER datapunt@amsterdam.nl
 
 WORKDIR /app

--- a/src/amsterdam_schema/publish/cli.py
+++ b/src/amsterdam_schema/publish/cli.py
@@ -14,12 +14,11 @@ import logging
 import os
 import shutil
 from importlib import resources
-from importlib.abc import Traversable
 from io import BytesIO
 from os.path import splitext
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable, Dict, Iterator, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 
 import click
 import in_place


### PR DESCRIPTION
Should have been caught by flake8

In this case, this is crashing the Jenkins pipeline,
because Traversable is only available in python3.9