### PR TITLE
Fix type of rioolleidingen.objnr

### DIFF
--- a/datasets/rioolnetwerk/dataset.json
+++ b/datasets/rioolnetwerk/dataset.json
@@ -56,7 +56,7 @@
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
           "objnr": {
-            "type": "number",
+            "type": "integer",
             "description": "Uniek objectnummer van de leiding (logische key)"
           },
           "bobBeginpunt": {


### PR DESCRIPTION
This is the primary key, so a numeric is not very sensible.
And, in the ref. db. this field actually is an integer.