### PR TITLE
BRK2 stukdelen aantekeningen.

### DIFF
--- a/datasets/brk2/aantekeningenkadastraleobjecten/v1.0.0.json
+++ b/datasets/brk2/aantekeningenkadastraleobjecten/v1.0.0.json
@@ -1,0 +1,142 @@
+{
+  "id": "aantekeningenkadastraleobjecten",
+  "type": "table",
+  "version": "1.0.0",
+  "auth": "BRK/RS",
+  "reasonsNonPublic": [
+    "5.1 1d: Bevat persoonsgegevens",
+    "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer"
+  ],
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": [
+        "beginGeldigheid",
+        "eindGeldigheid"
+      ]
+    }
+  },
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": [
+      "identificatie",
+      "volgnummer"
+    ],
+    "required": [
+      "schema",
+      "identificatie",
+      "volgnummer"
+    ],
+    "display": "volgnummer",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/schema"
+      },
+      "volgnummer": {
+        "type": "integer",
+        "description": "Uniek volgnummer van de toestand van het object."
+      },
+      "registratiedatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de toestand is geregistreerd."
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Begindatum geldigheid object."
+      },
+      "eindGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geldigheid object."
+      },
+      "einddatumRecht": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Een einddatum op een zakelijk recht (via tenaamstelling) wordt nu in een apart attribuut geleverd.Voorheen werd dit geleverd in het attribuut einddatum. Tenaamstellingen van een eindig recht worden niet automatisch beëindigd. Wel krijgt zo’n tenaamstelling de aantekening dat het recht eindig is en op een bepaalde datum zal eindigen of geëindigd is."
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het door het Kadaster toegekende landelijk unieke nummer aan deze aantekening."
+      },
+      "aard": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "omschrijving": {
+            "type": "string"
+          }
+        },
+        "description": "De aard van de aantekening."
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Omschrijving bij de aantekening"
+      },
+      "betreftGedeelteVanPerceel": {
+        "type": "boolean",
+        "description": "Er bestaan nu nog speciale aardAantekening-varianten met de toevoeging op een gedeelte van een perceel. Voorbeeld: 81. In het vervolg zal deze aard worden vervangen door de oorspronkelijke variant, in dit geval 80 ”Voorwaarden WKPB besluiten”, waarbij de indicator betreftGedeelteVanPerceel op true gezet wordt."
+      },
+      "heeftBrkBetrokkenPersoon": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk2:kadastralesubjecten",
+        "description": "Identificatie van het betrokken subject"
+      },
+      "heeftBetrekkingOpBrkKadastraalObject": {
+        "shortname": "hftBtrkOpKot",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          },
+          "volgnummer": {
+            "type": "integer"
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "relation": "brk2:kadastraleobjecten",
+        "description": "Identificatie van het kadastrale object (onroerende zaak)"
+      },
+      "isGebaseerdOpBrkStukdeel": {
+        "type": "string",
+        "relation": "brk2:stukdelen",
+        "description": "Identificatie van het betrokken stukdeel"
+      },
+      "einddatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+      },
+      "datumActueelTot": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum van de cyclus, eventueel in combinatie met het kenmerk Status"
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk2/aantekeningenkadastraleobjecten/v1.0.0.json
+++ b/datasets/brk2/aantekeningenkadastraleobjecten/v1.0.0.json
@@ -118,7 +118,12 @@
         "description": "Identificatie van het kadastrale object (onroerende zaak)"
       },
       "isGebaseerdOpBrkStukdeel": {
-        "type": "string",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
         "relation": "brk2:stukdelen",
         "description": "Identificatie van het betrokken stukdeel"
       },

