### PR TITLE
Update URL of spec in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains:
 
 Apart from the technical description
 an in-depth textual specification of the Amsterdam Schema can be found at
-https://github.com/Amsterdam/amsterdam-schema/wiki/Amsterdam-Schema-Specification
+https://schemas.data.amsterdam.nl/docs/ams-schema-spec.html.
 
 The Amsterdam Schema is chosen to be delimited in such a way
 that it can interoperate with as many systems as possible.


### PR DESCRIPTION
The wiki forwards to the version on schema.data, but by presenting a link to click.