### PR TITLE
Add validate tables workflow

### DIFF
--- a/.github/workflows/validate-tables.yml
+++ b/.github/workflows/validate-tables.yml
@@ -1,0 +1,30 @@
+name: validate-tables
+
+on:
+  push:
+  pull_request:
+    paths:
+      - datasets/
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "Fetch master branch"  # So we can diff against it.
+        run: |
+          git fetch origin master
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - id: install-schema-tools
+        run: |
+          python -m pip install --force-reinstall -v "amsterdam-schema-tools>=7.2.2"
+      - id: generate-previous-tables
+        run: |
+          changed_paths=$(./scripts/generate_previous_tables_from_master.sh ${{github.head_ref || github.ref_name}} | tail -n 1)
+          echo "changed_paths=$changed_paths" >> $GITHUB_OUTPUT
+      - id: validate-tables
+        run: |
+          schema validate-tables ${{steps.generate-previous-tables.outputs.changed_paths}}

--- a/scripts/generate_previous_tables_from_master.sh
+++ b/scripts/generate_previous_tables_from_master.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+declare -a changed_paths
+
+added_tables=$(git diff --name-only --diff-filter=A origin/master..origin/$1  -- 'datasets/**/v*.json')
+modified_tables=$(git diff --name-only --diff-filter=M origin/master..origin/$1  -- 'datasets/**/v*.json')
+
+# for added tables, we have to find a potential previous version
+# that may or may not exist
+for table_path in $added_tables
+do
+    folder_name="$(dirname $table_path)"
+    file_name="$(basename $table_path)"
+    previous_name="$folder_name/previous-$file_name"
+    semver=(${file_name//./ })
+    major=${semver[0]}
+    minor=${semver[1]}
+    patch=${semver[2]}
+    previous_patch="$(ls $folder_name | grep "$major.$minor.[^0-$patch]" | grep -v "$(basename $table_path)" | tail -n 1)"
+    echo $previous_patch
+    if [[ $previous_patch ]]; then
+        git show origin/master:$folder_name/$previous_patch > $previous_name
+        echo "created \"previous-$file_name\" from master's \"$previous_patch\" for \"$table_path\""
+        changed_paths+=("$table_path")
+        continue
+    fi
+    previous_minor="$(ls $folder_name | grep "$major.[0-$minor]" | grep -v "$(basename $table_path)" | tail -n 1)"
+    echo $previous_minor
+    if [[ $previous_minor ]]; then
+        git show origin/master:$folder_name/$previous_minor > $previous_name
+        echo "created \"previous-$file_name\" from master's \"$previous_minor\" for \"$table_path\""
+        changed_paths+=("$table_path")
+    fi
+done
+
+# for modified tables, we get the previous version from master
+for table_path in $modified_tables
+do
+    file_name="$(basename $table_path)"
+    previous_name="$(dirname $table_path)/previous-$file_name"
+    git show origin/master:$table_path > $previous_name
+    echo "created \"previous-$file_name\" for \"$table_path\""
+    changed_paths+=("$table_path")
+done
+echo "${changed_paths[*]}"


### PR DESCRIPTION
Dit runt de validatie bij pushes en pr's. 

Test run met wat aangepaste tabellen die werkte: https://github.com/Amsterdam/amsterdam-schema/actions/runs/14304598480/job/40085564053

Dit zet een `previous-` prefixed versie naast de toegevoegde of gewijzigde dataset-tabel. Deze wordt overgenomen van de main branch. Vervolgens checken we met behulp van schema-tools of de nieuwe versies geen breaking changes introduceren.

