### PR TITLE
Aanpassing namen van 4 schemas openbare verlichting kabels

### DIFF
--- a/datasets/leidingeninfrastructuur/bovengrondseKabels/v1.1.0.json
+++ b/datasets/leidingeninfrastructuur/bovengrondseKabels/v1.1.0.json
@@ -1,9 +1,9 @@
 {
-  "id": "bovengrondseKabels",
+  "id": "amsterdamOvlBovengrondseKabels",
   "type": "table",
   "version": "1.1.0",
-  "title": "Bovengrondse kabels",
-  "description": "Locaties en contextuele informatie bovengrondse kabels.",
+  "title": "Amsterdam openbare verlichting ondergrondse kabels",
+  "description": "Bovengrondse kabels openbare verlichting die door de Gemeente Amsterdam worden beheerd.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -16,7 +16,7 @@
     "properties": {
       "id": {
         "type": "integer",
-        "description": "Business-key: unieke aanduiding per voorkomen in tabel leidingeninfrastructuur_kabelsbovengronds (bestaande uit Kabels)."
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel."
       },
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/leidingeninfrastructuur/mantelbuizen/v1.0.0.json
+++ b/datasets/leidingeninfrastructuur/mantelbuizen/v1.0.0.json
@@ -1,9 +1,9 @@
 {
-  "id": "mantelbuizen",
+  "id": "amsterdamOvlOndergrondseMantelbuizen",
   "type": "table",
   "version": "1.0.0",
-  "title": "Mantelbuizen",
-  "description": "Locaties en contextuele informatie mantelbuizen.",
+  "title": "Amsterdam openbare verlichting ondergrondse mantelbuizen",
+  "description": "Locaties en contextuele informatie ondergrondse mantelbuizen voor de openbare verlichting die door de Gemeente Amsterdam worden beheerd",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -16,7 +16,7 @@
     "properties": {
       "id": {
         "type": "integer",
-        "description": "Business-key: unieke aanduiding per voorkomen in tabel Mantelbuizen (bestaande uit Mantelbuizen)."
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel."
       },
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/leidingeninfrastructuur/ondergrondseKabels/v1.1.0.json
+++ b/datasets/leidingeninfrastructuur/ondergrondseKabels/v1.1.0.json
@@ -1,9 +1,9 @@
 {
-  "id": "ondergrondseKabels",
+  "id": "amsterdamOvlOndergrondseKabels",
   "type": "table",
   "version": "1.1.0",
-  "title": "Ondergrondse kabels",
-  "description": "Locaties en contextuele informatie ondergrondse kabels.",
+  "title": "Amsterdam openbare verlichting ondergrondse kabels",
+  "description": "Ondergrondse kabels openbare verlichting die door de Gemeente Amsterdam worden beheerd.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -16,7 +16,7 @@
     "properties": {
       "id": {
         "type": "integer",
-        "description": "Business-key: unieke aanduiding per voorkomen in tabel leidingeninfrastructuur_kabelsbovengronds (bestaande uit Kabels)."
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel."
       },
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/leidingeninfrastructuur/punten/v1.1.0.json
+++ b/datasets/leidingeninfrastructuur/punten/v1.1.0.json
@@ -1,9 +1,9 @@
 {
-  "id": "punten",
+  "id": "amsterdamOvlPunten",
   "type": "table",
   "version": "1.1.0",
-  "title": "Punten",
-  "description": "Een Punt is een verbinding tussen 2 of meerdere kabels, eindpunt van een kabel, aardingspunt of opstijgpunt.",
+  "title": "Gemeente Amsterdam Punten Openbare verlichting ",
+  "description": "Punten openbare verlichting die door de Gemeente Amsterdam worden beheerd. Een Punt is een verbinding tussen 2 of meerdere kabels, eindpunt van een kabel, aardingspunt of opstijgpunt.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",


### PR DESCRIPTION
4 tabelnamen aangepast zodat het voor gebruikers duidelijker wordt naar welke data ze kijken.

Bovengrondse_kabels → Amsterdam_OVL_Bovengrondse_kabels
Ondergrondse_kabels → Amsterdam_OVL_Ondergrondse_kabels
Ondergrondse_Mantelbuizen → Amsterdam_OVL_Ondergrondse_Mantelbuizen
Punten → Amsterdam_OVL_Punten