### PR TITLE
Add show-diff workflow

### DIFF
--- a/.github/workflows/show-diff.yml
+++ b/.github/workflows/show-diff.yml
@@ -1,0 +1,21 @@
+name: show-diffs
+
+on:
+  push:
+  pull_request:
+    paths:
+      - datasets/
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "Fetch master branch"  # So we can diff against it.
+        run: |
+          git fetch origin master
+      - id: show-diffs
+        name: "Show diffs of the added and modified dataset tables"
+        run: |
+          ./scripts/generate_previous_tables_from_master.sh ${{github.head_ref || github.ref_name}}

--- a/.github/workflows/show-diff.yml
+++ b/.github/workflows/show-diff.yml
@@ -1,8 +1,8 @@
 name: show-diffs
 
 on:
-  push:
   pull_request:
+  push:
     paths:
       - datasets/
 jobs:

--- a/.github/workflows/validate-tables.yml
+++ b/.github/workflows/validate-tables.yml
@@ -1,8 +1,8 @@
 name: validate-tables
 
 on:
-  push:
   pull_request:
+  push:
     paths:
       - datasets/
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
           - flake8-debugger
           - flake8-raise
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict

--- a/scripts/generate_previous_tables_from_master.sh
+++ b/scripts/generate_previous_tables_from_master.sh
@@ -36,6 +36,17 @@ do
         git --no-pager diff --no-index --color $previous_name $table_path || true
         echo ""
         changed_paths+=("$table_path")
+        continue
+    fi
+    previous_major="$(ls $folder_name | grep "v[0-${major:1}]" | grep -v "$(basename $table_path)" | tail -n 1)"
+    if [[ $previous_major ]]; then
+        # this isn't  breaking, so no need to add to changed_paths, but helpful to see the diff.
+        echo "=======$table_path========="
+        echo ""
+        git show origin/master:$folder_name/$previous_major > $previous_name
+        echo "Comparing to master's \"$previous_major\":"
+        git --no-pager diff --no-index --color $previous_name $table_path || true
+        echo ""
     fi
 done
 


### PR DESCRIPTION
Ik realiseerde me dat we met wat kleine aanpassingen het script dat we gebruiken voor het valideren van tabellen ook kunnen gebruiken om in github de diff te laten zien tussen een tabel en de vorige versie van diezelfde tabel van main. 

Deze workflow laat die diff zien, hierdoor kun je snel zien wat er precies verandert in een PR op tabelniveau tussen twee versies, ipv zelf lokaal te diffen of bestanden te vergelijken.

Voorbeeld waar ik een nieuwe patch versie had toegevoegd met een extra veld: https://github.com/Amsterdam/amsterdam-schema/actions/runs/14338387595/job/40191282589