### PR TITLE
changing column name for column binary causes problems with escpaing

### DIFF
--- a/datasets/dave/dataset.json
+++ b/datasets/dave/dataset.json
@@ -79,7 +79,7 @@
             "type": "string",
             "description": "Comment field."
           },
-          "binary": {
+          "binarycolumn": {
             "title": "binary",
             "description": "Test to send binary data.",
             "type": "string",


### PR DESCRIPTION
on recommendation from Yashar:
Hey, jullie tabellen benk_lasteventids en dave_pedigree bevatten [sql keywords](https://www.postgresql.org/docs/current/sql-keywords-appendix.html) als kolom naam (binary en table). Dit mag in postgres maar levert escaping problemen in scripts van andere gebruikers. Is het een probleem om deze kolomnamen aan te passen? Zie https://datalab-amsterdam.slack.com/archives/C0439U1N21F/p1694526147139919?thread_ts=1690205646.978089&cid=C0439U1N21F