### PR TITLE
Fixes for Airflow

### DIFF
--- a/datasets/brk/aantekeningenkadastraleobjecten/v1.3.0.json
+++ b/datasets/brk/aantekeningenkadastraleobjecten/v1.3.0.json
@@ -1,0 +1,131 @@
+{
+  "id": "aantekeningenkadastraleobjecten",
+  "type": "table",
+  "version": "1.3.0",
+  "auth": "BRK/RS",
+  "reasonsNonPublic": [
+    "5.1 1c: Bevat persoonsgegevens",
+    "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer"
+  ],
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "identificatie",
+      "volgnummer"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Begindatum geldigheid object."
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geldigheid object."
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het door het Kadaster toegekende landelijk unieke nummer aan deze aantekening."
+      },
+      "aardCode": {
+        "type": "string",
+        "provenance": "$.aard.code",
+        "description": "De aard van de aantekening code"
+      },
+      "aardOmschrijving": {
+        "type": "string",
+        "provenance": "$.aard.omschrijving",
+        "description": "De aard van de aantekening omschrijving"
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Omschrijving bij de aantekening"
+      },
+      "heeftBetrokkenPersoon": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk:kadastralesubjecten",
+        "description": "Identificatie van het betrokken subject"
+      },
+      "heeftBetrekkingOpKadastraalObject": {
+        "shortname": "hftBtrkOpKot",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk:kadastraleobjecten",
+        "description": "Identificatie van het kadastrale object (onroerende zaak)"
+      },
+      "isGebaseerdOpStukdeel": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:stukdelen",
+        "description": "Identificatie van het betrokken stukdeel."
+      },
+      "einddatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk/aantekeningenrechten/v2.3.0.json
+++ b/datasets/brk/aantekeningenrechten/v2.3.0.json
@@ -1,0 +1,107 @@
+{
+  "id": "aantekeningenrechten",
+  "type": "table",
+  "version": "2.3.0",
+  "auth": "BRK/RS",
+  "reasonsNonPublic": [
+    "5.1 1c: Bevat persoonsgegevens",
+    "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer"
+  ],
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "id",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"
+      },
+      "neuronId": {
+        "type": "string",
+        "description": "Neuron ID",
+        "provenance": "id"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het aan deze aantekening toegekende landelijk unieke nummer."
+      },
+      "aardCode": {
+        "type": "string",
+        "provenance": "$.aard.code",
+        "description": "De aard van de aantekening. code"
+      },
+      "aardOmschrijving": {
+        "type": "string",
+        "provenance": "$.aard.omschrijving",
+        "description": "De aard van de aantekening. omschrijving"
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Omschrijving bij de aantekening"
+      },
+      "betrokkenTenaamstelling": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk:tenaamstellingen",
+        "description": "Identificatie van de betrokken tenaamstelling"
+      },
+      "heeftBetrokkenPersoon": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk:kadastralesubjecten",
+        "description": "Identificatie van het betrokken subject"
+      },
+      "isGebaseerdOpStukdeel": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "relation": "brk:stukdelen",
+        "description": "Identificatie van het betrokken stukdeel."
+      },
+      "einddatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk/dataset.json
+++ b/datasets/brk/dataset.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "aantekeningenrechten",
-      "$ref": "aantekeningenrechten/v2.2.0"
+      "$ref": "aantekeningenrechten/v2.3.0"
     },
     {
       "id": "aantekeningenkadastraleobjecten",

--- a/datasets/brk/dataset.json
+++ b/datasets/brk/dataset.json
@@ -39,7 +39,7 @@
     },
     {
       "id": "aantekeningenkadastraleobjecten",
-      "$ref": "aantekeningenkadastraleobjecten/v1.2.0"
+      "$ref": "aantekeningenkadastraleobjecten/v1.3.0"
     },
     {
       "id": "stukdelen",

--- a/datasets/woz/dataset.json
+++ b/datasets/woz/dataset.json
@@ -7,7 +7,7 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "owner": "Gemeente Amsterdam",
-  "creator": "bronhouder onbekend",
+  "creator": "Belastingen Amsterdam",
   "publisher": "Datateam Basis- en Kernregistraties",
   "auth": "OPENBAAR",
   "authorizationGrantor": "n.v.t.",
@@ -21,9 +21,9 @@
     },
     {
       "id": "wozdeelobjecten",
-      "$ref": "wozdeelobjecten/v1.0.0",
+      "$ref": "wozdeelobjecten/v1.1.0",
       "activeVersions": {
-        "1.0.0": "wozdeelobjecten/v1.0.0"
+        "1.1.0": "wozdeelobjecten/v1.1.0"
       }
     }
   ]

--- a/datasets/woz/wozdeelobjecten/v1.1.0.json
+++ b/datasets/woz/wozdeelobjecten/v1.1.0.json
@@ -1,0 +1,131 @@
+{
+  "id": "wozdeelobjecten",
+  "type": "table",
+  "version": "1.1.0",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "wozdeelobjectnummer",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "wozdeelobjectnummer",
+      "volgnummer"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "wozdeelobjectnummer": {
+        "type": "string",
+        "$comment": "should become: wozdeelobjectnummer, not possible atm.",
+        "description": "De unieke identificatie van een WOZ-deelobject"
+      },
+      "deelnummer": {
+        "type": "string",
+        "description": "Unieke identificatie WOZ-deelobject binnen het WOZ-object"
+      },
+      "wozobjectnummer": {
+        "type": "string",
+        "description": "Van welk WOZ-object is dit WOZ-deelobject een onderdeel"
+      },
+      "soortobjectCode": {
+        "type": "integer",
+        "provenance": "$.soortobject.code",
+        "description": "Nadere aanduiding van het feitelijk gebruik  (SOC) van een WOZ-object zoals dat ten grondslag heeft gelegen aan de waardebepaling en voor zover relevant voor de afnemers, uitgedrukt in een code code"
+      },
+      "soortobjectOmschrijving": {
+        "type": "string",
+        "provenance": "$.soortobject.omschrijving",
+        "description": "Nadere aanduiding van het feitelijk gebruik  (SOC) van een WOZ-object zoals dat ten grondslag heeft gelegen aan de waardebepaling en voor zover relevant voor de afnemers, uitgedrukt in een code omschrijving"
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date",
+        "description": "Een aanduiding op welk tijdstip het object is ontstaan"
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date",
+        "description": "Een aanduiding op welk tijdstip het object is beëindigd"
+      },
+      "isVerbondenMetVerblijfsobject": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:verblijfsobjecten",
+        "description": "Aan welk verblijfsobject heeft het WOZ-deelobject een relatie"
+      },
+      "isVerbondenMetLigplaats": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:ligplaatsen",
+        "description": "Aan welk ligplaats heeft het WOZ-deelobject een relatie"
+      },
+      "isVerbondenMetStandplaats": {
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          }
+        },
+        "relation": "bag:standplaatsen",
+        "description": "Aan welk standplaats heeft het WOZ-deelobject een relatie"
+      },
+      "heeftPand": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            }
+          },
+          "relation": "bag:panden",
+          "description": "Geeft aan of het WOZ-deelobject een (deel van een) pand is uit de BAG."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes for Airflow:
- WOZ wozdeelobjecten.heeftPand
- BRK aantekeningenkadastraleobjecten.isGebaseerdOpStukdeel
- BRK aantekeningenrechten.isGebaseerdOpStukdeel.