### PR TITLE
Update existing scope objects to conform to scope schema

### DIFF
--- a/scopes/BENK/brk_ro.json
+++ b/scopes/BENK/brk_ro.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BRK/RO",
   "name": "BRK/RO",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_brk_ro",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_brk_ro",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_brk_ro",
+    "production": "EM4W-DATA-schemascope-p-scope_brk_ro"
+  },
   "owner": {
     "$ref": "publishers/BENK"
   }

--- a/scopes/BENK/brk_rs.json
+++ b/scopes/BENK/brk_rs.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BRK/RS",
   "name": "BRK/RS",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_brk_rs",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_brk_rs",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_brk_rs",
+    "production": "EM4W-DATA-schemascope-p-scope_brk_rs"
+  },
   "owner": {
     "$ref": "publishers/BENK"
   }

--- a/scopes/BENK/brk_rsn.json
+++ b/scopes/BENK/brk_rsn.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BRK/RSN",
   "name": "BRK/RSN",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_brk_rsn",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_brk_rsn",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_brk_rsn",
+    "production": "EM4W-DATA-schemascope-p-scope_brk_rsn"
+  },
   "owner": {
     "$ref": "publishers/BENK"
   }

--- a/scopes/BENK/hr_r.json
+++ b/scopes/BENK/hr_r.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "HR/R",
   "name": "HR/R",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_hr_r",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_hr_r",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_hr_r",
+    "production": "EM4W-DATA-schemascope-p-scope_hr_r"
+  },
   "owner": {
     "$ref": "publishers/BENK"
   }

--- a/scopes/BENK/mon_rdm.json
+++ b/scopes/BENK/mon_rdm.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "MON/RDM",
   "name": "MON/RDM",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_mon_rdm",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_mon_rdm",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_mon_rdm",
+    "production": "EM4W-DATA-schemascope-p-scope_mon_rdm"
+  },
   "owner": {
     "$ref": "publishers/BENK"
   }

--- a/scopes/BOR/fp_iasset.json
+++ b/scopes/BOR/fp_iasset.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "FP/IASSET",
   "name": "FP/IASSET",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_fp_iasset",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_fp_iasset",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_fp_iasset",
+    "production": "EM4W-DATA-schemascope-p-scope_fp_iasset"
+  },
   "owner": {
     "$ref": "publishers/BOR"
   }

--- a/scopes/BOR/fp_wagenpark.json
+++ b/scopes/BOR/fp_wagenpark.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "FP/WAGENPARK",
   "name": "Functieprofiel Wagenpark",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_fp_wagenpark",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_fp_wagenpark",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_fp_wagenpark",
+    "production": "EM4W-DATA-schemascope-p-scope_fp_wagenpark"
+  },
   "owner": {
     "$ref": "publishers/BOR"
   }

--- a/scopes/DADI/fp_mdw.json
+++ b/scopes/DADI/fp_mdw.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "FP/MDW",
   "name": "Functieprofiel Medewerker",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_fp_mdw",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_fp_mdw",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_fp_mdw",
+    "production": "EM4W-DATA-schemascope-p-scope_fp_mdw"
+  },
   "owner": {
     "$ref": "publishers/DADI"
   }

--- a/scopes/DADI/openbaar.json
+++ b/scopes/DADI/openbaar.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "OPENBAAR",
   "name": "Openbaar",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_openbaar",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_openbaar",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_openbaar",
+    "production": "EM4W-DATA-schemascope-p-scope_openbaar"
+  },
   "owner": {
     "$ref": "publishers/DADI"
   }

--- a/scopes/DGEN/gnrk_octweb.json
+++ b/scopes/DGEN/gnrk_octweb.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "GNRK/OCTWEB",
   "name": "GNRK/OCTWEB",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_gnrk_octweb",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_gnrk_octweb",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_gnrk_octweb",
+    "production": "EM4W-DATA-schemascope-p-scope_gnrk_octweb"
+  },
   "owner": {
     "$ref": "publishers/DGEN"
   }

--- a/scopes/DTJZ/dtjz.json
+++ b/scopes/DTJZ/dtjz.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "DTJZ",
   "name": "DTJZ",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_dtjz",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_dtjz",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_dtjz",
+    "production": "EM4W-DATA-schemascope-p-scope_dtjz"
+  },
   "owner": {
     "$ref": "publishers/DTJZ"
   }

--- a/scopes/MOBI/park_mdw.json
+++ b/scopes/MOBI/park_mdw.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "PARK/MDW",
   "name": "PARK/MDW",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_park_mdw",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_park_mdw",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_park_mdw",
+    "production": "EM4W-DATA-schemascope-p-scope_park_mdw"
+  },
   "owner": {
     "$ref": "publishers/MOBI"
   }

--- a/scopes/SOEB/bb_wb_go_stan.json
+++ b/scopes/SOEB/bb_wb_go_stan.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BB/WB/GO/STAN",
   "name": "BB/WB/GO/STAN",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_bb_wb_go_stan",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_bb_wb_go_stan",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_bb_wb_go_stan",
+    "production": "EM4W-DATA-schemascope-p-scope_bb_wb_go_stan"
+  },
   "owner": {
     "$ref": "publishers/SOEB"
   }

--- a/scopes/SOEB/bb_wb_go_uitg.json
+++ b/scopes/SOEB/bb_wb_go_uitg.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BB/WB/GO/UITG",
   "name": "BB/WB/GO/UITG",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_bb_wb_go_uitg",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_bb_wb_go_uitg",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_bb_wb_go_uitg",
