### PR TITLE
Add new version v3.0.0 for benkagg handelsregisterkvk table

### DIFF
--- a/datasets/benkagg/dataset.json
+++ b/datasets/benkagg/dataset.json
@@ -84,7 +84,7 @@
         },
         {
           "id": "handelsregisterkvk",
-          "$ref": "handelsregisterkvk/v2"
+          "$ref": "handelsregisterkvk/v3"
         }
       ]
     }

--- a/datasets/benkagg/handelsregisterkvk/v2.2.0.json
+++ b/datasets/benkagg/handelsregisterkvk/v2.2.0.json
@@ -1,0 +1,826 @@
+{
+  "id": "handelsregisterkvk",
+  "type": "table",
+  "version": "2.2.0",
+  "crs": "EPSG:28992",
+  "auth": [
+    "FP/MDW",
+    "HR/R"
+  ],
+  "reasonsNonPublic": [
+    "5.1 2b: Zwaarwegende economische of financiële belangen van publiekrechtelijke lichamen (bevat geen milieu-informatie)"
+  ],
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "mainGeometry": "geometrieRd",
+    "identifier": "identificatie",
+    "required": [
+      "schema",
+      "identificatie"
+    ],
+    "display": "identificatie",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v2#/definitions/schema"
+      },
+      "identificatie": {
+        "type": "string",
+        "title": "Identificatie",
+        "description":"Uniek kvk nummer of kvk nummer plus vestigingsnummer"
+      },
+      "vestigingsnummer": {
+        "type": "string",
+        "title": "Vestiging ID",
+        "description": "Identificatie voor de vestiging"
+      },
+      "hoofdvestiging": {
+        "type": "string",
+        "title": "Hoofdvestiging indicatie",
+        "description": "Indicatie of de vestiging de hoofdvestiging betreft"
+      },
+      "datumAanvangVes": {
+        "type": "string",
+        "title": "Vestiging aanvangsdatum",
+        "description": "De datum van aanvang van de Vestiging"
+      },
+      "datumEindeVes": {
+        "type": "string",
+        "title": "Vestiging einddatum",
+        "description": "De datum van beëindiging van de Vestiging"
+      },
+      "datumVoortzettingVes": {
+        "type": "string",
+        "title": "Vestiging voortgezet datum",
+        "description": "Datum voortzetting van de vestiging"
+      },
+      "kvknummer": {
+        "type": "string",
+        "title": "Maatschappelijke activiteit waarbij vestiging hoort",
+        "description": "Identificatie (KvK-nummer) van de Maatschappelijke Activiteit (MAC) die bij deze vestiging hoort"
+      },
+      "typeVes": {
+        "type": "string",
+        "title": "Vestiging soort code",
+        "description": "Geeft aan of dit een commerciële vestiging (CSV) of niet-commerciële vestiging (NCV) betreft"
+      },
+      "eersteHandelsnaamVes": {
+        "type": "string",
+        "title": "Vestiging eerste handelsnaam",
+        "description": "De naam (niet commerciële vestiging) of eerste handelsnaam (commerciële vestiging) van de Vestiging"
+      },
+      "handelsnamenVes": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Handelsnaam of handelsnamen",
+        "description": "Handelsnaam of Handelsnamen van de niet-commerciële of commerciële vestiging"
+      },
+      "naamVes": {
+        "type": "string",
+        "title": "Niet commerciële vestiging naam",
+        "description": "De naam van de niet-commerciële vestiging"
+      },
+      "ookGenoemdVes": {
+        "type": "string",
+        "title": "Niet commerciële vestiging alternatieve naam",
+        "description": "Een andere naam waaronder de vereniging stichtingen en vereniging van eigenaars ook bekend is"
+      },
+      "communicatieVes": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Communicatie gegevens",
+        "description": "Gegevens over de communicatie van de Vestiging"
+      },
+      "emailAdressenVes": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Email adres",
+        "description": "Het e-mailadres waarop de ondernemer gemaild kan worden"
+      },
+      "domeinnamenVes": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Domein naam",
+        "description": "Het internetadres (website)"
+      },
+      "bezoekLocatieVes": {
+        "type": "object",
+        "properties": {
+          "afgeschermd": {
+            "type": "string",
+            "title": "Adres afgeschermd indicatie",
+            "description": "Geeft aan of het adres, op basis van een afschermingsverzoek, afgeschermd is of niet"
+          },
+          "toevoegingAdres": {
+            "type": "string",
+            "title": "Adres toevoeging",
+            "description": "Vrije tekst om een Locatie nader te kunnen duiden. Bijvoorbeeld bij bedrijfsverzamelgebouwen met meerdere vestigingen"
+          },
+          "volledigAdres": {
+            "type": "string",
+            "title": "Volledig adres",
+            "description": "Samengesteld adres dat wordt afgeleid van de overige adresgegevens"
+          },
+          "straatnaam": {
+            "type": "string",
+            "title": "Straat naam",
+            "description": "Officiële naam openbare ruimte (80 tekens)"
+          },
+          "huisnummer": {
+            "type": "integer",
+            "title": "Huisnummer",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nummering"
+          },
+          "huisletter": {
+            "type": "string",
+            "title": "Huisletter",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken"
+          },
+          "huisnummerToevoeging": {
+            "type": "string",
+            "title": "Huisnummertoevoeging",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter"
+          },
+          "postcode": {
+            "type": "string",
+            "title": "Postcode",
+            "description": "De door PostNL vastgestelde code bestaande uit 4 cijfers en 2 letters (1234AB)"
+          },
+          "plaats": {
+            "type": "string",
+            "title": "Plaats naam",
+            "description": "Officiële naam woonplaats"
+          },
+          "straatHuisnummerBuitenland": {
+            "type": "string",
+            "title": "Buitenland straat huisnummer",
+            "description": "Het straat/huisnummer is een combinatie van de straat en het huisnummer van het buitenlandse adres"
+          },
+          "postcodePlaatsBuitenland": {
+            "type": "string",
+            "title": "Buitenland plaats postcode",
+            "description": "De postcode/woonplaats is de combinatie van een eventuele postcode en woonplaats van het buitenlandse adres"
+          },
+          "regioBuitenland": {
+            "type": "string",
+            "title": "Buitenland regio naam",
+            "description": "Regio is een deel van het land (streek, provincie, etc.) van het buitenlandse adres"
+          },
+          "landBuitenland": {
+            "type": "string",
+            "title": "Buitenland naam",
+            "description": "De naam van het land waar het adres zich bevindt"
+          }
+        },
+        "title": "Bezoeklocatie locatiegegevens",
+        "description": "De locatiegegevens van de bezoekLocatie"
+      },
+      "bezoekHeeftBagNummeraanduidingVes": {
+        "type": "string",
+        "title": "Nummeraanduiding van bezoeklocatie",
+        "description": "Met welke nummeraanduiding heeft de bezoeklocatie een relatie"
+      },
+      "bezoekHeeftBagAdresseerbaarObjectIdentificatieVes": {
+        "type": "string",
+        "title": "Adresseerbaar object van bezoeklocatie",
+        "description": "Met welk adresseerbaar object heeft de bezoeklocatie een relatie"
+      },
+      "postLocatieVes": {
+        "type": "object",
+        "properties": {
+          "afgeschermd": {
+            "type": "string",
+            "title": "Adres afgeschermd indicatie",
+            "description": "Geeft aan of het adres, op basis van een afschermingsverzoek, afgeschermd is of niet"
+          },
+          "toevoegingAdres": {
+            "type": "string",
+            "title": "Adres toevoeging omschrijving",
+            "description": "Vrije tekst om een Locatie nader te kunnen duiden. Bijvoorbeeld om bedrijfsverzamelgebouwen met meerdere vestigingen"
+          },
+          "volledigAdres": {
+            "type": "string",
+            "title": "Volledig adres",
+            "description": "Samengesteld adres dat wordt afgeleid van de overige adresgegevens"
+          },
+          "straatnaam": {
+            "type": "string",
+            "title": "Straat naam",
+            "description": "Officiële naam openbare ruimte (80 tekens)"
+          },
+          "huisnummer": {
+            "type": "integer",
+            "title": "Huisnummer",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nummering"
+          },
+          "huisletter": {
+            "type": "string",
+            "title": "Huisletter",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken"
+          },
+          "huisnummerToevoeging": {
+            "type": "string",
+            "title": "Huisnummer toevoeging",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter"
+          },
+          "postbusnummer": {
+            "type": "integer",
+            "title": "Postbus nummer",
+            "description": "Het nummer van de postbus behorende bij het binnenlandse adres"
+          },
+          "postcode": {
+            "type": "string",
+            "title": "Postcode",
+            "description": "De door PostNL vastgestelde code bestaande uit 4 cijfers en 2 letters (1234AB)"
+          },
+          "plaats": {
+            "type": "string",
+            "title": "Plaats naam",
+            "description": "Officiële naam woonplaats"
+          },
+          "straatHuisnummerBuitenland": {
+            "type": "string",
+            "title": "Buitenland straat huisnummer",
+            "description": "Het straat/huisnummer is een combinatie van de straat en het huisnummer van het buitenlandse adres"
+          },
+          "postcodePlaatsBuitenland": {
+            "type": "string",
+            "title": "Buitenland plaats postcode",
+            "description": "De postcode/woonplaats is de combinatie van een eventuele postcode en woonplaats van het buitenlandse adres"
+          },
+          "regioBuitenland": {
+            "type": "string",
+            "title": "Buitenland regio naam",
+            "description": "Regio is een deel van het land (streek, provincie, etc.) van het buitenlandse adres"
+          },
+          "landBuitenland": {
+            "type": "string",
+            "title": "Buitenland naam",
+            "description": "De naam van het land waar het adres zich bevindt"
+          }
+        },
+        "title": "Postlocatie locatiegegevens",
+        "description": "De locatiegegevens van de postLocatie"
+      },
+      "postHeeftBagNummeraanduidingVes": {
+        "type": "string",
+        "title": "Nummeraanduiding van postlocatie",
+        "description": "Met welke nummeraanduiding heeft de postlocatie een relatie"
+      },
+      "postHeeftBagAdresseerbaarObjectIdentificatieVes": {
+        "type": "string",
+        "title": "Adresseerbaar object van postlocatie",
+        "description": "Met welke adresseerbaar object heeft de postlocatie een relatie"
+      },
+      "totaalWerkzamePersonenVes": {
+        "type": "integer",
+        "title": "Aantal werkzame personen",
+        "description": "Het totaal aantal werkzame personen bij de onderneming. Som van fulltime en parttime"
+      },
+      "voltijdWerkzamePersonenVes": {
+        "type": "integer",
+        "title": "Aantal voltijd werkzame personen",
+        "description": "Het aantal voltijd (meer dan 15 uur per week) werkzame personen bij de onderneming"
+      },
+      "deeltijdWerkzamePersonenVes": {
+        "type": "integer",
+        "title": "Aantal deeltijd werkzame personen",
+        "description": "Het aantal deeltijd (kleiner of gelijk aan 15 uur per week) werkzame personen bij de onderneming"
+      },
+      "activiteitOmschrijvingVes": {
+        "type": "string",
+        "title": "Vestiging activiteit omschrijving",
+        "description": "De omschrijving van de activiteiten die de vestiging uitoefent. De beschrijving bevat de nadere aanduiding van de commerciële activiteiten of de nadere aanduiding van de niet-commerciële activiteiten"
+      },
+      "activiteitenVes": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "SBI code",
+        "description": "Codering van activiteiten binnen het handelsregister volgens de standaard bedrijfsindeling (SBI) 2008"
+      },
+      "importeertVes": {
+        "type": "string",
+        "title": "Commerciele activiteit import indicatie",
+        "description": "Indicatie of de commerciële activiteit import betreft"
+      },
+      "exporteertVes": {
+        "type": "string",
+        "title": "Commerciele activiteit export indicatie",
+        "description": "Indicatie of de commerciële activiteit export betreft"
+      },
+      "datumAanvangMac": {
+        "shortname": "datumAanvangMac",
+        "type": "string",
+        "title": "Maatschappelijke activiteit geldigheid aanvangsdatum",
+        "description": "De datum waarbij de Maatschappelijke Activiteit in de echte wereld is ontstaan"
+      },
+      "datumEindeMac": {
+        "shortname": "datumEindeMac",
+        "type": "string",
+        "title": "Maatschappelijke activiteit geldigheid einddatum",
+        "description": "De datum waarbij de Maatschappelijke Activiteit in de echte wereld is beëindigd"
+      },
+      "naamMac": {
+        "type": "string",
+        "title": "Statutaire naam",
+        "description": "De statutaire naam of eerste handelsnaam van de inschrijving"
+      },
+      "nonMailingMac": {
+        "type": "string",
+        "title": "Non mailing indicatie",
+        "description": "Indicator die aangeeft of de inschrijving haar adresgegevens beschikbaar stelt voor mailing-doeleinden"
+      },
+      "activiteitenMac": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Sbi activiteiten",
+        "description": "De SBI-activiteiten van de maatschappelijke activiteit is het totaal van alle SBI-Activiteiten die voorkomen bij de maatschappelijke activiteit behorende niet commerciële vestiging (NCV)en bij de Rechtspersoon"
+      },
+      "incidenteelUitlenenArbeidskrachten": {
+        "type": "string",
+        "title": "Incidenteel uitlenen arbeidskrachten indicatie",
+        "description": "Indicatie die aangeeft of de ondernemer tijdelijk arbeidskrachten ter beschikking stelt en dit niet onderdeel is van zijn 'reguliere' activiteiten"
+      },
+      "heeftHrHoofdvestiging": {
+        "type": "object",
+        "properties": {
+          "vestigingsnummer": {
+            "type": "string"
+          }
+        },
+        "title": "Hoofdvestiging van maatschappelijke activiteit",
+        "description": "De vestiging die als hoofdvestiging wordt gebruikt"
+      },
+      "heeftAlsEigenaarNps": {
+        "shortname": "heeftEigenaarHrNps",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "title": "Natuurlijke persoon die eigenaar is",
+        "description": "Heeft als eigenaar een natuurlijke persoon (NPS)"
+      },
+      "heeftAlsEigenaarNnp": {
+        "shortname": "heeftEigenaarHrNnp",
+        "type": "object",
+        "properties": {
+          "identificatie": {
+            "type": "string"
+          }
+        },
+        "title": "Niet natuurlijke persoon die eigenaar is",
+        "description": "Heeft als eigenaar een niet natuurlijke persoon (NNP)"
+      },
+      "typeEigenaar": {
+        "type": "string",
+        "title": "Natuurlijk of Niet natuurlijk persoon",
+        "description": "Afgeleid gegeven: een eigenaar is een natuurlijk of niet natuurlijk persoon"
+      },
+      "onderneming": {
+        "type": "boolean",
+        "title": "Maatschappelijke activiteit is wel/geen onderneming",
+        "description": "Van onderneming (OND) is sprake indien een voldoende zelfstandig optredende organisatorische eenheid van één of meer personen bestaat waarin door voldoende inbreng van arbeid of middelen, ten behoeve van derden diensten of goederen worden geleverd of werken tot stand worden gebracht met het oogmerk daarmee materieel voordeel te behalen"
+      },
+      "totaalWerkzamePersonenOnderneming": {
+        "type": "integer",
+        "title": "Aantal werkzame personen",
+        "description": "Totaal aantal werkzame personen bij de onderneming"
+      },
+      "voltijdWerkzamePersonenOnderneming": {
+        "type": "integer",
+        "title": "Aantal voltijd werkzame personen",
+        "description": "Aantal voltijd (meer dan 15 uur per week) werkzame personen bij de onderneming"
+      },
+      "deeltijdWerkzamePersonenOnderneming": {
+        "type": "integer",
+        "title": "Aantal deeltijd werkzame personen",
+        "description": "Aantal deeltijd (kleiner of gelijk aan 15 uur per week) werkzame personen bij de onderneming"
+      },
+      "datumAanvangMacOnderneming": {
+        "type": "string",
+        "title": "Onderneming aanvangsdatum",
+        "description": "De datum van aanvang van de relatie tussen de onderneming en de commercielevestiging"
+      },
+      "datumEindeMacOnderneming": {
+        "type": "string",
+        "title": "Onderneming einddatum",
+        "description": "De einddatum van de relatie tussen de onderneming en de commercielevestiging"
+      },
+      "datumOverdrachtVoortzettingOnderneming": {
+        "type": "string",
+        "title": "Onderneming voortgezet overgedragen datum",
+        "description": "De datum waarop de onderneming is overgedragen of voortgezet"
+      },
+      "overdrachtOfVoortzettingOnderneming": {
+        "type": "string",
+        "title": "Indicatie onderneming voortgezet of overgedragen ",
+        "description": "Indicatie of de Onderneming is voortgezet of is overgedragen. (Overdracht of Voortzetting)"
+      },
+      "handelsnamenMac": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Handelsnaam",
+        "description": "Handelsnaam van de commerciële vestiging"
+      },
+      "wordtUitgeoefendInCommercieleVestigingen": {
+        "shortname": "uitgeoefendInHrCvs",
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Commerciële vestiging maatschappelijke activiteit",
+        "description": "Hiermee wordt vastgelegd in welke periode (datumAanvang-datumEinde) welke commerciele VES bij een onderneming behoort"
+      },
+      "wordtUitgeoefendInNietCommercieleVestigingen": {
+        "shortname": "uitgeoefendInHrNcv",
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Niet commerciële vestiging maatschappelijke activiteit",
+        "description": "Hiermee wordt beschreven in welke periode (datumAanvang-datumEinde) welke niet commerciele VES bij een MAC behoort"
+      },
+      "communicatieMac": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Communicatiegegevens",
+        "description": "Communicatiegegevens van de maatschappelijke activiteit"
+      },
+      "emailAdressenMac": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Email adres",
+        "description": "Het e-mailadres waarop de ondernemer gemaild kan worden"
+      },
+      "domeinnamenMac": {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Domein naam",
+        "description": "Het internetadres (web site)"
+      },
+      "bezoekLocatieMac": {
+        "type": "object",
+        "properties": {
+          "afgeschermd": {
+            "type": "string",
+            "title": "Adres afgeschermd indicatie",
+            "description": "Geeft aan of het adres afgeschermd is of niet"
+          },
+          "toevoegingAdres": {
+            "type": "string",
+            "title": "Adres toevoeging omschrijving",
+            "description": "Vrije tekst om een locatie nader te kunnen duiden. Bijvoorbeeld om bedrijfsverzamelgebouwen met meerdere vestigingen"
+          },
+          "volledigAdres": {
+            "type": "string",
+            "title": "Volledig adres",
+            "description": "Samengesteld adres dat wordt afgeleid van de overige adresgegevens"
+          },
+          "straatnaam": {
+            "type": "string",
+            "title": "Straat naam",
+            "description": "Officiële naam openbare ruimte (80 tekens)"
+          },
+          "huisnummer": {
+            "type": "integer",
+            "title": "Huisnummer",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nummering"
+          },
+          "huisletter": {
+            "type": "string",
+            "title": "Huisletter",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken"
+          },
+          "huisnummerToevoeging": {
+            "type": "string",
+            "title": "Huisnummer toevoeging",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter"
+          },
+          "postcode": {
+            "type": "string",
+            "title": "Postcode",
+            "description": "De door PostNL vastgestelde code bestaande uit 4 cijfers en 2 letters (1234AB)"
+          },
+          "plaats": {
+            "type": "string",
+            "title": "Plaats naam",
+            "description": "Officiële naam woonplaats"
+          },
+          "straatHuisnummerBuitenland": {
+            "type": "string",
+            "title": "Buitenland straat huisnummer",
+            "description": "Het straat/huisnummer is een combinatie van de straat en het huisnummer van het buitenlandse adres"
+          },
+          "postcodePlaatsBuitenland": {
+            "type": "string",
+            "title": "Buitenland plaats postcode",
+            "description": "De postcode/woonplaats is de combinatie van een eventuele postcode en woonplaats van het buitenlandse adres"
+          },
+          "regioBuitenland": {
+            "type": "string",
+            "title": "Buitenland regio naam",
+            "description": "Regio is een deel van het land (streek, provincie, etc.) van het buitenlandse adres"
+          },
+          "landBuitenland": {
+            "type": "string",
+            "title": "Buitenland naam",
+            "description": "De naam van het land waar het adres zich bevindt"
+          }
+        },
+        "title": "Bezoeklocatie locatiegegevens",
+        "description": "De locatiegegevens van de bezoekLocatie"
+      },
+      "bezoekHeeftBagNummeraanduidingMac": {
+        "type": "string",
+        "title": "Nummeraanduiding bezoeklocatie",
+        "description": "Unieke identificatie van de BAG nummeraanduiding"
+      },
+      "bezoekHeeftBagAdresseerbaarObjectIdentificatieMac": {
+        "type": "string",
+        "title": "Adresseerbaar object bezoeklocatie",
+        "description": "Unieke identificatie van de BAG Adresseerbaar object"
+      },
+      "postLocatieMac": {
+        "type": "object",
+        "properties": {
+          "afgeschermd": {
+            "type": "string",
+            "title": "Adres afgeschermd indicatie",
+            "description": "Geeft aan of het adres afgeschermd is of niet"
+          },
+          "toevoegingAdres": {
+            "type": "string",
+            "title": "Adres toevoeging omschrijving",
+            "description": "Vrije tekst om een locatie nader te kunnen duiden. Bijvoorbeeld bij bedrijfsverzamelgebouwen met meerdere vestigingen"
+          },
+          "volledigAdres": {
+            "type": "string",
+            "title": "Volledig adres",
+            "description": "Samengesteld adres dat wordt afgeleid van de overige adresgegevens"
+          },
+          "straatnaam": {
+            "type": "string",
+            "title": "Straat naam",
+            "description": "Officiële naam openbare ruimte (80 tekens)"
+          },
+          "huisnummer": {
+            "type": "integer",
+            "title": "Huisnummer",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nummering"
+          },
+          "huisletter": {
+            "type": "string",
+            "title": "Huisletter",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken"
+          },
+          "huisnummerToevoeging": {
+            "type": "string",
+            "title": "Huisnummer toevoeging",
+            "description": "Een door het bevoegde gemeentelijke orgaan ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter"
+          },
+          "postbusnummer": {
+            "type": "integer",
+            "title": "Postbus nummer",
+            "description": "Het nummer van de postbus behorende bij het binnenlandse adres"
+          },
+          "postcode": {
+            "type": "string",
+            "title": "Postcode",
+            "description": "De door PostNL vastgestelde code bestaande uit 4 cijfers en 2 letters (1234AB)"
+          },
+          "plaats": {
+            "type": "string",
+            "title": "Plaats naam",
+            "description": "Officiële naam woonplaats"
+          },
+          "straatHuisnummerBuitenland": {
+            "type": "string",
+            "title": "Buitenland straat huisnummer",
+            "description": "Het straat/huisnummer is een combinatie van de straat en het huisnummer van het buitenlandse adres"
+          },
+          "postcodePlaatsBuitenland": {
+            "type": "string",
+            "title": "Buitenland plaats postcode",
+            "description": "De postcode/woonplaats is de combinatie van een eventuele postcode en woonplaats van het buitenlandse adres"
+          },
+          "regioBuitenland": {
+            "type": "string",
+            "title": "Buitenland regio naam",
+            "description": "Regio is een deel van het land (streek, provincie, etc.) van het buitenlandse adres"
+          },
+          "landBuitenland": {
+            "type": "string",
+            "title": "Buitenland naam",
+            "description": "De naam van het land waar het adres zich bevindt"
+          }
+        },
+        "title": "Postlocatie locatiegegevens",
+        "description": "De locatiegegevens van de postLocatie"
+      },
+      "postHeeftBagNummeraanduidingMac": {
+        "type": "string",
+        "title": "Nummeraanduiding postlocatie",
+        "description": "Unieke identificatie van de BAG nummeraanduiding"
+      },
+      "postHeeftBagAdresseerbaarObjectIdentificatieMac": {
+        "type": "string",
+        "title": "Adresseerbaar object postlocatie",
+        "description": "Unieke identificatie van de BAG Adresseerbaar object"
+      },
+      "rol": {
+        "title": "Rol omschrijving",
+        "type": "string",
+        "description": "De rol die een Niet Natuurlijk Persoon (NNP) of Natuurlijk Persoon (NPS) vervult bij de maatschappelijke activiteit"
+      },
+      "typePersoon": {
+        "type": "string",
+        "title": "Persoon type",
+        "description": "Type Niet Natuurlijk (NNP) of Natuurlijk Persoon (NPS)"
+      },
+      "persoonRechtsvorm": {
+        "type": "string",
+        "title": "Persoon rechtsvorm omschrijving",
+        "description": "Rechtsvorm van de persoon, dus Natuurlijk Persoon (NPS) of Niet Natuurlijke Persoon (NNP)"
+      },
+      "uitgebreideRechtsvorm": {
+        "type": "string",
+        "title": "Persoon uitgebreide rechtsvorm omschrijving",
+        "description": "Rechtsvorm van inschrijving Natuurlijk Persoon (NPS) of Niet Natuurlijke Persoon (NNP) aangevuld met informatie over structuur, rechtbevoegdheid etc"
+      },
+      "volledigeNaam": {
+        "type": "string",
+        "title": "Persoon volledige naam",
+        "description": "De volledige naam van de Persoon (NPS of NNP)"
+      },
+      "bijzondereRechtstoestandPersoon": {
+        "type": "string",
+        "title": "Persoon bijzondere rechtstoestand",
+        "description": "bijzondere rechtstoestand (schuldsanering, surséance van betaling, faillissement) (NPS of NNP)"
+      },
+      "status": {
+        "type": "string",
+        "title": "Surceance status code",
+        "description": "De status waarin de surseance verkeert, dit kan voorlopig of definitief zijn"
+      },
+      "duur": {
+        "type": "integer",
+        "title": "Surceance duur",
+        "description": "De duur van de periode (in maanden) waarvoor surseance van betaling geldt"
+      },
+      "persoonFunctievervullingenFvv": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "title": "Functievervulling die de niet natuurlijke of natuurlijke persoon heeft",
+        "description": "Een Niet Natuurlijk of Natuurlijk Persoon (NNP en NPS) heeft geen, een of meerdere Functievervullingen (FVV)"
+      },
+      "rsinNnp": {
+        "type": "string",
+        "title": "Rechtspersoon en Samenwerkingsverband Informatienummer",
+        "description": "Rechtspersonen en Samenwerkingsverbanden Informatienummer (RSIM). Het door een kamer toegekend uniek nummer voor de Niet Natuurlijk Persoon"
+      },
+      "datumUitschrijvingNnp": {
+        "type": "string",
+        "title": "Uitschrijving datum",
+        "description": "De datum dat de niet-natuurlijk persoon is uitgeschreven. Deze wordt gebruikt bij de verhuizing naar het buitenland. De NNP is hiemee niet beëindigd"
+      },
+      "naamNnp": {
+        "type": "string",
+        "title": "Niet natuurlijk persoon naam",
+        "description": "De naam van de Niet Natuurlijk persoon (NNP)"
+      },
+      "ookGenoemdNnp": {
+        "type": "string",
+        "title": "Persoon alternatieve naam",
+        "description": "Een andere naam waaronder de vereniging, stichting of vereniging van eigenaars ook bekend is"
+      },
+      "doelRechtsvormNnp": {
+        "type": "string",
+        "title": "Niet natuurlijk persoon doelrechtsvorm omschrijving",
+        "description": "Rechtsvorm die de Niet natuurlijk persoon (NNP) na oprichting zal krijgen"
+      },
+      "rechtsvormNnp": {
+        "type": "string",
+        "title": "Niet natuurlijk persoon rechtsvorm omschrijving",
+        "description": "Rechtsvorm van de Niet natuurlijk Persoon (NNP)"
+      },
+      "datumAanvangNnp": {
+        "type": "string",
+        "title": "Niet natuurlijke persoon aanvangsdatum",
+        "description": "Datum van aanvang van de Niet Natuurlijk Persoon (NNP)"
+      },
+      "datumEindeNnp": {
+        "type": "string",
+        "title": "Niet natuurlijke persoon einddatum",
+        "description": "Datum van beëindiging van de Niet Natuurlijk Persoon (NNP)"
+      },
+      "bsnNps": {
+        "type": "string",
+        "auth": "HR/RSN",
+        "title": "Burgerservicenummer",
+        "description": "Het burgerservicenummer (BSN) van de Natuurlijke persoon (NPS)"
+      },
+      "voorvoegselGeslachtsnaamNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon geslachtsnaam voorvoegsel",
+        "description": "Het voorvoegsel van de geslachtsnaam van de Natuurlijk persoon"
+      },
+      "geslachtsnaamNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon geslachtsnaam",
+        "description": "Geslachtsnaam van de Natuurlijk persoon"
+      },
+      "voornamenNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon voornaam",
+        "description": "De voornaam of voornamen van de Natuurlijk persoon"
+      },
+      "geslachtsaanduidingNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon geslachtsaanduiding omschrijving",
+        "description": "De geslachtsaanduiding van de {NatuurlijkPersoon} conform de standaarden van de BRP"
+      },
+      "geboortedatumNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon geboortedatum",
+        "description": "Geboortedatum van de Natuurlijk persoon"
+      },
+      "geboorteplaatsNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon geboorteplaats",
+        "description": "De plaats waar de betreffende Natuurlijk persoon is geboren"
+      },
+      "geboortelandNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon geboorteland",
+        "description": "Het land waar de Natuurlijk persoon geboren is"
+      },
+      "overlijdensdatumNps": {
+        "type": "string",
+        "title": "Natuurlijk persoon overlijdensdatum",
+        "description": "De overlijdensdatum van de Natuurlijk persoon"
+      },
+      "bagPostcode": {
+        "type": "string",
+        "title": "Postcode",
+        "description": "De door PostNL vastgestelde code bestaande uit 4 cijfers en 2 letters (1234AB)"
+      },
+      "bagOpenbareruimteNaam": {
+        "type": "string",
+        "title": "Openbare ruimte naam",
+        "description": "Officiële naam openbare ruimte (80 tekens)"
+      },
+      "gebiedenBuurtNaam": {
+        "type": "string",
+        "title": "Object naam",
+        "description": "De naam van het object"
+      },
+      "gebiedenBuurtCode": {
+        "type": "string",
+        "title": "Buurt code",
+        "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode"
+      },
+      "gebiedenWijkNaam": {
+        "type": "string",
+        "title": "Object naam",
+        "description": "De naam van het object"
+      },
+      "gebiedenWijkCode": {
+        "type": "string",
+        "title": "Buurt code",
+        "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode"
+      },
+      "gebiedenStadsdeelNaam": {
+        "type": "string",
+        "title": "Object naam",
+        "description": "De naam van het object"
+      },
+      "gebiedenStadsdeelCode": {
+        "type": "string",
+        "title": "Buurt code",
+        "description": "Volledige, samengestelde, code, bestaande uit stadsdeelcode en wijkcode"
+      },
+      "gebiedenGgwgebiedNaam": {
+        "type": "string",
+        "title": "Object naam",
+        "description": "De naam van het object"
+      },
+      "gebiedenGgwgebiedCode": {
+        "type": "string",
+        "title": "Object code",
+        "description": "Officiële code van het object"
+      },
+      "geometrieRd": {
+        "$ref": "https://geojson.org/schema/Point.json",
+        "title": "Puntgeometrie RD adresseerbaar object",
+        "description": "Puntgeometrie van het adresseerbare object in het stelsel van de Rijksdriehoeksmeting (RD)"
+      },
+      "geometrieWgs84": {
+        "crs": "EPSG:4326",
+        "$ref": "https://geojson.org/schema/Point.json",
+        "title": "Puntgeometrie in WGS84 formaat adresseerbaar object",
+        "description": "Puntgeometrie van het adresseerbare object in WGS84 formaat (WGS84)"
+      }
+    }
+  }
+}

