### PR TITLE
Add files via upload

### DIFF
--- a/datasets/leidingeninfrastructuur/amsterdamOvlBovengrondseKabels/v1.3.0.json
+++ b/datasets/leidingeninfrastructuur/amsterdamOvlBovengrondseKabels/v1.3.0.json
@@ -1,0 +1,146 @@
+{
+  "id": "amsterdamOvlBovengrondseKabels",
+  "type": "table",
+  "version": "1.3.0",
+  "title": "Amsterdam openbare verlichting bovengrondse kabels",
+  "description": "Bovengrondse kabels openbare verlichting die door de Gemeente Amsterdam worden beheerd.",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "schema",
+      "id"
+    ],
+    "display": "id",
+    "properties": {
+      "id": {
+        "type": "integer",
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel."
+      },
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "geometry": {
+        "$ref": "https://geojson.org/schema/MultiLineString.json",
+        "description": "Lijnco\u00f6rdinaten van de bovengrondse kabel (epsg:28992)"
+      },
+      "inwinningstype": {
+        "type": "string",
+        "description": "Kwaliteit van inwinning."
+      },
+      "thema": {
+        "type": "string",
+        "description": "WIBON Thema."
+      },
+      "klasse": {
+        "type": "string",
+        "description": "WIBON Klasse."
+      },
+      "type": {
+        "type": "string",
+        "description": "WIBON Type."
+      },
+      "zichtbaar": {
+        "type": "string",
+        "description": "Zichtbaar (Ja/Nee)."
+      },
+      "indicatieBovenOnder": {
+        "type": "string",
+        "description": "Indicatie: Boven-/ondergronds.",
+        "provenance": "bovenonder"
+      },
+      "diepte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Diepte in cm (t.o.v. maaiveld)."
+      },
+      "nauwkeurigheidDiepte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de diepte."
+      },
+      "hoogte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Hoogte in cm. (t.o.v. maaiveld)"
+      },
+      "nauwkeurigheidHoogte": {
+        "type": "string",
+        "description": "Nauwkeurigheid van de hoogte."
+      },
+      "hoofdcategorie": {
+        "type": "string",
+        "description": "Hoofdcategorie."
+      },
+      "eigenaar": {
+        "type": "string",
+        "description": "Eigenaar van de Kabel."
+      },
+      "jaarVanAanleg": {
+        "type": "integer",
+        "description": "Jaar van aanleg van de Kabel.",
+        "provenance": "jva"
+      },
+      "typeExtra": {
+        "type": "string",
+        "description": "Type extra (AC/DC).",
+        "provenance": "typeextra"
+      },
+      "functie": {
+        "type": "string",
+        "description": "Functie van de Kabel."
+      },
+      "van": {
+        "type": "string",
+        "description": "Van (locatie van de Kabel)."
+      },
+      "tot": {
+        "type": "string",
+        "description": "Tot (locatie van de Kabel)."
+      },
+      "kast": {
+        "type": "string",
+        "description": "Kastnummer waarop de Kabel is aangesloten."
+      },
+      "groep": {
+        "type": "string",
+        "description": "Groepsnummer binnen de Kast waar de Kabel op is aangesloten."
+      },
+      "kabeltype": {
+        "type": "string",
+        "description": "Kabeltype."
+      },
+      "kabeldiameter": {
+        "type": "string",
+        "description": "Kabeldiameter."
+      },
+      "voltage": {
+        "type": "string",
+        "description": "Voltage van de Kabel."
+      },
+      "bouwtype": {
+        "type": "string",
+        "description": "Bouwtype van de Kabel."
+      },
+      "bereikbaar": {
+        "type": "string",
+        "description": "Bereikbaarheid van de Kabel.",
+        "provenance": "bereikbaarheid"
+      },
+      "lengte": {
+        "type": "number",
+        "unit": "cm",
+        "description": "Lengte van de Kabel."
+      },
+      "kabelzegel": {
+        "type": "string",
+        "provenance": "zegel",
+        "description": "Typering zegel van de Kabel."
+      },
+      "ovs": {
+        "type": "string",
+        "description": "Overspanningsinstallatie."
+      }
+    }
+  }
+}

--- a/datasets/leidingeninfrastructuur/dataset.json
+++ b/datasets/leidingeninfrastructuur/dataset.json
@@ -56,9 +56,9 @@
     },
     {
       "id": "amsterdamOvlBovengrondseKabels",
-      "$ref": "amsterdamOvlBovengrondseKabels/v1.2.0",
+      "$ref": "amsterdamOvlBovengrondseKabels/v1.3.0",
       "activeVersions": {
-        "1.2.0": "amsterdamOvlBovengrondseKabels/v1.2.0"
+        "1.3.0": "amsterdamOvlBovengrondseKabels/v1.3.0"
       }
     },
     {


### PR DESCRIPTION
Voeg uit Wibon-brontabel OVL-kabels kolom ovs (string, Overspanningsinstallatie) toe aan OVL-bovengrondse_kabels:

Ik heb in deze featurebranch feature/raymondyoung/leidingen_ovl_boven_kabels in dataset leidingeninfrastructuur aan de producttabel bovengrondse_kabels (nieuwe versie 1.3.0) als laatste kolom ovs (string: overspanningsinstallatie) toegevoegd.

Als jullie dit goedkeuren, kan deze wijziging dan in RefDB-ACC worden uitgerold?

Dank, groet, Raymond