### PR TITLE
verwijder 1 attribuut uit ziekte_plagen_exoten_groen

### DIFF
--- a/datasets/ziekte_plagen_exoten_groen/dataset.json
+++ b/datasets/ziekte_plagen_exoten_groen/dataset.json
@@ -286,14 +286,6 @@
               "5.2 4: Zwaarwegend belang: persoonlijke beleidsopvattingen (bevat milieu-informatie)"
             ]
           },
-          "notitieToezichthouder": {
-            "description": "Notitie van de toezichthouder",
-            "type": "string",
-            "auth": "FP/MDW",
-            "reasonsNonPublic": [
-              "5.2 4: Zwaarwegend belang: persoonlijke beleidsopvattingen (bevat milieu-informatie)"
-            ]
-          },
           "omschrijvingMelding": {
             "description": "Omschrijving van een melding",
             "type": "string",


### PR DESCRIPTION
We verwijderen dit attribuut omdat het een open tekst veld is en daardoor risico's met zich meebrengt.