### PR TITLE
Remove "format": "uuid" from objectenopenbareruimte

### DIFF
--- a/datasets/objectenopenbareruimte/dataset.json
+++ b/datasets/objectenopenbareruimte/dataset.json
@@ -60,13 +60,11 @@
           },
           "guid": {
             "description": "Uniek nummer van het IMBOR-object (GUID)",
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           "imgeoIdentificatie": {
             "description": "Overerving van de geometrie van beheerobject uit bovenliggend informatiemodel of automatisch genereren.",
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           "aantalDeklagen": {
             "description": "Aantal deklagen bij asfaltverharding.",
@@ -305,14 +303,12 @@
           "guid": {
             "auth": "FP/MDW",
             "description": "Uniek nummer van het IMBOR-object (GUID).",
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           "imgeoIdentificatie": {
             "auth": "FP/MDW",
             "description": "Overerving van de geometrie van beheerobject uit bovenliggend informatiemodel of automatisch genereren.",
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           "identificatie": {
             "description": "Uniek identificatienummer voor het object dat onveranderlijk is zolang het object bestaat.",


### PR DESCRIPTION
This isn't in the schema spec and it confuses DSO-API.