--- a/datasets/brk2/aantekeningenrechten/v1.0.0.json
+++ b/datasets/brk2/aantekeningenrechten/v1.0.0.json
@@ -53,7 +53,7 @@
         "description": "Omschrijving bij de aantekening"
       },
       "betreftGedeelteVanPerceel": {
-        "type": "boolean",
+        "type": "string",
         "description": "Er bestaan nu nog speciale aardAantekening-varianten met de toevoeging op een gedeelte van een perceel. Voorbeeld: 81. In het vervolg zal deze aard worden vervangen door de oorspronkelijke variant, in dit geval 80 ”Voorwaarden WKPB besluiten”, waarbij de indicator betreftGedeelteVanPerceel op true gezet wordt."
       },
       "betrokkenBrkTenaamstelling": {
@@ -61,8 +61,8 @@
         "items": {
           "type": "object",
           "properties": {
-            "identificatie": {
-              "type": "string"
+            "neuronId": {
+              "type": "integer"
             },
             "volgnummer": {
               "type": "integer"
@@ -94,7 +94,12 @@
         "description": "Identificatie van het betrokken subject"
       },
       "isGebaseerdOpBrkStukdeel": {
-        "type": "string",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
         "relation": "brk2:stukdelen",
         "description": "Identificatie van het betrokken stukdeel"
       },

--- a/datasets/brk2/aantekeningenrechten/v1.0.0.json
+++ b/datasets/brk2/aantekeningenrechten/v1.0.0.json
@@ -1,0 +1,118 @@
+{
+  "id": "aantekeningenrechten",
+  "type": "table",
+  "version": "1.0.0",
+  "auth": "BRK/RS",
+  "reasonsNonPublic": [
+    "5.1 1d: Bevat persoonsgegevens",
+    "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer"
+  ],
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "neuronId",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/schema"
+      },
+      "neuronId": {
+        "type": "integer",
+        "description": "Neuron ID",
+        "provenance": "id"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het aan deze aantekening toegekende landelijk unieke nummer."
+      },
+      "einddatumRecht": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Een einddatum op een zakelijk recht (via tenaamstelling) wordt nu in een apart attribuut geleverd.Voorheen werd dit geleverd in het attribuut einddatum. Tenaamstellingen van een eindig recht worden niet automatisch beëindigd. Wel krijgt zo’n tenaamstelling de aantekening dat het recht eindig is en op een bepaalde datum zal eindigen of geëindigd is."
+      },
+      "aard": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "omschrijving": {
+            "type": "string"
+          }
+        },
+        "description": "De aard van de aantekening."
+      },
+      "omschrijving": {
+        "type": "string",
+        "description": "Omschrijving bij de aantekening"
+      },
+      "betreftGedeelteVanPerceel": {
+        "type": "boolean",
+        "description": "Er bestaan nu nog speciale aardAantekening-varianten met de toevoeging op een gedeelte van een perceel. Voorbeeld: 81. In het vervolg zal deze aard worden vervangen door de oorspronkelijke variant, in dit geval 80 ”Voorwaarden WKPB besluiten”, waarbij de indicator betreftGedeelteVanPerceel op true gezet wordt."
+      },
+      "betrokkenBrkTenaamstelling": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk2:tenaamstellingen",
+        "description": "Identificatie van de betrokken tenaamstelling"
+      },
+      "heeftBrkBetrokkenPersoon": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk2:kadastralesubjecten",
+        "description": "Identificatie van het betrokken subject"
+      },
+      "isGebaseerdOpBrkStukdeel": {
+        "type": "string",
+        "relation": "brk2:stukdelen",
+        "description": "Identificatie van het betrokken stukdeel"
+      },
+      "einddatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum geeft aan wanneer een bepaalde aantekening volgens het ingeschreven stuk niet langer meer rechtsgeldig is."
+      },
+      "datumActueelTot": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum van de cyclus, eventueel in combinatie met het kenmerk Status"
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      }
+    }
+  }
+}

--- a/datasets/brk2/dataset.json
+++ b/datasets/brk2/dataset.json
@@ -50,6 +50,27 @@
       "activeVersions": {
         "1.0.0": "meta/v1.0.0"
       }
+    },
+    {
+      "id": "stukdelen",
+      "$ref": "stukdelen/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "stukdelen/v1.0.0"
+      }
+    },
+    {
+      "id": "aantekeningenkadastraleobjecten",
+      "$ref": "aantekeningenkadastraleobjecten/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "aantekeningenkadastraleobjecten/v1.0.0"
+      }
+    },
+    {
+      "id": "aantekeningenrechten",
+      "$ref": "aantekeningenrechten/v1.0.0",
+      "activeVersions": {
+        "1.0.0": "aantekeningenrechten/v1.0.0"
+      }
     }
   ]
 }

