### PR TITLE
Make pre-commit work with Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # Supported hooks: https://pre-commit.com/hooks.html
 # Running "make format" fixes most issues for you
 repos:
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
@@ -48,7 +48,7 @@ repos:
     rev: v0.991
     hooks:
       - id: mypy
-        language_version: python3.9
+        language_version: python3
   - repo: https://github.com/pycqa/isort
     rev: 5.11.4
     hooks:


### PR DESCRIPTION
Its author says the Python version doesn't matter for black (which also moved to github.com/psf): https://stackoverflow.com/a/69465958