### PR TITLE
Simplify schema validation of different types of schemas

### DIFF
--- a/schema@v3.1.0/schema.json
+++ b/schema@v3.1.0/schema.json
@@ -167,26 +167,30 @@
   },
   "allOf": [
     {
-      "oneOf": [
-        {
-          "$ref": "./dataset@v3.1.0"
-        },
-        {
-          "$ref": "./dataset-version@v3.1.0"
-        },
-        {
-          "$ref": "./table@v3.1.0"
-        },
-        {
-          "$ref": "./row-meta-schema@v3.1.0"
-        },
-        {
-          "$ref": "./publisher@v3.1.0"
-        },
-        {
-          "$ref": "./scope@v3.1.0"
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "const": "dataset"
+            },
+            {
+              "const": "dataset-version"
+            },
+            {
+              "const": "table"
+            },
+            {
+              "const": "publisher"
+            },
+            {
+              "const": "scope"
+            },
+            {
+              "const": "object"
+            }
+          ]
         }
-      ]
+      }
     },
     {
       "if": {


### PR DESCRIPTION
Hij checkte bij de validatie elk schema tegen elk van de metaschema's (dataset, table, scope, publisher, etc.). Dit zorgde ten eerste voor vreemde output waarbij het bij fouten in een dataset schema leek alsof hij checkte tegen een ander metaschema en ten tweede voor een slechtere performance omdat hij ze allemaal checkt (duurde 2 a 3 keer zo lang). 

De oplossing versimpelt de check, de allOf zorgt er nu alleen voor dat het juiste type aan het juiste metaschema voldoet.