### PR TITLE
Remove !"bronhouder onbekend" constraint from metaschemas

### DIFF
--- a/schema@v1.3.0/dataset.json
+++ b/schema@v1.3.0/dataset.json
@@ -62,10 +62,7 @@
     "creator": {
       "description": "Naam van de bronhouder.",
       "type": "string",
-      "minLength": 1,
-      "not": {
-        "const": "bronhouder onbekend"
-      }
+      "minLength": 1
     },
     "owner": {
       "type": "string",

--- a/schema@v2/dataset.json
+++ b/schema@v2/dataset.json
@@ -71,10 +71,7 @@
     "creator": {
       "description": "Naam van de bronhouder.",
       "type": "string",
-      "minLength": 1,
-      "not": {
-        "const": "bronhouder onbekend"
-      }
+      "minLength": 1
     },
     "owner": {
       "type": "string",


### PR DESCRIPTION
We can re-enable this once we've actually got rid of the occurrences of this string. That problem is out of scope for now.