### PR TITLE
Change the display field for gebieden tables

### DIFF
--- a/datasets/gebieden/bouwblokken/v1.1.1.json
+++ b/datasets/gebieden/bouwblokken/v1.1.1.json
@@ -25,7 +25,7 @@
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "code",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/gebieden/buurten/v1.1.2.json
+++ b/datasets/gebieden/buurten/v1.1.2.json
@@ -25,7 +25,7 @@
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "naam",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/gebieden/ggpgebieden/v1.1.1.json
+++ b/datasets/gebieden/ggpgebieden/v1.1.1.json
@@ -26,7 +26,7 @@
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "naam",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/gebieden/ggwgebieden/v1.1.1.json
+++ b/datasets/gebieden/ggwgebieden/v1.1.1.json
@@ -26,7 +26,7 @@
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "naam",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/gebieden/grootstedelijkeprojecten/v1.0.0.json
+++ b/datasets/gebieden/grootstedelijkeprojecten/v1.0.0.json
@@ -12,7 +12,7 @@
       "id",
       "geometrie"
     ],
-    "display": "id",
+    "display": "naam",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/gebieden/stadsdelen/v1.1.0.json
+++ b/datasets/gebieden/stadsdelen/v1.1.0.json
@@ -25,7 +25,7 @@
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "naam",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/datasets/gebieden/wijken/v1.1.2.json
+++ b/datasets/gebieden/wijken/v1.1.2.json
@@ -25,7 +25,7 @@
       "identificatie",
       "volgnummer"
     ],
-    "display": "id",
+    "display": "naam",
     "properties": {
       "schema": {
         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"


### PR DESCRIPTION
The display is used in the results from geosearch. So, usings the `id` is usually not very helpful for users.