### PR TITLE
Fix broken arrays

### DIFF
--- a/datasets/afvalwijzer/accAfvalwijzer/v1.2.0.json
+++ b/datasets/afvalwijzer/accAfvalwijzer/v1.2.0.json
@@ -126,6 +126,9 @@
             "afvalwijzerOphaaldagen": {
                 "title": "Afval ophaaldagen omschrijving",
                 "type": "array",
+                "items": {
+                    "type": "string"
+                },
                 "description": "Omschrijving van de dagen waarop het afval wordt opgehaald"
             },
             "afvalwijzerAfvalkalenderMelding": {
@@ -172,6 +175,9 @@
             "afvalwijzerOphaaldagen2": {
                 "title": "Afval aanvullende ophaaldagen informatie",
                 "type": "array",
+                "items": {
+                    "type": "string"
+                },
                 "description": "Aanvullende informatie over de ophaaldagen"
             },
             "afvalwijzerWaar": {


### PR DESCRIPTION
Arrays in this schema are missing item definitions. This bugs got through the tests. 
The tests have been fixed, but this schema still needs to be corrected.