### PR TITLE
datasets team bor/beeldschoon compliant maken met v2 van het Amsterdam schema

### DIFF
--- a/datasets/afvalwijzer/dataset.json
+++ b/datasets/afvalwijzer/dataset.json
@@ -9,7 +9,7 @@
   "homepage": "https://data.amsterdam.nl",
   "owner": "Gemeente Amsterdam, Afval en Grondstoffen",
   "spatialDescription": "Amsterdam",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Afvalwijzer",
   "language": "nl",
   "dateCreated": "2022-01-01T00:00:00+01:00",

--- a/datasets/afvalwijzer/dataset.json
+++ b/datasets/afvalwijzer/dataset.json
@@ -9,7 +9,7 @@
   "homepage": "https://data.amsterdam.nl",
   "owner": "Gemeente Amsterdam, Afval en Grondstoffen",
   "spatialDescription": "Amsterdam",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "title": "Afvalwijzer",
   "language": "nl",
   "dateCreated": "2022-01-01T00:00:00+01:00",

--- a/datasets/bor_inspecties/dataset.json
+++ b/datasets/bor_inspecties/dataset.json
@@ -11,7 +11,7 @@
     "Ruimte en Topografie",
     "Beheer openbare ruimte"
   ],
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://data.amsterdam.nl",
   "owner": "Gemeente Amsterdam, Stadsbeheer",
   "dateModified": "2021-04-27T00:00:00+01:00",
@@ -19,7 +19,9 @@
   "title": "BOR Inspecties",
   "language": "nl",
   "creator": "Datateam Beeldschoon/BOR",
-  "publisher": "Datateam Beheer en Openbare Ruimte",
+  "publisher": {
+    "$ref": "publishers/BOR"
+  },
   "hasBeginning": "2017-01-29T00:00:00+01:00",
   "accrualPeriodicity": "maandelijks",
   "description": "Binnen de Gemeente Amsterdam wordt op verschillende niveaus inspecties uitgevoerd door verschillende directies en partijen. Bijvoorbeeld inspecties voor het dagelijkse onderhoud of technische inspecties voor vervangingsplannen.  Soms met een gelijke- methodiek en andere momenten een andere methodiek (CROW, NEN, etc.). Onder de dataset \u201cinspecties\u201d vind je diverse inspectie tabellen",

--- a/datasets/fietspaaltjes/dataset.json
+++ b/datasets/fietspaaltjes/dataset.json
@@ -3,13 +3,15 @@
   "id": "fietspaaltjes",
   "title": "fietspaaltjes",
   "status": "beschikbaar",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "authorizationGrantor": "n.v.t.",
   "owner": "Gemeente Amsterdam",
   "creator": "bronhouder onbekend",
