### PR TITLE
status verwijderd bij BRT 50 wegdelen

### DIFF
--- a/datasets/brt50/wegdelen/v1.0.0.json
+++ b/datasets/brt50/wegdelen/v1.0.0.json
@@ -73,10 +73,6 @@
         "type": "string",
         "description": "Naam van een tunnel."
       },
-      "status": {
-        "type": "string",
-        "description": " De staat waarin het object zich bevindt."
-      },
       "hoogteniveau": {
         "type": "integer",
         "description": "Met het hoogteniveau wordt de relatieve hoogte van het geo-object weergegeven. Zo kan worden bepaald op welke wijze geo-objecten elkaar kruisen."


### PR DESCRIPTION
kenmerk 'status' verwijderd bij wegdelen, deze stond onterecht er in