--- a/datasets/benkagg/handelsregisterkvk/v3.json
+++ b/datasets/benkagg/handelsregisterkvk/v3.json
@@ -356,6 +356,7 @@
       "heeftAlsEigenaarNps": {
         "shortname": "heeftEigenaarHrNps",
         "type": "object",
+        "auth": "HR/RSN",
         "properties": {
           "identificatie": {
             "type": "string"

--- a/datasets/benkagg/handelsregisterkvk/v3.json
+++ b/datasets/benkagg/handelsregisterkvk/v3.json
@@ -1,7 +1,8 @@
 {
   "id": "handelsregisterkvk",
   "type": "table",
-  "version": "2.2.0",
+  "version": "3.0.0",
+  "lifecycleStatus": "stable",
   "crs": "EPSG:28992",
   "auth": [
     "FP/MDW",
@@ -722,41 +723,49 @@
       },
       "voorvoegselGeslachtsnaamNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon geslachtsnaam voorvoegsel",
         "description": "Het voorvoegsel van de geslachtsnaam van de Natuurlijk persoon"
       },
       "geslachtsnaamNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon geslachtsnaam",
         "description": "Geslachtsnaam van de Natuurlijk persoon"
       },
       "voornamenNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon voornaam",
         "description": "De voornaam of voornamen van de Natuurlijk persoon"
       },
       "geslachtsaanduidingNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon geslachtsaanduiding omschrijving",
         "description": "De geslachtsaanduiding van de {NatuurlijkPersoon} conform de standaarden van de BRP"
       },
       "geboortedatumNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon geboortedatum",
         "description": "Geboortedatum van de Natuurlijk persoon"
       },
       "geboorteplaatsNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon geboorteplaats",
         "description": "De plaats waar de betreffende Natuurlijk persoon is geboren"
       },
       "geboortelandNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon geboorteland",
         "description": "Het land waar de Natuurlijk persoon geboren is"
       },
       "overlijdensdatumNps": {
         "type": "string",
+        "auth": "HR/RSN",
         "title": "Natuurlijk persoon overlijdensdatum",
         "description": "De overlijdensdatum van de Natuurlijk persoon"
       },


### PR DESCRIPTION
The table can contain Maatschappelijke  Activiteiten (macs) without Vestigingen and date values are represented as strings.