### PR TITLE
Sport/sportaanbieder schema change

### DIFF
--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -477,6 +477,10 @@
             "type": "integer",
             "description": "Unieke aanduiding van de sportaanbieder."
           },
+          "geometry": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Puntgeometrie van de sportfaciliteit."
+          },
           "typeSport": {
             "type": "string",
             "description": "Het sporttype dat de sportaanbieder aanbiedt.",
@@ -531,20 +535,10 @@
             "description": "Indicatie korting sporten via stadspas voor jeugd.",
             "provenance": "stadspas jeugd"
           },
-          "stadspas55+": {
+          "stadspas55": {
             "type": "boolean",
             "description": "Indicatie korting sporten via stadspas voor 55+.",
             "provenance": "stadspas 55+"
-          },
-          "latitude": {
-            "type": "number",
-            "description": "Latitude van de sportfaciliteit, x-coordinaat op de kaart.",
-            "provenance": "latitude (x)"
-          },
-          "longitude": {
-            "type": "number",
-            "description": "Longitude van de sportfaciliteit, y-coordinaat op de kaart.",
-            "provenance": "longitude (y)"
           }
         }
       }

--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -459,27 +459,18 @@
       "id": "sportaanbieder",
       "title": "Sportaanbieder",
       "type": "table",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "schema",
-          "id"
+          "schema"
         ],
         "display": "naamAanbieder",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
-          },
-          "id": {
-            "type": "integer",
-            "description": "Unieke aanduiding van de aanbieder."
-          },
-          "geometry": {
-            "$ref": "https://geojson.org/schema/Point.json",
-            "description": "Puntgeometrie van de aanbieder."
           },
           "typeSport": {
             "type": "string",
@@ -520,7 +511,7 @@
             "type": "string",
             "description": "Stadsdeel waaronder de aanbieder valt."
           },
-          "indicatieAangepastSporten": {
+          "aangepastSporten": {
             "type": "string",
             "description": "Indictie ondersteuning voor aangepast sporten.",
             "provenance": "aangepast sporten"
@@ -530,10 +521,25 @@
             "description": "Kamer van koophandel nummer van de aanbieder.",
             "provenance": "kvk"
           },
-          "indicatieStadspas": {
-            "type": "string",
-            "description": "Indicatie korting sporten via stadspas.",
-            "provenance": "stadspas"
+          "stadspasJeugd": {
+            "type": "boolean",
+            "description": "Indicatie korting sporten via stadspas voor jeugd.",
+            "provenance": "stadspas jeugd"
+          },
+          "stadspas55+": {
+            "type": "boolean",
+            "description": "Indicatie korting sporten via stadspas voor 55+.",
+            "provenance": "stadspas 55+"
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Latitude van de sportfaciliteit, x-coordinaat op de kaart.",
+            "provenance": "latitude (x)"
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Longitude van de sportfaciliteit, y-coordinaat op de kaart.",
+            "provenance": "longitude (y)"
           }
         }
       }

--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -465,12 +465,17 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "schema"
+          "schema",
+          "id"
         ],
         "display": "naamAanbieder",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke aanduiding van de sportaanbieder."
           },
           "typeSport": {
             "type": "string",


### PR DESCRIPTION
Dit is nodig voor de sportkaart op kaart.amsterdam.nl. Nu is de tabel afhankelijk van een handmatige upload en die stap wil ik eruit halen. De airflow job die hieraan gelinkt is kan (of is nu al) uit.