+    "production": "EM4W-DATA-schemascope-p-scope_bb_wb_go_uitg"
+  },
   "owner": {
     "$ref": "publishers/SOEB"
   }

--- a/scopes/SOEB/fp_wonen.json
+++ b/scopes/SOEB/fp_wonen.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "FP/WONEN",
   "name": "Functieprofiel Wonen",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_fp_wonen",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_fp_wonen",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_fp_wonen",
+    "production": "EM4W-DATA-schemascope-p-scope_fp_wonen"
+  },
   "owner": {
     "$ref": "publishers/SOEB"
   }

--- a/scopes/STAT/bsk_bedrijven.json
+++ b/scopes/STAT/bsk_bedrijven.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BSK/BEDRIJVEN",
   "name": "BSK/BEDRIJVEN",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_bsk_bedrijven",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_bsk_bedrijven",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_bsk_bedrijven",
+    "production": "EM4W-DATA-schemascope-p-scope_bsk_bedrijven"
+  },
   "owner": {
     "$ref": "publishers/STAT"
   }

--- a/scopes/STAT/bsk_eigendom.json
+++ b/scopes/STAT/bsk_eigendom.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "BSK/EIGENDOM",
   "name": "BSK/EIGENDOM",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_bsk_eigendom",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_bsk_eigendom",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_bsk_eigendom",
+    "production": "EM4W-DATA-schemascope-p-scope_bsk_eigendom"
+  },
   "owner": {
     "$ref": "publishers/STAT"
   }

--- a/scopes/SVD/contactcentre.json
+++ b/scopes/SVD/contactcentre.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "CONTACTCENTRE",
   "name": "CONTACTCENTRE",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_contactcentre",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_contactcentre",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_contactcentre",
+    "production": "EM4W-DATA-schemascope-p-scope_contactcentre"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/SVD/contactcentrehetservicepunt.json
+++ b/scopes/SVD/contactcentrehetservicepunt.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "CONTACTCENTREHETSERVICEPUNT",
   "name": "CONTACTCENTREHETSERVICEPUNT",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_contactcentrehetservicepunt",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_contactcentrehetservicepunt",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_contactcentrehetservicepunt",
+    "production": "EM4W-DATA-schemascope-p-scope_contactcentrehetservicepunt"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/SVD/dvlopenbaar.json
+++ b/scopes/SVD/dvlopenbaar.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "DVLOPENBAAR",
   "name": "DVLOPENBAAR",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_dvlopenbaar",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_dvlopenbaar",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_dvlopenbaar",
+    "production": "EM4W-DATA-schemascope-p-scope_dvlopenbaar"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/SVD/klachtenafhandeling.json
+++ b/scopes/SVD/klachtenafhandeling.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "KLACHTENAFHANDELING",
   "name": "Klachtenafhandeling",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_klachtenafhandeling",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_klachtenafhandeling",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_klachtenafhandeling",
+    "production": "EM4W-DATA-schemascope-p-scope_klachtenafhandeling"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/SVD/klachtenafhandelingcoordinator.json
+++ b/scopes/SVD/klachtenafhandelingcoordinator.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "KLACHTENAFHANDELINGCOORDINATOR",
   "name": "Klachtenafhandelingcoordinator",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_klachtenafhandelingcoordinator",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_klachtenafhandelingcoordinator",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_klachtenafhandelingcoordinator",
+    "production": "EM4W-DATA-schemascope-p-scope_klachtenafhandelingcoordinator"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/SVD/klachtenafhandelingdvl.json
+++ b/scopes/SVD/klachtenafhandelingdvl.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "KLACHTENAFHANDELINGDVL",
   "name": "Klachtenafhandeling Dienstverlening",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_klachtenafhandelingdvl",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_klachtenafhandelingdvl",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_klachtenafhandelingdvl",
+    "production": "EM4W-DATA-schemascope-p-scope_klachtenafhandelingdvl"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/SVD/klachtenafhandelingparkeren.json
+++ b/scopes/SVD/klachtenafhandelingparkeren.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "KLACHTENAFHANDELINGPARKEREN",
   "name": "Klachtenafhandeling Parkeren",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_klachtenafhandelingparkeren",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_klachtenafhandelingparkeren",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_klachtenafhandelingparkeren",
+    "production": "EM4W-DATA-schemascope-p-scope_klachtenafhandelingparkeren"
+  },
   "owner": {
     "$ref": "publishers/SVD"
   }

--- a/scopes/WPI/wpi_loa.json
+++ b/scopes/WPI/wpi_loa.json
@@ -2,8 +2,10 @@
   "type": "scope",
   "id": "WPI/LOA",
   "name": "WPI/LOA",
-  "nonProductiePackage": "EM4W-DATA-schemascope-ot-scope_wpi_loa",
-  "productiePackage": "EM4W-DATA-schemascope-p-scope_wpi_loa",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_wpi_loa",
+    "production": "EM4W-DATA-schemascope-p-scope_wpi_loa"
+  },
   "owner": {
     "$ref": "publishers/WPI"
   }


### PR DESCRIPTION
Sinds #1258 hebben we een update in het scope schema gedaan. Deze PR update de bestaande scope objects om aan dat schema te voldoen. Aparte PR omdat de checks de live versie van het schema gebruiken. 