### PR TITLE
Voeg missende BRP/R scope toe

### DIFF
--- a/scopes/BENK/brp_r.json
+++ b/scopes/BENK/brp_r.json
@@ -1,0 +1,9 @@
+{
+  "type": "scope",
+  "id": "BRP/R",
+  "name": "BRP/R",
+  "accessPackages": {},
+  "owner": {
+    "$ref": "publishers/BENK"
+  }
+}

--- a/scopes/index.json
+++ b/scopes/index.json
@@ -31,6 +31,7 @@
     "brk_ro",
     "brk_rs",
     "brk_rsn",
+    "brp_r",
     "hr_r",
     "mon_rdm"
   ],

--- a/scopes/scopes.json
+++ b/scopes/scopes.json
@@ -66,6 +66,16 @@
   },
   {
     "type": "scope",
+    "id": "BRP/R",
+    "name": "BRP/R",
+    "accessPackages": {},
+    "owner": {
+      "$ref": "publishers/BENK"
+    },
+    "dbRole": "scope_brp_r"
+  },
+  {
+    "type": "scope",
     "id": "BSK/BEDRIJVEN",
     "name": "BSK/BEDRIJVEN",
     "accessPackages": {

--- a/scopes/scopes.json
+++ b/scopes/scopes.json
@@ -66,16 +66,6 @@
   },
   {
     "type": "scope",
-    "id": "BRP/R",
-    "name": "BRP/R",
-    "accessPackages": {},
-    "owner": {
-      "$ref": "publishers/BENK"
-    },
-    "dbRole": "scope_brp_r"
-  },
-  {
-    "type": "scope",
     "id": "BSK/BEDRIJVEN",
     "name": "BSK/BEDRIJVEN",
     "accessPackages": {

--- a/src/amsterdam_schema/publish/cli.py
+++ b/src/amsterdam_schema/publish/cli.py
@@ -393,6 +393,7 @@ def generate_publisher_index() -> None:
 
 
 SCOPES_IGNORED_FILES = ["index", "packages", "scopes"]
+SCOPES_UNAVAILABLE_DATASETS = ["brp_r"]
 
 
 def fetch_scope_index() -> Dict[str, List[str]]:
@@ -422,7 +423,7 @@ def generate_scope_index() -> None:
 def fetch_scope_files() -> list[dict]:
     result = []
     for p in Path(".").glob(SCOPES_DIR + "/**/*.json"):
-        if p.stem in SCOPES_IGNORED_FILES:
+        if p.stem in SCOPES_IGNORED_FILES + SCOPES_UNAVAILABLE_DATASETS:
             continue
         with open(p) as f:
             scope = json.load(f)


### PR DESCRIPTION
Deze wordt alleen gebruikt in een dataset die "niet_beschikbaar" is, maar is nog steeds nodig voor het opzetten van de DSO. 

Aangezien de dataset zelf niet meer toegankelijk is, zijn er geen access packages mee verbonden. We laten hem ook uit de scopes.json, zodat er geen onnodige db role wordt gecreeerd.