### PR TITLE
add title (business term) to columns

### DIFF
--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -475,70 +475,84 @@
           },
           "id": {
             "type": "integer",
-            "description": "Unieke aanduiding van de sportaanbieder."
+            "description": "Unieke aanduiding van de sportaanbieder.",
+            "title": "ID"
           },
           "geometry": {
             "$ref": "https://geojson.org/schema/Point.json",
-            "description": "Puntgeometrie van de sportfaciliteit."
+            "description": "Puntgeometrie van de sportfaciliteit.",
+            "title": "Puntgeometrie"
           },
           "typeSport": {
             "type": "string",
             "description": "Het sporttype dat de sportaanbieder aanbiedt.",
-            "provenance": "sport"
+            "title": "Sport"
           },
           "website": {
             "type": "string",
             "format": "uri",
-            "description": "Website van de aanbieder."
+            "description": "Website van de aanbieder.",
+            "title": "Website"
           },
           "naamAanbieder": {
             "type": "string",
             "description": "Naam van de aanbieder.",
-            "provenance": "naam"
+            "provenance": "naam",
+            "title": "Naam sportaanbieder"
           },
           "naamSportfaciliteit": {
             "type": "string",
             "description": "Naam van de sportfaciliteit.",
-            "provenance": "naam accommodatie"
+            "provenance": "naam accommodatie",
+            "title": "Naam sportfaciliteit"
           },
           "adres": {
             "type": "string",
             "description": "Adres van de sportfaciliteit.",
-            "provenance": "adres accommodatie"
+            "provenance": "adres accommodatie",
+            "title": "Adres"
           },
           "postcode": {
             "type": "string",
             "description": "Postcode van de sportfaciliteit.",
-            "provenance": "postcode accommodatie"
+            "provenance": "postcode accommodatie",
+            "title": "Postcode"
           },
           "plaats": {
             "type": "string",
             "description": "Plaats van de sportfaciliteit.",
-            "provenance": "plaats accommodatie"
+            "provenance": "plaats accommodatie",
+            "title": "Plaats"
           },
           "stadsdeel": {
             "type": "string",
-            "description": "Stadsdeel waaronder de aanbieder valt."
+            "description": "Stadsdeel waaronder de aanbieder valt.",
+            "provenance": "stadsdeel",
+            "title": "Stadsdeel"
           },
           "aangepastSporten": {
             "type": "string",
             "description": "Indictie ondersteuning voor aangepast sporten.",
-            "provenance": "aangepast sporten"
+            "provenance": "aangepast sporten",
+            "title": "Aangepast sporten"
           },
           "kvkNummer": {
             "type": "string",
             "description": "Kamer van koophandel nummer van de aanbieder.",
-            "provenance": "kvk"
+            "provenance": "kvk",
+            "title": "KvK nummer"
           },
           "stadspasJeugd": {
             "type": "boolean",
             "description": "Indicatie korting sporten via stadspas voor jeugd.",
-            "provenance": "stadspas jeugd"
+            "provenance": "stadspas jeugd",
+            "title": "Stadspas jeugd"
           },
           "stadspas55": {
             "type": "boolean",
             "description": "Indicatie korting sporten via stadspas voor 55+.",
-            "provenance": "stadspas 55+"
+            "provenance": "stadspas 55+",
+            "title": "Stadspas 55+"
           }
         }
       }

--- a/datasets/subsidies/dataset.json
+++ b/datasets/subsidies/dataset.json
@@ -41,56 +41,69 @@
                     },
                     "id": {
                         "type": "integer",
-                        "description": "Unieke aanduiding van de subsidieverlening."
+                        "description": "Unieke aanduiding van de subsidieverlening.",
+                        "title": "ID"
                     },
                     "dossiernummer": {
                         "type": "string",
-                        "description": "Het unieke dossiernummer van de subsidieverlening"
+                        "description": "Het unieke dossiernummer van de subsidieverlening",
+                        "title": "Dossiernummer"
                     },
                     "aanvrager": {
                         "type": "string",
-                        "description": "De aanvrager van de subsidie"
+                        "description": "De aanvrager van de subsidie",
+                        "title": "Subsidieaanvrager"
                     },
                     "regelingnaam": {
                         "type": "string",
-                        "description": "De naam van de regeling van de subsidie"
+                        "description": "De naam van de regeling van de subsidie",
+                        "title": "Regeling"
                     },
                     "beleidsterrein": {
                         "type": "string",
-                        "description": "Het project dat verband houdt met de subsidie"
+                        "description": "Het project dat verband houdt met de subsidie",
+                        "title": "Beleidsterrein"
                     },
                     "organisatieonderdeel": {
                         "type": "string",
-                        "description": "Het organisatieonderdeel dat de subsidie heeft verstrekt"
+                        "description": "Het organisatieonderdeel dat de subsidie heeft verstrekt",
+                        "title": "Organisatieonderdeel"
                     },
                     "typePeriodiciteit": {
                         "type": "string",
-                        "description": "De periodiciteit van de subsidie"
+                        "description": "De periodiciteit van de subsidie",
+                        "title": "Periodiciteit"
                     },
                     "projectnaam": {
                         "type": "string",
-                        "description": "De naam van het project dat verband houdt met de subsidie"
+                        "description": "De naam van het project dat verband houdt met de subsidie",
+                        "title": "Projectnaam"
                     },
                     "bedragAangevraagd": {
                         "type": "number",
-                        "description": "Het bedrag dat is aangevraagd"
+                        "description": "Het bedrag dat is aangevraagd",
+                        "title": "Bedrag aangevraagd"
                     },
                     "bedragVerleend": {
                         "type": "number",
-                        "description": "Het bedrag dat is verleend"
+                        "description": "Het bedrag dat is verleend",
+                        "title": "Bedrag verleend"
                     },
                     "bedragVastgesteld": {
                         "type": "number",
-                        "description": "Het bedrag dat is vastgesteld"
+                        "description": "Het bedrag dat is vastgesteld",
+                        "title": "Bedrag vastgesteld"
                     },
                     "subsidiejaar": {
                         "type": "integer",
-                        "description": "Het jaar waarin de subsidie is verleend"
+                        "description": "Het jaar waarin de subsidie is verleend",
+                        "title": "Subsidiejaar"
                     },
                     "datumOverzicht": {
                         "type": "string",
                         "format": "date",
-                        "description": "De datum waarop het overzicht is gemaakt"
+                        "description": "De datum waarop het overzicht is gemaakt",
+                        "title": "Datum overzicht"
                     }
                 }
             }


### PR DESCRIPTION
Business termen zijn nodig voor een verwijzing vanuit het datacontract. Meteen gedaan voor dataset sport en subsidies (beide vanuit datateam MOSS+ snel datacontract nodig)