### PR TITLE
Remove double __main__ from publish/cli.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,6 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bandit
-          - bandit<1.7.3  # pinning, because 1.7.3 is imcompatible, flake8-bandit needs to fix this
           - flake8-bugbear
           - flake8-builtins
           - flake8-comprehensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ where = src
 tests =
     mypy
     flake8
-    flake8-bandit  # security checks
     flake8-bugbear  # assorted opinionated checks
     flake8-builtins  # check for name collision with builtins
     flake8-comprehensions
@@ -96,12 +95,18 @@ select = A, B, C, D, E, F, G, P, RST, S, T, W, B9, ISC
 # select = B, C, D, E, F, G, RST, W, B9, ISC
 doctests = True
 ignore=
-    D100  # Missing docstring in public module
-    D103  # Missing docstring in public function
-    D104  # Missing docstring in public package
-    E203  # Black may add spaces in slice[func(v) : end] syntax
-    E231  # Black leaves commas after combining lines
-    W503  # line break before binary operator (incompatible with black):
+    # Missing docstring in public module
+    D100,
+    # Missing docstring in public function
+    D103,
+    # Missing docstring in public package
+    D104,
+    # Black may add spaces in slice[func(v) : end] syntax
+    E203,
+    # Black leaves commas after combining lines
+    E231,
+    # line break before binary operator (incompatible with black):
+    W503,
 exclude=
     .git
     .cache

--- a/src/amsterdam_schema/publish/cli.py
+++ b/src/amsterdam_schema/publish/cli.py
@@ -119,10 +119,7 @@ def get_index_file_obj(publishable_paths: List[List[str]], files_root: Path) -> 
 
         # Check for duplicate ids
         if key in index:
-            raise Exception(
-                f"Datasets with duplicate id:'{key}' \
-                in {folder} and {index[key]}."
-            )
+            raise Exception(f"Datasets with duplicate id:{key!r} in {folder} and {index[key]}.")
 
         index[key] = folder
     return BytesIO(json.dumps(index).encode())
@@ -363,10 +360,6 @@ def generate_publisher_index() -> None:
     by schematools.
     """
     sys.stdout.write(get_publisher_index())
-
-
-if __name__ == "__main__":
-    main()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also updated the pre-commit config and setup.cfg. flake8-bandit would not run at all, so removed that. We already run bandit separately in pre-commit. flake8 would not run because of a mistake in setup.cfg, see https://stackoverflow.com/a/74558566. Finally, fixed an issue found by flake8.