### PR TITLE
Remove identifier fields at dataset level

### DIFF
--- a/datasets/bag/dataset.json
+++ b/datasets/bag/dataset.json
@@ -5,7 +5,6 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
-  "identifier": "identificatie",
   "owner": "Gemeente Amsterdam",
   "publisher": "Datateam Basis- en Kernregistraties",
   "creator": "Basisinformatie",

--- a/datasets/bag_azure/dataset.json
+++ b/datasets/bag_azure/dataset.json
@@ -5,7 +5,6 @@
   "status": "niet_beschikbaar",
   "version": "2.0.0",
   "crs": "EPSG:28992",
-  "identifier": "identificatie",
   "owner": "Basisinformatie",
   "publisher": "Datateam Basis- en Kernregistraties",
   "creator": "Basisinformatie, Stadsdelen, Belastingen en Omgevingsdienst NZKG",

--- a/datasets/brk/dataset.json
+++ b/datasets/brk/dataset.json
@@ -5,7 +5,6 @@
   "status": "beschikbaar",
   "version": "1.0.0",
   "crs": "EPSG:28992",
-  "identifier": "identificatie",
   "owner": "Gemeente Amsterdam, afdeling Basisinformatie",
   "creator": "Kadaster",
   "publisher": "Datateam Basis- en Kernregistraties",

--- a/datasets/brk2/dataset.json
+++ b/datasets/brk2/dataset.json
@@ -5,7 +5,6 @@
   "status": "niet_beschikbaar",
   "version": "1.0.0",
   "crs": "EPSG:28992",
-  "identifier": "identificatie",
   "owner": "Gemeente Amsterdam, afdeling Basisinformatie",
   "creator": "Kadaster",
   "publisher": "Datateam Basis- en Kernregistraties",

--- a/datasets/gebieden/dataset.json
+++ b/datasets/gebieden/dataset.json
@@ -4,7 +4,6 @@
   "title": "gebieden",
   "status": "beschikbaar",
   "version": "0.0.1",
-  "identifier": "identificatie",
   "auth": "OPENBAAR",
   "authorizationGrantor": "Basisinformatie",
   "owner": "Gemeente Amsterdam",

--- a/datasets/gebieden_azure/dataset.json
+++ b/datasets/gebieden_azure/dataset.json
@@ -4,7 +4,6 @@
   "title": "gebieden",
   "status": "niet_beschikbaar",
   "version": "2.0.0",
-  "identifier": "identificatie",
   "auth": "OPENBAAR",
   "authorizationGrantor": "gebruik.basisinformatie@amsterdam.nl",
   "owner": "Onderzoek, Informatie en Statistiek",


### PR DESCRIPTION
These are never used. The ones on the tables are used instead.