--- a/datasets/brk2/kadastralesubjecten/v1.0.0.json
+++ b/datasets/brk2/kadastralesubjecten/v1.0.0.json
@@ -268,19 +268,16 @@
             "provenance": "$.woonadresBuitenlandWoonplaats"
           },
           "buitenlandRegio": {
-            "auth": "BRK/RSN",
             "type": "string",
             "provenance": "$.woonadresBuitenlandRegio",
             "description": "Buitenlands adres regio"
           },
           "buitenlandLandCode": {
-            "auth": "BRK/RSN",
             "type": "string",
             "provenance": "$.woonadresBuitenlandLandCode",
             "description": "Buitenlands adres land. Code"
           },
           "buitenlandLandOmschrijving": {
-            "auth": "BRK/RSN",
             "type": "string",
             "provenance": "$.woonadresBuitenlandLandOmschrijving",
             "description": "Buitenlands adres land. Omschrijving"

--- a/datasets/brk2/stukdelen/v1.0.0.json
+++ b/datasets/brk2/stukdelen/v1.0.0.json
@@ -11,7 +11,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
-    "identifier": "neuronId",
+    "identifier": "identificatie",
     "required": [
       "schema",
       "neuronId",
@@ -49,7 +49,7 @@
             "type": "string"
           },
           "bedrag": {
-            "type": "integer"
+            "type": "number"
           }
         },
         "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen."
