### PR TITLE
Fix GH Action, again

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,15 +12,17 @@ jobs:
       SCHEMA_URL: datasets/
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch_depth: 0
       - name: "Fetch master branch"  # So we can diff against it.
         run: |
-          git fetch origin master --depth=100  # Should be enough to determine merge base.
+          git fetch origin master
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9.x'
       - id: changed-datasets
         # We are only interested in changed and new (not deleted) datasets files.
-        run: echo "::set-output name=DATASET_FILES::$(git diff --name-only --diff-filter=d --merge-base origin/master -- datasets)"
+        run: echo "::set-output name=DATASET_FILES::$(git diff --name-only --diff-filter=d origin/master.. -- datasets)"
         shell: bash
       - run: |
           echo "Dataset files to be validated:"


### PR DESCRIPTION
Reverts some of the recent commits to the pre-commit workflow. They don't seem to work. We'll have to accept unrelated changes showing up in the logs. Just rebase.