### PR TITLE
Add the `reasonsNonPublic` attribute for the field definitions

### DIFF
--- a/schema@v1.2.0/row-meta-schema.json
+++ b/schema@v1.2.0/row-meta-schema.json
@@ -9,6 +9,9 @@
         "auth": {
           "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/auth"
         },
+        "reasonsNonPublic": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/reasonsNonPublic"
+        },
         "description": {
           "type": "string"
         },

--- a/schema@v1.2.0/schema.json
+++ b/schema@v1.2.0/schema.json
@@ -78,7 +78,7 @@
       "minItems": 1,
       "type": "array",
       "items": {
-        "$ref": "./schema@v1.1.1#/definitions/nonPubReason"
+        "$ref": "#/definitions/nonPubReason"
       }
     },
     "nonPubReason": {

--- a/schema@v1.2.0/schema.json
+++ b/schema@v1.2.0/schema.json
@@ -48,11 +48,7 @@
           "$ref": "#/definitions/type"
         },
         "reasonsNonPublic": {
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "./schema@v1.1.1#/definitions/nonPubReason"
-          }
+          "$ref": "#/definitions/reasonsNonPublic"
         }
       }
     },
@@ -77,6 +73,13 @@
         "dataset",
         "table"
       ]
+    },
+    "reasonsNonPublic": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "$ref": "./schema@v1.1.1#/definitions/nonPubReason"
+      }
     },
     "nonPubReason": {
       "type": "string",

--- a/schema@v1.3.0/row-meta-schema.json
+++ b/schema@v1.3.0/row-meta-schema.json
@@ -9,6 +9,9 @@
         "auth": {
           "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/auth"
         },
+        "reasonsNonPublic": {
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/reasonsNonPublic"
+        },
         "description": {
           "type": "string"
         },

--- a/schema@v1.3.0/schema.json
+++ b/schema@v1.3.0/schema.json
@@ -78,7 +78,7 @@
       "minItems": 1,
       "type": "array",
       "items": {
-        "$ref": "./schema@v1.1.1#/definitions/nonPubReason"
+        "$ref": "#/definitions/nonPubReason"
       }
     },
     "nonPubReason": {

--- a/schema@v1.3.0/schema.json
+++ b/schema@v1.3.0/schema.json
@@ -48,11 +48,7 @@
           "$ref": "#/definitions/type"
         },
         "reasonsNonPublic": {
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "./schema@v1.3.0#/definitions/nonPubReason"
-          }
+          "$ref": "#/definitions/reasonsNonPublic"
         }
       }
     },
@@ -77,6 +73,13 @@
         "dataset",
         "table"
       ]
+    },
+    "reasonsNonPublic": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "$ref": "./schema@v1.1.1#/definitions/nonPubReason"
+      }
     },
     "nonPubReason": {
       "type": "string",


### PR DESCRIPTION
In v1.2.0 and v1.3.0
Because users are still on v1.2.0 and this is not a change, but a bug-fix.