@@ -61,9 +61,6 @@
           "properties": {
             "identificatie": {
               "type": "string"
-            },
-            "volgnummer": {
-              "type": "integer"
             },
             "beginGeldigheid": {
               "type": "string",
@@ -85,9 +82,6 @@
           "properties": {
             "identificatie": {
               "type": "string"
-            },
-            "volgnummer": {
-              "type": "integer"
             },
             "beginGeldigheid": {
               "type": "string",
@@ -123,9 +117,6 @@
             "identificatie": {
               "type": "string"
             },
-            "volgnummer": {
-              "type": "integer"
-            },
             "beginGeldigheid": {
               "type": "string",
               "format": "date-time"
@@ -149,6 +140,7 @@
       },
       "tijdstipAanbiedingStuk": {
         "type": "string",
+        "format": "date-time",
         "description": "Het tijdstip waarop een ter inschrijving aangeboden stuk is ontvangen met inachtneming van de openingstijden en -dagen van het Kadaster. Als tijdstip van inschrijving geldt het tijdstip van aanbieding van de voor de inschrijving vereiste stukken."
       },
       "reeks": {
@@ -201,7 +193,7 @@
         "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
       },
       "tekeningIngeschreven": {
-        "type": "boolean",
+        "type": "string",
         "description": "Er is sprake van een appartementstekening (splitsingstekening van appartementen) als bijlage bij het stuk. (J/N/NULL)"
       },
       "tijdstipOndertekening": {

--- a/datasets/brk2/stukdelen/v1.0.0.json
+++ b/datasets/brk2/stukdelen/v1.0.0.json
@@ -1,0 +1,228 @@
+{
+  "id": "stukdelen",
+  "type": "table",
+  "version": "1.0.0",
+  "auth": "BRK/RS",
+  "reasonsNonPublic": [
+    "5.1 1d: Bevat persoonsgegevens",
+    "5.1 2e: Zwaarwegend belang: eerbiediging van de persoonlijke levenssfeer"
+  ],
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "identifier": "neuronId",
+    "required": [
+      "schema",
+      "neuronId",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/schema"
+      },
+      "neuronId": {
+        "type": "integer",
+        "description": "Neuron ID"
+      },
+      "identificatie": {
+        "type": "string",
+        "description": "Het door het Kadaster toegekende landelijk unieke nummer aan het stukdeel."
+      },
+      "aard": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "omschrijving": {
+            "type": "string"
+          }
+        },
+        "description": "Aanduiding voor de aard van een deel van het ter inschrijving aangeboden stuk (rechtsfeit)."
+      },
+      "bedragTransactie": {
+        "type": "object",
+        "properties": {
+          "valuta": {
+            "type": "string"
+          },
+          "bedrag": {
+            "type": "integer"
+          }
+        },
+        "description": "Het in een ter inschrijving aangeboden stuk vermelde bedrag, waarvoor 1 of meer onroerende zaken zijn verkregen."
+      },
+      "isBronVoorBrkTenaamstelling": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk2:tenaamstellingen",
+        "description": "Geeft weer welke tenaamstelling is ontstaan op basis van dit stukdeel"
+      },
+      "isBronVoorBrkAantekeningKadastraalObject": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk2:aantekeningenkadastraleobjecten",
+        "description": "Geeft weer welke aantekening kadastraal object is ontstaan op basis van dit stukdeel"
+      },
+      "isBronVoorBrkAantekeningRecht": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            }
+          }
+        },
+        "relation": "brk2:aantekeningenrechten",
+        "description": "Geeft weer welke aantekening recht is ontstaan op basis van dit stukdeel"
+      },
+      "isBronVoorBrkZakelijkRecht": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "identificatie": {
+              "type": "string"
+            },
+            "volgnummer": {
+              "type": "integer"
+            },
+            "beginGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "eindGeldigheid": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "relation": "brk2:zakelijkerechten",
+        "description": "Geeft weer welk zakelijk recht is ontstaan op basis van dit stukdeel."
+      },
+      "stukidentificatie": {
+        "type": "string",
+        "description": "Het door het Kadaster toegekende landelijk unieke nummer aan het stuk."
+      },
+      "portefeuillenummerAkr": {
+        "type": "string",
+        "description": "Portefeuillenummer toegekend aan het stuk in het AKR-systeem."
+      },
+      "tijdstipAanbiedingStuk": {
+        "type": "string",
+        "description": "Het tijdstip waarop een ter inschrijving aangeboden stuk is ontvangen met inachtneming van de openingstijden en -dagen van het Kadaster. Als tijdstip van inschrijving geldt het tijdstip van aanbieding van de voor de inschrijving vereiste stukken."
+      },
+      "reeks": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "omschrijving": {
+            "type": "string"
+          }
+        },
+        "description": "Verwijzing naar de oorspronkelijke (mogelijk tussentijds vervallen) Kadastervestiging waar het stuk oorspronkelijk is ingeschreven."
+      },
+      "volgnummerStuk": {
+        "type": "integer",
+        "description": "Volgnummer van het stuk."
+      },
+      "registercodeStuk": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "omschrijving": {
+            "type": "string"
+          }
+        },
+        "description": "Het soort register, aangeduid met een code."
+      },
+      "soortRegisterStuk": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "omschrijving": {
+            "type": "string"
+          }
+        },
+        "description": "Het register waarvan een ter inschrijving aangeboden stuk deel uitmaakt."
+      },
+      "deelSoortStuk": {
+        "type": "string",
+        "description": "Identificatie van het stuk binnen zijn soort."
+      },
+      "toestandsdatum": {
+        "type": "string",
+        "format": "date-time",
+        "description": "De datum waarop de geleverde toestand van het onderliggende kadatraal object is ontstaan in de Basisregistratie Kadaster. (normaal gesproken maximaal 2 weken later t.o.v. tijdstip inschrijving)"
+      },
+      "tekeningIngeschreven": {
+        "type": "boolean",
+        "description": "Er is sprake van een appartementstekening (splitsingstekening van appartementen) als bijlage bij het stuk. (J/N/NULL)"
+      },
+      "tijdstipOndertekening": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Het tijdstip waarop het stuk ondertekend is."
+      },
+      "toelichtingBewaarder": {
+        "type": "string",
+        "description": "Toelichtende tekst van de bewaarder bij het stuk. Een Toelichting Bewaarder wordt opgevoerd wanneer een toelichting bij gegevens in de registratie noodzakelijk is."
+      },
+      "datumActueelTot": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Einddatum van de cyclus, eventueel in combinatie met het kenmerk Status"
+      },
+      "beginGeldigheid": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Begindatum geldigheid."
+      }
+    }
+  }
+}

--- a/datasets/brk2/stukdelen/v1.0.0.json
+++ b/datasets/brk2/stukdelen/v1.0.0.json
@@ -59,8 +59,8 @@
         "items": {
           "type": "object",
           "properties": {
-            "identificatie": {
-              "type": "string"
+            "neuronId": {
+              "type": "integer"
             },
             "beginGeldigheid": {
               "type": "string",

--- a/datasets/brk2/zakelijkerechten/v1.0.0.json
+++ b/datasets/brk2/zakelijkerechten/v1.0.0.json
@@ -26,11 +26,10 @@
     ],
     "required": [
       "schema",
-      "id",
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "identificatie",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.2.0#/definitions/schema"


### PR DESCRIPTION
BRK2:

- zakelijkerechten: removed `id`
- kadastralesubjecten: removed redundant `auth` attribute
- added _stukdelen_ table
- added _aantekeningenkadastraleobjecten_ table
- added _aantekeningenrechten_ table