### PR TITLE
Remove redundant wgs84 fields from kwaliteitsmonitor

### DIFF
--- a/datasets/kwaliteitsmonitor/dataset.json
+++ b/datasets/kwaliteitsmonitor/dataset.json
@@ -4,7 +4,7 @@
   "title": "Kwaliteitsmonitor",
   "status": "beschikbaar",
   "description": "Per verblijfsobject, ligplaats of standplaats de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "dateCreated": "2022-11-23T00:00:00+01:00",
   "dateModified": "2022-12-14T00:00:00+01:00",
   "license": "Creative Commons, Naamsvermelding",
@@ -43,23 +43,23 @@
     },
     {
       "id": "wonenLigplaats",
-      "$ref": "wonenLigplaats/v1.0.0",
+      "$ref": "wonenLigplaats/v2.0.0",
       "activeVersions": {
-        "1.0.0": "wonenLigplaats/v1.0.0"
+        "2.0.0": "wonenLigplaats/v2.0.0"
       }
     },
     {
       "id": "wonenStandplaats",
-      "$ref": "wonenStandplaats/v1.0.0",
+      "$ref": "wonenStandplaats/v2.0.0",
       "activeVersions": {
-        "1.0.0": "wonenStandplaats/v1.0.0"
+        "2.0.0": "wonenStandplaats/v2.0.0"
       }
     },
     {
       "id": "wonenVerblijfsobject",
-      "$ref": "wonenVerblijfsobject/v1.0.0",
+      "$ref": "wonenVerblijfsobject/v2.0.0",
       "activeVersions": {
-        "1.0.0": "wonenVerblijfsobject/v1.0.0"
+        "2.0.0": "wonenVerblijfsobject/v2.0.0"
       }
     }
   ]

--- a/datasets/kwaliteitsmonitor/wonenLigplaats/v2.0.0.json
+++ b/datasets/kwaliteitsmonitor/wonenLigplaats/v2.0.0.json
@@ -1,8 +1,8 @@
 {
-  "id": "wonenStandplaats",
+  "id": "wonenLigplaats",
   "type": "table",
-  "version": "1.0.0",
-  "description": "Per standplaats de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
+  "version": "2.0.0",
+  "description": "Per ligplaats de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -11,7 +11,7 @@
       "schema",
       "id"
     ],