-  "publisher": "Datateam Beheer en Openbare Ruimte",
+  "publisher": {
+    "$ref": "publishers/BOR"
+  },
   "tables": [
     {
       "id": "fietspaaltjes",

--- a/datasets/huishoudelijkafval/dataset.json
+++ b/datasets/huishoudelijkafval/dataset.json
@@ -12,8 +12,8 @@
   "owner": "Gemeente Amsterdam, Stadswerken",
   "dateModified": "2020-01-13T00:00:00+01:00",
   "spatialDescription": "Gemeente Amsterdam",
-  "version": "2.1.0",
-  "default_version": "2.1.0",
+  "version": "2.1.1",
+  "default_version": "2.1.1",
   "title": "Onder- en bovengrondse Afvalcontainers en putten",
   "language": "nl",
   "dateCreated": "2020-01-13T00:00:00+01:00",
@@ -37,7 +37,9 @@
   "objective": "Het doel van deze dataset is het beschikbaar stellen van gegevens voor het ondersteunen van plaatsingsbeleid betreffende ondergrondse afvalcontainers en het ondersteunen van routeoptimalisatie voor afvalinzameling.",
   "temporalUnit": "uren",
   "creator": "Directie Afval en Grondstoffen",
-  "publisher": "Datateam Beheer en Openbare Ruimte",
+  "publisher": {
+    "$ref": "publishers/BOR"
+  },
   "tables": [
     {
       "id": "container",

--- a/datasets/verzinkbarepalen/dataset.json
+++ b/datasets/verzinkbarepalen/dataset.json
@@ -5,7 +5,7 @@
   "description": "Locaties en contextuele informatie over verzinkbare palen / afsluitingsmechanismen.",
   "license": "public",
   "status": "beschikbaar",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "theme": [
     "verzinkbarepalen",
     "Ruimte en Topografie"
@@ -14,7 +14,9 @@
   "auth": "OPENBAAR",
   "authorizationGrantor": "OIS",
   "creator": "bronhouder onbekend",
-  "publisher": "Datateam Beheer en Openbare Ruimte",
+  "publisher": {
+    "$ref": "publishers/BOR"
+  },
   "keywords": [
     "verzinkbarepalen"
   ],
@@ -24,7 +26,7 @@
       "id": "verzinkbarepalen",
       "title": "Locaties en contextuele informatie over verzinkbare palen / afsluitingsmechanismen.",
       "type": "table",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/datasets/wagenpark/dataset.json
+++ b/datasets/wagenpark/dataset.json
@@ -10,7 +10,7 @@
   "owner": "Gemeente Amsterdam, Interne Dienstverlening",
   "dateModified": "2021-01-27T00:00:00+01:00",
   "spatialDescription": "Gemeente Amsterdam",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Wagenpark",
   "language": "nl",
   "dateCreated": "2021-01-27T00:00:00+01:00",
@@ -34,7 +34,9 @@
   "objective": "Het doel van de dataset Wagenparkbeheer is een goede registratie bij te houden van stam- en procesgegevens over het Amsterdamse Wagenpark en het daarbij behorende onderhoud ter ondersteuning van het beheer van het wagenpark",
   "temporalUnit": "seconden",
   "creator": "bronhouder onbekend",
-  "publisher": "Datateam Beheer en Openbare Ruimte",
+  "publisher": {
+    "$ref": "publishers/BOR"
+  },
   "tables": [
     {
       "id": "materieel",

--- a/datasets/ziekte_plagen_exoten_groen/dataset.json
+++ b/datasets/ziekte_plagen_exoten_groen/dataset.json
@@ -9,7 +9,7 @@
   "homepage": "https://data.amsterdam.nl",
   "owner": "Directie V&OR, Gemeente Amsterdam",
   "spatialDescription": "Gemeente Amsterdam",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Ziekten, Plagen en Exoten Groen",
   "language": "nl",
   "dateCreated": "2023-01-01T00:00:00+01:00",
@@ -35,7 +35,7 @@
       "auth": "OPENBAAR",
       "license": "openbaar, tenzij anders aangegeven / behoudens uitzonderingen",
       "title": "Eikenprocessierups",
-      "description": "De data toont op welke plekken in de stad en wanneer nesten van de eikenprocessierups zijn aangetroffen. Burgers kunnen meldingen maken van de eikenprocessierups met de Signalen-app. Inspecteurs doen dit via het interne systeem van de gemeente. De data wordt dagelijks geüpdatet en is gekoppeld aan het registratiesysteem (gisib) waarin doorlopend mutaties plaatsvinden. Als een nest is verwijderd, dan wordt dat ook aangegeven. Naarmate het overlastseizoen vordert, zullen steeds meer aangetroffen en verwijderde nesten zichtbaar zijn. Aan het begin van het seizoen zijn nog niet alle eikenbomen gecontroleerd. De urgentie wordt bepaald aan de hand van de grootte van het nest, het aantal nesten per boom en het aantal aangetaste bomen:",
+      "description": "De data toont op welke plekken in de stad en wanneer nesten van de eikenprocessierups zijn aangetroffen. Burgers kunnen meldingen maken van de eikenprocessierups met de Signalen-app. Inspecteurs doen dit via het interne systeem van de gemeente. De data wordt dagelijks geüpdatet en is gekoppeld aan het registratiesysteem (gisib) waarin doorlopend mutaties plaatsvinden. Als een nest is verwijderd, dan wordt dat ook aangegeven. Naarmate het overlastseizoen vordert, zullen steeds meer aangetroffen en verwijderde nesten zichtbaar zijn. Aan het begin van het seizoen zijn nog niet alle eikenbomen gecontroleerd. De urgentie wordt bepaald aan de hand van de grootte van het nest, het aantal nesten per boom en het aantal aangetaste bomen.",
       "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Het publisher attribuut van de bor/beeldschoon datasets aangepast om compliant te zijn met v2.