### PR TITLE
Bump schematools to 5.6.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: isort
         args: ['--filter-files']
   - repo: https://github.com/Amsterdam/schema-tools
-    rev: "v5.6.6"
+    rev: "v5.6.8"
     hooks:
       - id: validate-schema
         args: ['https://schemas.data.amsterdam.nl/schema@v1.3.0', "--extra_meta_schema_url", "https://schemas.data.amsterdam.nl/schema@v2.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ dev =
     isort
     tbump >= 6.3.2  # Bumping version number and Git tagging
     build  # PEP5127 package builder (recommended by PYPA)
-    amsterdam-schema-tools >= 5.6.6
+    amsterdam-schema-tools >= 5.6.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
To fix the validation (was broken because a new pg-grant was being used).