### PR TITLE
Rename schema v2.0.0 to v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,10 +58,10 @@ repos:
     rev: "v5.6.9"
     hooks:
       - id: validate-schema
-        args: ['https://schemas.data.amsterdam.nl/schema@v1.3.0', "--extra_meta_schema_url", "https://schemas.data.amsterdam.nl/schema@v2.0.0"]
+        args: ['https://schemas.data.amsterdam.nl/schema@v1.3.0', "--extra_meta_schema_url", "https://schemas.data.amsterdam.nl/schema@v2"]
         files: '^datasets/.*\.json$'
         verbose: true # so we can see against which metaschema it is valid
         exclude: "^schema@.+" # exclude meta schemas
       - id: validate-publishers
-        args: ['https://schemas.data.amsterdam.nl/schema@v2.0.0', '--schema-url', './publishers']
+        args: ['https://schemas.data.amsterdam.nl/schema@v2', '--schema-url', './publishers']
         verbose: true # so we can see against which metaschema it is valid

--- a/schema@v2/dataset.json
+++ b/schema@v2/dataset.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/dataset@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/dataset@v2",
   "type": "object",
   "allOf": [
     {
-      "$ref": "./schema@v2.0.0#/definitions/basicProperties"
+      "$ref": "./schema@v2#/definitions/basicProperties"
     }
   ],
   "required": [
@@ -21,7 +21,7 @@
       "const": "dataset"
     },
     "version": {
-      "$ref": "./schema@v2.0.0#/definitions/version"
+      "$ref": "./schema@v2#/definitions/version"
     },
     "status": {
       "type": "string",
@@ -113,7 +113,7 @@
     },
     "contactPoint": {
       "description": "Person and (optional) e-mail.",
-      "$ref": "./schema@v2.0.0#/definitions/contactPoint",
+      "$ref": "./schema@v2#/definitions/contactPoint",
       "default": {
         "name": "datapunt",
         "email": "datapunt@amsterdam.nl"
@@ -121,7 +121,7 @@
     },
     "crs": {
       "description": "Coordinate reference system",
-      "$ref": "./schema@v2.0.0#/definitions/crs"
+      "$ref": "./schema@v2#/definitions/crs"
     },
     "tables": {
       "type": "array",
@@ -129,7 +129,7 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "./table@v2.0.0"
+            "$ref": "./table@v2"
           },
           {
             "type": "object",

--- a/schema@v2/distribution.json
+++ b/schema@v2/distribution.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/distribution@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/distribution@v2",
   "type": "object",
   "properties": {
     "title": {

--- a/schema@v2/meta/auth.json
+++ b/schema@v2/meta/auth.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/meta/auth@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/meta/auth@v2",
   "$vocabulary": {
-    "https://schemas.data.amsterdam.nl/meta/auth@v2.0.0": true
+    "https://schemas.data.amsterdam.nl/meta/auth@v2": true
   },
   "$recursiveAnchor": true,
   "title": "Amsterdam Schema authorization",

--- a/schema@v2/meta/provenance.json
+++ b/schema@v2/meta/provenance.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/meta/provenance@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/meta/provenance@v2",
   "$vocabulary": {
-    "https://schemas.data.amsterdam.nl/meta/provenance@v2.0.0": true
+    "https://schemas.data.amsterdam.nl/meta/provenance@v2": true
   },
   "$recursiveAnchor": true,
   "title": "Amsterdam Schema provenance",

--- a/schema@v2/meta/relation.json
+++ b/schema@v2/meta/relation.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/meta/relation@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/meta/relation@v2",
   "$vocabulary": {
-    "https://schemas.data.amsterdam.nl/meta/relation@v2.0.0": true
+    "https://schemas.data.amsterdam.nl/meta/relation@v2": true
   },
   "$recursiveAnchor": true,
   "properties": {

--- a/schema@v2/meta/unit.json
+++ b/schema@v2/meta/unit.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/meta/unit@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/meta/unit@v2",
   "$vocabulary": {
-    "https://schemas.data.amsterdam.nl/meta/unit@v2.0.0": true
+    "https://schemas.data.amsterdam.nl/meta/unit@v2": true
   },
   "$recursiveAnchor": true,
   "title": "Amsterdam Schema unit",

--- a/schema@v2/publisher.json
+++ b/schema@v2/publisher.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/publisher@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/publisher@v2",
   "type": "object",
   "required": [
     "name",

--- a/schema@v2/row-meta-schema.json
+++ b/schema@v2/row-meta-schema.json
@@ -1,16 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/row-meta-schema@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/row-meta-schema@v2",
   "definitions": {
     "rootProperty": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "auth": {
-          "$ref": "https://schemas.data.amsterdam.nl/schema@v2.0.0#/definitions/auth"
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v2#/definitions/auth"
         },
         "reasonsNonPublic": {
-          "$ref": "https://schemas.data.amsterdam.nl/schema@v2.0.0#/definitions/reasonsNonPublic"
+          "$ref": "https://schemas.data.amsterdam.nl/schema@v2#/definitions/reasonsNonPublic"
         },
         "description": {
           "type": "string"
@@ -78,7 +78,7 @@
           ]
         },
         "provenance": {
-          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v2.0.0#properties/provenance"
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v2#/properties/provenance"
         },
         "relation": {
           "type": "string"
@@ -92,7 +92,7 @@
         },
         "crs": {
           "description": "Coordinate reference system",
-          "$ref": "./schema@v2.0.0#/definitions/crs"
+          "$ref": "./schema@v2#/definitions/crs"
         },
         "unit": {
           "type": [

--- a/schema@v2/schema.json
+++ b/schema@v2/schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/schema@v2.0.0#",
+  "$id": "https://schemas.data.amsterdam.nl/schema@v2#",
   "title": "Amsterdam Schema",
   "$vocabulary": {
     "https://json-schema.org/draft/2019-09/vocab/core": true,
-    "https://schemas.data.amsterdam.nl/meta/auth@v2.0.0": false,
-    "https://schemas.data.amsterdam.nl/meta/units@v2.0.0": false,
-    "https://schemas.data.amsterdam.nl/meta/relation@v2.0.0": false,
-    "https://schemas.data.amsterdam.nl/meta/provenance@v2.0.0": false
+    "https://schemas.data.amsterdam.nl/meta/auth@v2": false,
+    "https://schemas.data.amsterdam.nl/meta/units@v2": false,
+    "https://schemas.data.amsterdam.nl/meta/relation@v2": false,
+    "https://schemas.data.amsterdam.nl/meta/provenance@v2": false
   },
   "$recursiveAnchor": true,
   "definitions": {
@@ -39,7 +39,7 @@
           "type": "string"
         },
         "provenance": {
-          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v2.0.0#properties/provenance"
+          "$ref": "https://schemas.data.amsterdam.nl/meta/provenance@v2#/properties/provenance"
         },
         "title": {
           "$ref": "#/definitions/title"
@@ -160,16 +160,16 @@
     {
       "oneOf": [
         {
-          "$ref": "./dataset@v2.0.0"
+          "$ref": "./dataset@v2"
         },
         {
-          "$ref": "./table@v2.0.0"
+          "$ref": "./table@v2"
         },
         {
-          "$ref": "./row-meta-schema@v2.0.0"
+          "$ref": "./row-meta-schema@v2"
         },
         {
-          "$ref": "./publisher@v2.0.0"
+          "$ref": "./publisher@v2"
         }
       ]
     },
@@ -182,7 +182,7 @@
         }
       },
       "then": {
-        "$ref": "./dataset@v2.0.0"
+        "$ref": "./dataset@v2"
       }
     },
     {
@@ -194,7 +194,7 @@
         }
       },
       "then": {
-        "$ref": "./table@v2.0.0"
+        "$ref": "./table@v2"
       }
     },
     {
@@ -206,7 +206,7 @@
         }
       },
       "then": {
-        "$ref": "./publisher@v2.0.0"
+        "$ref": "./publisher@v2"
       }
     },
     {
@@ -219,7 +219,7 @@
         }
       },
       "then": {
-        "$ref": "./row-meta-schema@v2.0.0"
+        "$ref": "./row-meta-schema@v2"
       }
     }
   ]

--- a/schema@v2/table.json
+++ b/schema@v2/table.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://schemas.data.amsterdam.nl/table@v2.0.0",
+  "$id": "https://schemas.data.amsterdam.nl/table@v2",
   "type": "object",
   "allOf": [
     {
-      "$ref": "./schema@v2.0.0#/definitions/basicProperties"
+      "$ref": "./schema@v2#/definitions/basicProperties"
     }
   ],
   "required": [
@@ -29,7 +29,7 @@
     },
     "crs": {
       "description": "Coordinate reference system",
-      "$ref": "./schema@v2.0.0#/definitions/crs"
+      "$ref": "./schema@v2#/definitions/crs"
     },
     "temporal": {
       "type": "object",
@@ -54,7 +54,7 @@
     "schema": {
       "oneOf": [
         {
-          "$ref": "./row-meta-schema@v2.0.0"
+          "$ref": "./row-meta-schema@v2"
         },
         {
           "type": "object",


### PR DESCRIPTION
Keeping around minor and patch versions of the metaschemas is an excuse for not fixing issues with schemas. It also makes it much harder to use git/GitHub because new versions are new files. Let's just keep a v2 file from now on and edit that.

No schemas need to be changed, because none were explicitly referring to v2.