### PR TITLE
schema change aanvraagd door de business

### DIFF
--- a/datasets/subsidies/dataset.json
+++ b/datasets/subsidies/dataset.json
@@ -43,68 +43,54 @@
                         "type": "integer",
                         "description": "Unieke aanduiding van de subsidieverlening."
                     },
-                    "naam": {
+                    "dossiernummer": {
                         "type": "string",
-                        "description": "De naam van de subsidie"
+                        "description": "Het unieke dossiernummer van de subsidieverlening"
                     },
-                    "project": {
+                    "aanvrager": {
+                        "type": "string",
+                        "description": "De aanvrager van de subsidie"
+                    },
+                    "reglingnaam": {
+                        "type": "string",
+                        "description": "De naam van de regeling van de subsidie"
+                    },
+                    "beleidsterrein": {
                         "type": "string",
                         "description": "Het project dat verband houdt met de subsidie"
                     },
-                    "ontvanger": {
+                    "organisatieonderdeel": {
                         "type": "string",
-                        "description": "De ontvanger van de subsidie"
+                        "description": "Het organisatieonderdeel dat de subsidie heeft verstrekt"
                     },
-                    "regeling": {
-                        "type": "string",
-                        "description": "De regeling waarop de subsidie wordt verstrekt"
-                    },
-                    "directie": {
-                        "type": "string",
-                        "description": "De afdeling verantwoordelijk voor de subsidie"
-                    },
-                    "organisatie": {
-                        "type": "string",
-                        "description": "De organisatie die de subsidie verstrekt"
-                    },
-                    "thema": {
-                        "type": "string",
-                        "description": "Het thema van de subsidie"
-                    },
-                    "jaar": {
-                        "type": "number",
-                        "description": "Het jaar waarin de subsidie is verleend"
-                    },
-                    "periodiciteit": {
+                    "type_periodiciteit": {
                         "type": "string",
                         "description": "De periodiciteit van de subsidie"
                     },
-                    "vaststellingsdatum": {
+                    "projectnaam": {
+                        "type": "string",
+                        "description": "De naam van het project dat verband houdt met de subsidie"
+                    },
+                    "bedragAangevraagd": {
+                        "type": "number",
+                        "description": "Het bedrag dat is aangevraagd"
+                    },
+                    "bedragVerleend": {
+                        "type": "number",
+                        "description": "Het bedrag dat is verleend"
+                    },
+                    "bedragVastgesteld": {
+                        "type": "number",
+                        "description": "Het bedrag dat is vastgesteld"
+                    },
+                    "subsidiejaar": {
+                        "type": "integer",
+                        "description": "Het jaar waarin de subsidie is verleend"
+                    },
+                    "datumOverzicht": {
                         "type": "string",
                         "format": "date",
-                        "description": "De datum waarop de subsidie is vastgesteld"
-                    },
-                    "verleningsdatum": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "De datum waarop de subsidie is verleend"
-                    },
-                    "publicatiedatum": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "De datum waarop de subsidie is gepubliceerd"
-                    },
-                    "aangevraagd": {
-                        "type": "number",
-                        "description": "Het bedrag aan gevraagde subsidie"
-                    },
-                    "verleend": {
-                        "type": "number",
-                        "description": "Het bedrag aan verleende subsidie"
-                    },
-                    "vastgesteld": {
-                        "type": "number",
-                        "description": "Het bedrag aan vastgestelde subsidie"
+                        "description": "De datum waarop het overzicht is gemaakt"
                     }
                 }
             }

--- a/datasets/subsidies/dataset.json
+++ b/datasets/subsidies/dataset.json
@@ -34,7 +34,7 @@
                     "schema",
                     "id"
                 ],
-                "display": "naam",
+                "display": "regelingnaam",
                 "properties": {
                     "schema": {
                         "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -51,7 +51,7 @@
                         "type": "string",
                         "description": "De aanvrager van de subsidie"
                     },
-                    "reglingnaam": {
+                    "regelingnaam": {
                         "type": "string",
                         "description": "De naam van de regeling van de subsidie"
                     },
@@ -63,7 +63,7 @@
                         "type": "string",
                         "description": "Het organisatieonderdeel dat de subsidie heeft verstrekt"
                     },
-                    "type_periodiciteit": {
+                    "typePeriodiciteit": {
                         "type": "string",
                         "description": "De periodiciteit van de subsidie"
                     },


### PR DESCRIPTION
Het schema moet precies zo zijn als nu op data.amsterdam.nl bij het "Openbaar Subsidieregister".