### PR TITLE
Remove brk2 tables that break automation

### DIFF
--- a/datasets/brk2/dataset.json
+++ b/datasets/brk2/dataset.json
@@ -18,34 +18,6 @@
   },
   "tables": [
     {
-      "id": "kadastraleobjecten",
-      "$ref": "kadastraleobjecten/v1.0.0",
-      "activeVersions": {
-        "1.0.0": "kadastraleobjecten/v1.0.0"
-      }
-    },
-    {
-      "id": "kadastralesubjecten",
-      "$ref": "kadastralesubjecten/v1.0.0",
-      "activeVersions": {
-        "1.0.0": "kadastralesubjecten/v1.0.0"
-      }
-    },
-    {
-      "id": "zakelijkerechten",
-      "$ref": "zakelijkerechten/v1.0.0",
-      "activeVersions": {
-        "1.0.0": "zakelijkerechten/v1.0.0"
-      }
-    },
-    {
-      "id": "tenaamstellingen",
-      "$ref": "tenaamstellingen/v1.0.0",
-      "activeVersions": {
-        "1.0.0": "tenaamstellingen/v1.0.0"
-      }
-    },
-    {
       "id": "meta",
       "$ref": "meta/v1.0.0",
       "activeVersions": {


### PR DESCRIPTION
Some brk2 tables use object type fields.
Automation does not support this and fails.
This commit temporarily removes reference to these tables untill this is fixed. #AB61561