### PR TITLE
featurebranch RY_OVL: nieuwe versie 1.3.0 Leidingeninfra_boven_kabels

### DIFF
--- a/datasets/leidingeninfrastructuur/dataset.json
+++ b/datasets/leidingeninfrastructuur/dataset.json
@@ -56,9 +56,9 @@
     },
     {
       "id": "amsterdamOvlBovengrondseKabels",
-      "$ref": "amsterdamOvlBovengrondseKabels/v1.2.0",
+      "$ref": "amsterdamOvlBovengrondseKabels/v1.3.0",
       "activeVersions": {
-        "1.2.0": "amsterdamOvlBovengrondseKabels/v1.2.0"
+        "1.3.0": "amsterdamOvlBovengrondseKabels/v1.3.0"
       }
     },
     {


### PR DESCRIPTION
Hallo @jjmurre , hierbij opnieuw mijn pullrequest op Leidingeninfrastructuur / Bovengrondse_kabels, v1.3.0.
(feature/raymondyoung/leidinginfrastructuur_boven_kabel_v1.3.0)
In dataset leidingeninfrastructuur is zowel de tabel bovengrondse_kabels opgehoogd tot versie 1.3.0 met nieuwe kolom ovs,
als ook in de betreffende dataset de versie van deze tabel opgehoogd tot versie 1.3.0.

Kan je deze featurebranch reviewen en zo mogelijk mergen naar master?

Kan deze feature dan alleen in de referentiedatabase ACC worden uitgerold, omdat we eerst de wijzigingen willen testen?

En als dat niet kan, en alleen tegelijk kan worden uitgerold in ACC en PROD, dan neem ik aan dat de Airflow-DAG van DataVerwerking alleen deze tabel in PROD terugdraait zodat de DAG daar goed loopt, maar wij in ACC de nieuwe versie hebben zodat we die kunnen testen?

Bij voorbaat dank!