### PR TITLE
Update dataset.json vergunningen

### DIFF
--- a/datasets/vergunningen/dataset.json
+++ b/datasets/vergunningen/dataset.json
@@ -6,9 +6,9 @@
   "version": "1.0.0",
   "status": "beschikbaar",
   "publisher": {
-    "$ref": "/publishers/BOR"
+    "$ref": "/publishers/SVD"
   },
-  "creator": "Datateam Beeldschoon/BOR",
+  "creator": "Datateam SVD",
   "auth": "OPENBAAR",
   "authorizationGrantor": "Stadswerken, Gemeente Amsterdam",
   "theme": [
@@ -43,9 +43,9 @@
     },
     {
       "id": "werkEnVervoerOpStraat",
-      "$ref": "werkEnVervoerOpStraat/v1.0.0",
+      "$ref": "werkEnVervoerOpStraat/v1.1.0",
       "activeVersions": {
-        "1.0.0": "werkEnVervoerOpStraat/v1.0.0"
+        "1.1.0": "werkEnVervoerOpStraat/v1.1.0"
       }
     }
   ]


### PR DESCRIPTION
Verwijzing naar nieuwe versie van Werk en vervoer op straat (met uitbreiding objectvergunningsgegevens) en wijziging van publisher / creator van BOR naar SVD (datateam Stadsdelen, Vergunningen Toezicht & Handhaving en Dienstverlening).