### PR TITLE
Openbaar Subsidieregister (Wet Open Overheid),

### DIFF
--- a/subsidies/dataset.json
+++ b/subsidies/dataset.json
@@ -1,0 +1,99 @@
+{
+    "type": "dataset",
+    "id": "subsidies",
+    "title": "Subsidies",
+    "description": "Subsidies die de Gemeente Amsterdam heeft verstrekt.",
+    "license": "public",
+    "status": "beschikbaar",
+    "owner": "Gemeente Amsterdam",
+    "auth": "OPENBAAR",
+    "authorizationGrantor": "",
+    "creator": "",
+    "publisher": "Datateam MOSS+",
+    "theme": ["Subsidies"],
+    "keywords": ["Openbaar", "Subsidies", "Subsidieregister", "WOO", "Wet Open Overheid"],
+    "crs": "",
+    "tables": [
+        {
+            "id": "openbaar_subsidieregister",
+            "title": "openbaar_subsidieregister",
+            "type": "table",
+            "version": "1.0.0",
+            "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "schema",
+                    "id"
+                ],
+                "display": "naam",
+                "properties": {
+                    "naam": {
+                        "type": "string",
+                        "description": "De naam van de subsidie"
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": "Het project dat verband houdt met de subsidie"
+                    },
+                    "ontvanger": {
+                        "type": "string",
+                        "description": "De ontvanger van de subsidie"
+                    },
+                    "regeling": {
+                        "type": "string",
+                        "description": "De regeling waarop de subsidie wordt verstrekt"
+                    },
+                    "directie": {
+                        "type": "string",
+                        "description": "De afdeling verantwoordelijk voor de subsidie"
+                    },
+                    "organisatie": {
+                        "type": "string",
+                        "description": "De organisatie die de subsidie verstrekt"
+                    },
+                    "thema": {
+                        "type": "string",
+                        "description": "Het thema van de subsidie"
+                    },
+                    "jaar": {
+                        "type": "number",
+                        "description": "Het jaar waarin de subsidie is verleend"
+                    },
+                    "periodiciteit": {
+                        "type": "string",
+                        "description": "De periodiciteit van de subsidie"
+                    },
+                    "vaststellingsdatum": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "De datum waarop de subsidie is vastgesteld"
+                    },
+                    "verleningsdatum": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "De datum waarop de subsidie is verleend"
+                    },
+                    "publicatiedatum": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "De datum waarop de subsidie is gepubliceerd"
+                    },
+                    "aangevraagd": {
+                        "type": "number",
+                        "description": "Het bedrag aan gevraagde subsidie"
+                    },
+                    "verleend": {
+                        "type": "number",
+                        "description": "Het bedrag aan verleende subsidie"
+                    },
+                    "vastgesteld": {
+                        "type": "number",
+                        "description": "Het bedrag aan vastgestelde subsidie"
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Nu vindbaar op https://data.amsterdam.nl/data/datasets/yvlbMxqPKn1ULw/openbaar-subsidieregister-amsterdam/, maar dat is een wekelijkse, handmatige upload vanuit de directie Subsidies. Ik wil dat voor de migratie 15 maart vanuit de API beschikbaar gaan stellen.