-    "mainGeometry": "spsGeomMiddel",
+    "mainGeometry": "ligGeomMiddel",
     "display": "id",
     "properties": {
       "id": {
@@ -21,45 +21,45 @@
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
       },
-      "bkStandplaats": {
+      "bkLigplaats": {
         "type": "string",
-        "description": "Unieke key van de standplaats"  
+        "description": "Unieke key van de ligplaats"
       },
       "adres": {
         "type": "string",
-        "description": "Adres van de standplaats"
+        "description": "Adres van de ligplaats"
       },
       "huisnummer": {
         "type": "integer",
-        "description": "Huisnummer van de standplaats"
+        "description": "Huisnummer van de ligplaats"
       },
       "huisletter": {
         "type": "string",
-        "description": "Huisletter van de standplaats"
+        "description": "Huisletter van de ligplaats"
       },
       "huisnummertoevoeging": {
         "type": "string",
-        "description": "Huisnummertoevoeging van de standplaats"
+        "description": "Huisnummertoevoeging van de ligplaats"
       },
       "postcode": {
         "type": "string",
-        "description": "Postcode van de standplaats"
+        "description": "Postcode van de ligplaats"
       },
       "woonplaats": {
         "type": "string",
-        "description": "Woonplaats van de standplaats"
+        "description": "Woonplaats van de ligplaats"
       },
       "bagNagId": {
         "type": "string",
-        "description": "Unieke nummeraanduiding van de standplaats"
+        "description": "Unieke nummeraanduiding van de ligplaats"
       },
       "bagNagVolgnummer": {
         "type": "integer",
-        "description": "Volgnummer van de nummeraanduiding behorende bij de standplaats"
+        "description": "Volgnummer van de nummeraanduiding behorende bij de ligplaats"
       },
-      "spsIdentificatie": {
+      "ligIdentificatie": {
         "type": "string",
-        "description": "Unieke aanduiding van de standplaats"
+        "description": "Unieke aanduiding van de ligplaats"
       },
       "bagTypeadresseerbaarobject": {
         "type": "string",
@@ -67,19 +67,19 @@
       },
       "bagStatus": {
         "type": "string",
-        "description": "De fase van de levenscyclus van een standplaats waarin de betreffende standplaats zich bevindt"
+        "description": "De fase van de levenscyclus van een ligplaats waarin de betreffende ligplaats zich bevindt"
       },
       "bagStatusCode": {
         "type": "string",
-        "description": "Code behorend bij status standplaats"
+        "description": "Code behorend bij status ligplaats"
       },
       "bsdLigtInBeschermdGebied": {
         "type": "string",
-        "description": "Ja/Nee indicator welke aangeeft of de standplaats in een beschermd stads- of dorpgezicht valt"
+        "description": "Ja/Nee indicator welke aangeeft of de ligplaats in een beschermd stads- of dorpgezicht valt"
       },
       "bsdBeschermdStadsdorpsgezicht": {
         "type": "string",
-        "description": "Tot welk gebied van het beschermd stadsdorpsgezicht de standplaats behoort"
+        "description": "Tot welk gebied van het beschermd stadsdorpsgezicht de ligplaats behoort"
       },
       "gbdBrtIdentificatie": {
         "type": "string",
@@ -121,25 +121,15 @@
         "type": "string",
         "description": "Code van het gebiedsgericht werken"
       },
-      "spsGeomVlak": {
-        "description": "Geometrie van het type POLYGON van de standplaats",
+      "ligGeomVlak": {
+        "description": "Geometrie van het type POLYGON van de ligplaats",
         "$ref": "https://geojson.org/schema/Polygon.json",
         "crs": "EPSG:28992"
       },
-      "spsGeomVlakWgs84": {
-        "description": "Geometrie van het type POLYGON van de standplaats",
-        "$ref": "https://geojson.org/schema/Polygon.json",
-        "crs": "EPSG:4326"
-      },
-      "spsGeomMiddel": {
-        "description": "Geometrie van het middelpunt van de standplaats van het type POINT",
+      "ligGeomMiddel": {
+        "description": "Geometrie van het middelpunt van de ligplaats van het type POINT",
         "$ref": "https://geojson.org/schema/Point.json",
         "crs": "EPSG:28992"
-      },
-      "spsGeomMiddelWgs84": {
-        "description": "Geometrie van het middelpunt van de standplaats van het type POINT",
-        "$ref": "https://geojson.org/schema/Point.json",
-        "crs": "EPSG:4326"
       },
       "peildatumBag": {
         "type": "integer",

--- a/datasets/kwaliteitsmonitor/wonenStandplaats/v2.0.0.json
+++ b/datasets/kwaliteitsmonitor/wonenStandplaats/v2.0.0.json
@@ -1,8 +1,8 @@
 {
-  "id": "wonenLigplaats",
+  "id": "wonenStandplaats",
   "type": "table",
-  "version": "1.0.0",
-  "description": "Per ligplaats de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
+  "version": "2.0.0",
+  "description": "Per standplaats de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
@@ -11,7 +11,7 @@
       "schema",
       "id"
     ],
-    "mainGeometry": "ligGeomMiddel",
+    "mainGeometry": "spsGeomMiddel",
     "display": "id",
     "properties": {
       "id": {
@@ -21,45 +21,45 @@
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
       },
-      "bkLigplaats": {
+      "bkStandplaats": {
         "type": "string",
-        "description": "Unieke key van de ligplaats"  
+        "description": "Unieke key van de standplaats"
       },
       "adres": {
         "type": "string",
-        "description": "Adres van de ligplaats"
+        "description": "Adres van de standplaats"
       },
       "huisnummer": {
         "type": "integer",
-        "description": "Huisnummer van de ligplaats"
+        "description": "Huisnummer van de standplaats"
       },
       "huisletter": {
         "type": "string",
-        "description": "Huisletter van de ligplaats"
+        "description": "Huisletter van de standplaats"
       },
       "huisnummertoevoeging": {
         "type": "string",
-        "description": "Huisnummertoevoeging van de ligplaats"
+        "description": "Huisnummertoevoeging van de standplaats"
       },
       "postcode": {
         "type": "string",
-        "description": "Postcode van de ligplaats"
+        "description": "Postcode van de standplaats"
       },
       "woonplaats": {
         "type": "string",
-        "description": "Woonplaats van de ligplaats"
+        "description": "Woonplaats van de standplaats"
       },
       "bagNagId": {
         "type": "string",
-        "description": "Unieke nummeraanduiding van de ligplaats"
+        "description": "Unieke nummeraanduiding van de standplaats"
       },
       "bagNagVolgnummer": {
         "type": "integer",
-        "description": "Volgnummer van de nummeraanduiding behorende bij de ligplaats"
+        "description": "Volgnummer van de nummeraanduiding behorende bij de standplaats"
       },
-      "ligIdentificatie": {
+      "spsIdentificatie": {
         "type": "string",
-        "description": "Unieke aanduiding van de ligplaats"
+        "description": "Unieke aanduiding van de standplaats"
       },
       "bagTypeadresseerbaarobject": {
         "type": "string",
@@ -67,19 +67,19 @@
       },
       "bagStatus": {
         "type": "string",
-        "description": "De fase van de levenscyclus van een ligplaats waarin de betreffende ligplaats zich bevindt"
+        "description": "De fase van de levenscyclus van een standplaats waarin de betreffende standplaats zich bevindt"
       },
       "bagStatusCode": {
         "type": "string",
-        "description": "Code behorend bij status ligplaats"
+        "description": "Code behorend bij status standplaats"
       },
       "bsdLigtInBeschermdGebied": {
         "type": "string",
-        "description": "Ja/Nee indicator welke aangeeft of de ligplaats in een beschermd stads- of dorpgezicht valt"
+        "description": "Ja/Nee indicator welke aangeeft of de standplaats in een beschermd stads- of dorpgezicht valt"
       },
       "bsdBeschermdStadsdorpsgezicht": {
         "type": "string",
-        "description": "Tot welk gebied van het beschermd stadsdorpsgezicht de ligplaats behoort"
+        "description": "Tot welk gebied van het beschermd stadsdorpsgezicht de standplaats behoort"
       },
       "gbdBrtIdentificatie": {
         "type": "string",
@@ -121,25 +121,15 @@
         "type": "string",
         "description": "Code van het gebiedsgericht werken"
       },
-      "ligGeomVlak": {
-        "description": "Geometrie van het type POLYGON van de ligplaats",
+      "spsGeomVlak": {
+        "description": "Geometrie van het type POLYGON van de standplaats",
         "$ref": "https://geojson.org/schema/Polygon.json",
         "crs": "EPSG:28992"
       },
-      "ligGeomVlakWgs84": {
-        "description": "Geometrie van het type POLYGON van de ligplaats",
-        "$ref": "https://geojson.org/schema/Polygon.json",
-        "crs": "EPSG:4326"
-      },
-      "ligGeomMiddel": {
-        "description": "Geometrie van het middelpunt van de ligplaats van het type POINT",
+      "spsGeomMiddel": {
+        "description": "Geometrie van het middelpunt van de standplaats van het type POINT",
         "$ref": "https://geojson.org/schema/Point.json",
         "crs": "EPSG:28992"
-      },
-      "ligGeomMiddelWgs84": {
-        "description": "Geometrie van het middelpunt van de ligplaats van het type POINT",
-        "$ref": "https://geojson.org/schema/Point.json",
-        "crs": "EPSG:4326"
       },
       "peildatumBag": {
         "type": "integer",

--- a/datasets/kwaliteitsmonitor/wonenVerblijfsobject/v2.0.0.json
+++ b/datasets/kwaliteitsmonitor/wonenVerblijfsobject/v2.0.0.json
@@ -1,7 +1,7 @@
 {
   "id": "wonenVerblijfsobject",
   "type": "table",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Per verblijfsobject de kenmerken van de woningvoorraad van de gemeente Amsterdam.",
   "schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -23,7 +23,7 @@
       },
       "bkVerblijfsobject": {
         "type": "string",
-        "description": "Unieke key van het verblijfobject"  
+        "description": "Unieke key van het verblijfobject"
       },
       "adres": {
         "type": "string",
@@ -202,30 +202,15 @@
         "$ref": "https://geojson.org/schema/Point.json",
         "crs": "EPSG:28992"
       },
-      "votGeomPuntWgs84": {
-        "description": "Geometrie van het verblijfobject van het type POINT",
-        "$ref": "https://geojson.org/schema/Point.json",
-        "crs": "EPSG:4326"
-      },
       "pandGeomVlak": {
         "description": "Geometrie van het type POLYGON van het pand",
         "$ref": "https://geojson.org/schema/Polygon.json",
         "crs": "EPSG:28992"
       },
-      "pandGeomVlakWgs84": {
-        "description": "Geometrie van het type POLYGON van het pand",
-        "$ref": "https://geojson.org/schema/Polygon.json",
-        "crs": "EPSG:4326"
-      },
       "pandGeomMiddel": {
         "description": "Geometrie van het middelpunt van het pand van het type POINT",
         "$ref": "https://geojson.org/schema/Point.json",
         "crs": "EPSG:28992"
-      },
-      "pandGeomMiddelWgs84": {
-        "description": "Geometrie van het middelpunt van het pand van het type POINT",
-        "$ref": "https://geojson.org/schema/Point.json",
-        "crs": "EPSG:4326"
       },
       "peildatumEig": {
         "type": "string",


### PR DESCRIPTION
WFS performance in DSO-API is hindered by the large number of fields in this dataset. Removing the redundant ones should help. DSO-API has all the required CRS conversions.