### PR TITLE
update views to v1

### DIFF
--- a/datasets/dataverkenner/aantekeningen/aantekeningen/v1.json
+++ b/datasets/dataverkenner/aantekeningen/aantekeningen/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "aantekeningen",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:aantekeningenkadastraleobjecten"
   ],

--- a/datasets/dataverkenner/aantekeningen/dataset.json
+++ b/datasets/dataverkenner/aantekeningen/dataset.json
@@ -18,7 +18,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "aantekeningen",

--- a/datasets/dataverkenner/aantekeningen/dataset.sql
+++ b/datasets/dataverkenner/aantekeningen/dataset.sql
@@ -1,5 +1,5 @@
-create or replace view public.dataverkenner_aantekeningen_aantekeningen WITH (security_barrier) as
-select 
+create or replace view public.dataverkenner_aantekeningen_aantekeningen_v1 WITH (security_barrier) as
+select
 brk_2_aantekeningenkadastraleobjecten.id as "id",
 brk_2_aantekeningenkadastraleobjecten.identificatie as "identificatie",
 brk_2_aantekeningenkadastraleobjecten.volgnummer as "volgnummer",

--- a/datasets/dataverkenner/aantekeningenm/aantekeningen/v1.json
+++ b/datasets/dataverkenner/aantekeningenm/aantekeningen/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "aantekeningen",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:aantekeningenkadastraleobjecten"
   ],

--- a/datasets/dataverkenner/aantekeningenm/dataset.json
+++ b/datasets/dataverkenner/aantekeningenm/dataset.json
@@ -18,7 +18,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "aantekeningen",

--- a/datasets/dataverkenner/aantekeningenm/dataset.sql
+++ b/datasets/dataverkenner/aantekeningenm/dataset.sql
@@ -1,5 +1,5 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_aantekeningenm_aantekeningen as
-select 
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_aantekeningenm_aantekeningen_v1 as
+select
 brk_2_aantekeningenkadastraleobjecten.id as "id",
 brk_2_aantekeningenkadastraleobjecten.identificatie as "identificatie",
 brk_2_aantekeningenkadastraleobjecten.volgnummer as "volgnummer",

--- a/datasets/dataverkenner/bagadresinformatie/bagadresinformatie/v1.json
+++ b/datasets/dataverkenner/bagadresinformatie/bagadresinformatie/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bagadresinformatie",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/bagadresinformatie/dataset.json
+++ b/datasets/dataverkenner/bagadresinformatie/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bagadresinformatie",

--- a/datasets/dataverkenner/bagadresinformatie/dataset.sql
+++ b/datasets/dataverkenner/bagadresinformatie/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_bagadresinformatie_bagadresinformatie WITH (security_barrier) as
+create or replace view public.dataverkenner_bagadresinformatie_bagadresinformatie_v1 WITH (security_barrier) as
 select
 bag_nummeraanduidingen.id as "id",
 bag_nummeraanduidingen.identificatie as "identificatie",

--- a/datasets/dataverkenner/bagadresinformatiem/bagadresinformatie/v1.json
+++ b/datasets/dataverkenner/bagadresinformatiem/bagadresinformatie/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bagadresinformatie",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/bagadresinformatiem/dataset.json
+++ b/datasets/dataverkenner/bagadresinformatiem/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bagadresinformatie",

--- a/datasets/dataverkenner/bagadresinformatiem/dataset.sql
+++ b/datasets/dataverkenner/bagadresinformatiem/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bagadresinformatiem_bagadresinformatie as
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bagadresinformatiem_bagadresinformatie_v1 as
 select
 bag_nummeraanduidingen.id as "id",
 bag_nummeraanduidingen.identificatie as "identificatie",

--- a/datasets/dataverkenner/bagpanden/bagpanden/v1.json
+++ b/datasets/dataverkenner/bagpanden/bagpanden/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bagpanden",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/bagpanden/dataset.json
+++ b/datasets/dataverkenner/bagpanden/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bagpanden",

--- a/datasets/dataverkenner/bagpanden/dataset.sql
+++ b/datasets/dataverkenner/bagpanden/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_bagpanden_bagpanden WITH (security_barrier) as
+create or replace view public.dataverkenner_bagpanden_bagpanden_v1 WITH (security_barrier) as
 select
 bag_panden.id as "id",
 bag_panden.identificatie as "pand_identificatie",
@@ -18,5 +18,5 @@ bag_panden.documentnummer as "pand_documentnummer",
 bag_panden.begin_geldigheid as "pand_begin_geldigheid",
 bag_panden.eind_geldigheid as "pand_eind_geldigheid"
 from bag_panden
-where bag_panden.eind_geldigheid is null 
+where bag_panden.eind_geldigheid is null
 and bag_panden.status_omschrijving in ('Bouwaanvraag ontvangen','Bouwvergunning verleend','Bouw gestart','Pand in gebruik (niet ingemeten)','Pand in gebruik','Sloopvergunning verleend','Pand buiten gebruik','verbouwing pand');

--- a/datasets/dataverkenner/bagpandenm/bagpanden/v1.json
+++ b/datasets/dataverkenner/bagpandenm/bagpanden/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bagpanden",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/bagpandenm/dataset.json
+++ b/datasets/dataverkenner/bagpandenm/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bagpanden",

--- a/datasets/dataverkenner/bagpandenm/dataset.sql
+++ b/datasets/dataverkenner/bagpandenm/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bagpandenm_bagpanden AS WITH verblijfsobjecten AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bagpandenm_bagpanden_v1 AS WITH verblijfsobjecten AS
   ( SELECT ligt_in_panden_id,
            array_agg(verblijfsobjecten_identificatie) AS vots
    FROM bag_verblijfsobjecten_ligt_in_panden

--- a/datasets/dataverkenner/bagzoek/bagzoek/v1.json
+++ b/datasets/dataverkenner/bagzoek/bagzoek/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bagzoek",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/bagzoek/dataset.json
+++ b/datasets/dataverkenner/bagzoek/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bagzoek",

--- a/datasets/dataverkenner/bagzoek/dataset.sql
+++ b/datasets/dataverkenner/bagzoek/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_bagzoek_bagzoek WITH (security_barrier) as
+create or replace view public.dataverkenner_bagzoek_bagzoek_v1 WITH (security_barrier) as
 select
 bag_nummeraanduidingen.id as "id",
 bag_nummeraanduidingen.identificatie as "identificatie",

--- a/datasets/dataverkenner/bagzoekm/bagzoek/v1.json
+++ b/datasets/dataverkenner/bagzoekm/bagzoek/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bagzoek",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/bagzoekm/dataset.json
+++ b/datasets/dataverkenner/bagzoekm/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bagzoek",

--- a/datasets/dataverkenner/bagzoekm/dataset.sql
+++ b/datasets/dataverkenner/bagzoekm/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bagzoekm_bagzoek as
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bagzoekm_bagzoek_v1 as
 select
 bag_nummeraanduidingen.id as "id",
 bag_nummeraanduidingen.identificatie as "identificatie",

--- a/datasets/dataverkenner/betrokkenbij/betrokkenbij/v1.json
+++ b/datasets/dataverkenner/betrokkenbij/betrokkenbij/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "betrokkenbij",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:kadastraleobjecten",
     "brk2:kadastraleobjecten_is_ontstaan_uit_brk_kadastraalobject"

--- a/datasets/dataverkenner/betrokkenbij/dataset.json
+++ b/datasets/dataverkenner/betrokkenbij/dataset.json
@@ -14,7 +14,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "betrokkenbij",

--- a/datasets/dataverkenner/betrokkenbij/dataset.sql
+++ b/datasets/dataverkenner/betrokkenbij/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_betrokkenbij_betrokkenbij WITH (security_barrier) as
+create or replace view public.dataverkenner_betrokkenbij_betrokkenbij_v1 WITH (security_barrier) as
 SELECT
     kot1.id,
     kot1.identificatie,

--- a/datasets/dataverkenner/betrokkenbijm/betrokkenbij/v1.json
+++ b/datasets/dataverkenner/betrokkenbijm/betrokkenbij/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "betrokkenbij",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:kadastraleobjecten",
     "brk2:kadastraleobjecten_is_ontstaan_uit_brk_kadastraalobject"

--- a/datasets/dataverkenner/betrokkenbijm/dataset.json
+++ b/datasets/dataverkenner/betrokkenbijm/dataset.json
@@ -14,7 +14,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "betrokkenbij",

--- a/datasets/dataverkenner/betrokkenbijm/dataset.sql
+++ b/datasets/dataverkenner/betrokkenbijm/dataset.sql
@@ -1,5 +1,5 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_betrokkenbijm_betrokkenbij as
-SELECT 
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_betrokkenbijm_betrokkenbij_v1 as
+SELECT
     kot1.id,
     kot1.identificatie,
     kot1.volgnummer,

--- a/datasets/dataverkenner/bevatverblijfsobjecten/bevatverblijfsobjecten/v1.json
+++ b/datasets/dataverkenner/bevatverblijfsobjecten/bevatverblijfsobjecten/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bevatverblijfsobjecten",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "auth": "OPENBAAR",
   "derivedFrom": [
     "bag:verblijfsobjecten_ligt_in_panden"

--- a/datasets/dataverkenner/bevatverblijfsobjecten/dataset.json
+++ b/datasets/dataverkenner/bevatverblijfsobjecten/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bevatverblijfsobjecten",

--- a/datasets/dataverkenner/bevatverblijfsobjecten/dataset.sql
+++ b/datasets/dataverkenner/bevatverblijfsobjecten/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_bevatverblijfsobjecten_bevatverblijfsobjecten WITH (security_barrier) as
+create or replace view public.dataverkenner_bevatverblijfsobjecten_bevatverblijfsobjecten_v1 WITH (security_barrier) as
 select
 bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id as "id",
 bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id as "verblijfsobjecten_id",
@@ -11,9 +11,9 @@ bag_verblijfsobjecten_ligt_in_panden.begin_geldigheid as "begin_geldigheid",
 bag_verblijfsobjecten_ligt_in_panden.eind_geldigheid as "eind_geldigheid"
 from bag_verblijfsobjecten_ligt_in_panden
 left join bag_verblijfsobjecten vot
-on bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id = vot.id 
-left join bag_panden pnd 
-on bag_verblijfsobjecten_ligt_in_panden.ligt_in_panden_id = pnd.id 
-where bag_verblijfsobjecten_ligt_in_panden.eind_geldigheid is null 
+on bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id = vot.id
+left join bag_panden pnd
+on bag_verblijfsobjecten_ligt_in_panden.ligt_in_panden_id = pnd.id
+where bag_verblijfsobjecten_ligt_in_panden.eind_geldigheid is null
 and vot.status_omschrijving in ('Verblijfsobject gevormd','Verblijfsobject in gebruik (niet ingemeten)','Verblijfsobject in gebruik','Verblijfsobject buiten gebruik','Verbouwing verblijfsobject')
 and pnd.status_omschrijving in ('Bouwaanvraag ontvangen','Bouwvergunning verleend','Bouw gestart','Pand in gebruik (niet ingemeten)','Pand in gebruik','Sloopvergunning verleend','Pand buiten gebruik','Verbouwing pand');

--- a/datasets/dataverkenner/bevatverblijfsobjectenm/bevatverblijfsobjecten/v1.json
+++ b/datasets/dataverkenner/bevatverblijfsobjectenm/bevatverblijfsobjecten/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "bevatverblijfsobjecten",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "auth": "OPENBAAR",
   "derivedFrom": [
     "bag:verblijfsobjecten_ligt_in_panden"

--- a/datasets/dataverkenner/bevatverblijfsobjectenm/dataset.json
+++ b/datasets/dataverkenner/bevatverblijfsobjectenm/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "bevatverblijfsobjecten",

--- a/datasets/dataverkenner/bevatverblijfsobjectenm/dataset.sql
+++ b/datasets/dataverkenner/bevatverblijfsobjectenm/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bevatverblijfsobjectenm_bevatverblijfsobjecten as
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_bevatverblijfsobjectenm_bevatverblijfsobjecten_v1 as
 select
 bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id as "id",
 bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id as "verblijfsobjecten_id",
@@ -11,10 +11,10 @@ bag_verblijfsobjecten_ligt_in_panden.begin_geldigheid as "begin_geldigheid",
 bag_verblijfsobjecten_ligt_in_panden.eind_geldigheid as "eind_geldigheid"
 from bag_verblijfsobjecten_ligt_in_panden
 left join bag_verblijfsobjecten vot
-on bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id = vot.id 
-left join bag_panden pnd 
-on bag_verblijfsobjecten_ligt_in_panden.ligt_in_panden_id = pnd.id 
-where bag_verblijfsobjecten_ligt_in_panden.eind_geldigheid is null 
+on bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id = vot.id
+left join bag_panden pnd
+on bag_verblijfsobjecten_ligt_in_panden.ligt_in_panden_id = pnd.id
+where bag_verblijfsobjecten_ligt_in_panden.eind_geldigheid is null
 and vot.status_omschrijving in ('Verblijfsobject gevormd','Verblijfsobject in gebruik (niet ingemeten)','Verblijfsobject in gebruik','Verblijfsobject buiten gebruik','Verbouwing verblijfsobject')
 and pnd.status_omschrijving in ('Bouwaanvraag ontvangen','Bouwvergunning verleend','Bouw gestart','Pand in gebruik (niet ingemeten)','Pand in gebruik','Sloopvergunning verleend','Pand buiten gebruik','Verbouwing pand')
 with no data;

--- a/datasets/dataverkenner/isontstaanuit/dataset.json
+++ b/datasets/dataverkenner/isontstaanuit/dataset.json
@@ -14,7 +14,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "isontstaanuit",

--- a/datasets/dataverkenner/isontstaanuit/dataset.sql
+++ b/datasets/dataverkenner/isontstaanuit/dataset.sql
@@ -1,5 +1,5 @@
-create or replace view public.dataverkenner_isontstaanuit_isontstaanuit WITH (security_barrier) as
-SELECT 
+create or replace view public.dataverkenner_isontstaanuit_isontstaanuit_v1 WITH (security_barrier) as
+SELECT
 kot.id AS "id",
 kot.identificatie AS "identificatie",
 kot.neuron_id AS "neuron_id",
@@ -10,11 +10,11 @@ ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_id AS "is_ontstaan_uit_kadastr
 ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_volgnummer AS "is_ontstaan_uit_kadastraalobjecten_volgnummer",
 kot2.kadastrale_aanduiding AS "is_ontstaan_uit_kadastrale_aanduiding"
 FROM brk_2_kadastraleobjecten kot
-LEFT JOIN 
+LEFT JOIN
   (SELECT *
    FROM brk_2_kadastraleobjecten_is_ontstaan_uit_brk_kadastraalobject
    WHERE eind_geldigheid IS NULL) ontstaan_uit
-LEFT JOIN brk_2_kadastraleobjecten kot2 ON ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_id=kot2.id 
+LEFT JOIN brk_2_kadastraleobjecten kot2 ON ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_id=kot2.id
 ON  kot.id=ontstaan_uit.kadastraleobjecten_id
 WHERE kot.datum_actueel_tot IS NULL
 AND kot2.datum_actueel_tot IS NULL;

--- a/datasets/dataverkenner/isontstaanuit/isontstaanuit/v1.json
+++ b/datasets/dataverkenner/isontstaanuit/isontstaanuit/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "isontstaanuit",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:kadastraleobjecten",
     "brk2:kadastraleobjecten_is_ontstaan_uit_brk_kadastraalobject"

--- a/datasets/dataverkenner/isontstaanuitm/dataset.json
+++ b/datasets/dataverkenner/isontstaanuitm/dataset.json
@@ -14,7 +14,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "isontstaanuit",

--- a/datasets/dataverkenner/isontstaanuitm/dataset.sql
+++ b/datasets/dataverkenner/isontstaanuitm/dataset.sql
@@ -1,5 +1,5 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_isontstaanuitm_isontstaanuit AS
-SELECT 
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_isontstaanuitm_isontstaanuit_v1 AS
+SELECT
 kot.id AS "id",
 kot.identificatie AS "identificatie",
 kot.neuron_id AS "neuron_id",
@@ -10,11 +10,11 @@ ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_id AS "is_ontstaan_uit_kadastr
 ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_volgnummer AS "is_ontstaan_uit_kadastraalobjecten_volgnummer",
 kot2.kadastrale_aanduiding AS "is_ontstaan_uit_kadastrale_aanduiding"
 FROM brk_2_kadastraleobjecten kot
-LEFT JOIN 
+LEFT JOIN
   (SELECT *
    FROM brk_2_kadastraleobjecten_is_ontstaan_uit_brk_kadastraalobject
    WHERE eind_geldigheid IS NULL) ontstaan_uit
-LEFT JOIN brk_2_kadastraleobjecten kot2 ON ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_id=kot2.id 
+LEFT JOIN brk_2_kadastraleobjecten kot2 ON ontstaan_uit.is_ontstaan_uit_brk_kadastraalobject_id=kot2.id
 ON  kot.id=ontstaan_uit.kadastraleobjecten_id
 WHERE kot.datum_actueel_tot IS NULL
 AND kot2.datum_actueel_tot IS NULL

--- a/datasets/dataverkenner/isontstaanuitm/isontstaanuit/v1.json
+++ b/datasets/dataverkenner/isontstaanuitm/isontstaanuit/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "isontstaanuit",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:kadastraleobjecten",
     "brk2:kadastraleobjecten_is_ontstaan_uit_brk_kadastraalobject"

--- a/datasets/dataverkenner/kadastraleobject/dataset.json
+++ b/datasets/dataverkenner/kadastraleobject/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "kadastraleobject",

--- a/datasets/dataverkenner/kadastraleobject/dataset.sql
+++ b/datasets/dataverkenner/kadastraleobject/dataset.sql
@@ -1,5 +1,5 @@
-create or replace view public.dataverkenner_kadastraleobject_kadastraleobject WITH (security_barrier) as
-select 
+create or replace view public.dataverkenner_kadastraleobject_kadastraleobject_v1 WITH (security_barrier) as
+select
 brk_2_kadastraleobjecten.id as "id",
 brk_2_kadastraleobjecten.identificatie as "identificatie",
 brk_2_kadastraleobjecten.neuron_id as "neuron_id",

--- a/datasets/dataverkenner/kadastraleobject/kadastraleobject/v1.json
+++ b/datasets/dataverkenner/kadastraleobject/kadastraleobject/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "kadastraleobject",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "derivedFrom": [
     "brk2:kadastralegemeentes"

--- a/datasets/dataverkenner/kadastraleobjectm/dataset.json
+++ b/datasets/dataverkenner/kadastraleobjectm/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "kadastraleobject",

--- a/datasets/dataverkenner/kadastraleobjectm/dataset.sql
+++ b/datasets/dataverkenner/kadastraleobjectm/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_kadastraleobjectm_kadastraleobject as
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_kadastraleobjectm_kadastraleobject_v1 as
 WITH verblijfsobjecten as
      (
               select
@@ -6,11 +6,11 @@ WITH verblijfsobjecten as
                      , array_agg(hft_rel_mt_vot_identificatie) as vots
               from
                        brk_2_kadastraleobjecten_hft_rel_mt_vot
-              WHERE eind_geldigheid IS null        
+              WHERE eind_geldigheid IS null
               group by
                        kadastraleobjecten_id
      )
-select 
+select
 brk_2_kadastraleobjecten.id as "id",
 brk_2_kadastraleobjecten.identificatie as "identificatie",
 brk_2_kadastraleobjecten.neuron_id as "neuron_id",
@@ -27,7 +27,7 @@ brk_2_kadastraleobjecten.aangeduid_door_brk_gemeente_id as "aangeduid_door_brk_g
 brk_2_gemeentes.naam  as "aangeduid_door_brk_gemeente",
 brk_2_kadastraleobjecten.grootte as "grootte",
 brk_2_kadastraleobjecten.perceelnummer as "perceelnummer",
-brk_2_kadastraleobjecten.soort_cultuur_onbebouwd_omschrijving as "soort_cultuur_onbebouwd_omschrijving",																			 
+brk_2_kadastraleobjecten.soort_cultuur_onbebouwd_omschrijving as "soort_cultuur_onbebouwd_omschrijving",
 brk_2_kadastraleobjecten.soort_cultuur_bebouwd_omschrijving as "soort_cultuur_bebouwd_omschrijving",
 brk_2_kadastraleobjecten.koopsom as "koopsom",
 brk_2_kadastraleobjecten.koopjaar as "koopjaar",
@@ -37,10 +37,10 @@ brk_2_kadastraleobjecten.toestandsdatum as "toestandsdatum",
 brk_2_kadastraleobjecten.in_onderzoek as "in_onderzoek",
 brk_2_kadastraleobjecten.indicatie_voorlopige_kadastrale_grens as "indicatie_voorlopige_kadastrale_grens",
 verblijfsobjecten.vots::_VARCHAR as "heeft_een_relatie_met_bag_verblijfsobject_identificaties",
-brk_2_kadastraleobjecten.geometrie 
-from brk_2_kadastraleobjecten																																															
+brk_2_kadastraleobjecten.geometrie
+from brk_2_kadastraleobjecten
 LEFT JOIN verblijfsobjecten ON brk_2_kadastraleobjecten.id=verblijfsobjecten.kadastraleobjecten_id
-LEFT JOIN brk_2_gemeentes ON brk_2_kadastraleobjecten.aangeduid_door_brk_gemeente_id=brk_2_gemeentes.id 
-where brk_2_kadastraleobjecten.datum_actueel_tot is null																						 
+LEFT JOIN brk_2_gemeentes ON brk_2_kadastraleobjecten.aangeduid_door_brk_gemeente_id=brk_2_gemeentes.id
+where brk_2_kadastraleobjecten.datum_actueel_tot is null
 AND brk_2_gemeentes.eind_geldigheid IS NULL
 with no data;

--- a/datasets/dataverkenner/kadastraleobjectm/kadastraleobject/v1.json
+++ b/datasets/dataverkenner/kadastraleobjectm/kadastraleobject/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "kadastraleobject",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "derivedFrom": [
     "brk2:kadastralegemeentes"

--- a/datasets/dataverkenner/pandligtin/dataset.json
+++ b/datasets/dataverkenner/pandligtin/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "pandligtin",

--- a/datasets/dataverkenner/pandligtin/dataset.sql
+++ b/datasets/dataverkenner/pandligtin/dataset.sql
@@ -1,5 +1,5 @@
-create or replace view public.dataverkenner_pandligtin_pandligtin WITH (security_barrier) as
-select 
+create or replace view public.dataverkenner_pandligtin_pandligtin_v1 WITH (security_barrier) as
+select
 bag_panden.id as "id",
 bag_panden.identificatie as "identificatie",
 bag_panden.volgnummer as "volgnummer",
@@ -35,10 +35,10 @@ left join gebieden_wijken on gebieden_buurten.ligt_in_wijk_id = gebieden_wijken.
 left join gebieden_stadsdelen on gebieden_wijken.ligt_in_stadsdeel_id = gebieden_stadsdelen.id
 left join gebieden_ggwgebieden on gebieden_buurten.ligt_in_ggwgebied_id = gebieden_ggwgebieden.id
 left join gebieden_bouwblokken on bag_panden.ligt_in_bouwblok_id=gebieden_bouwblokken.id
-where gebieden_bouwblokken.eind_geldigheid is null 
-and gebieden_buurten.eind_geldigheid is null 
-and gebieden_wijken.eind_geldigheid is null 
+where gebieden_bouwblokken.eind_geldigheid is null
+and gebieden_buurten.eind_geldigheid is null
+and gebieden_wijken.eind_geldigheid is null
 and gebieden_ggwgebieden.eind_geldigheid is null
-and gebieden_stadsdelen.eind_geldigheid is null 
+and gebieden_stadsdelen.eind_geldigheid is null
 and bag_panden.eind_geldigheid is null
 and bag_panden.status_omschrijving in ('Bouwaanvraag ontvangen','Bouwvergunning verleend','Bouw gestart','Pand in gebruik (niet ingemeten)','Pand in gebruik','Sloopvergunning verleend','Pand buiten gebruik','Verbouwing pand');

--- a/datasets/dataverkenner/pandligtin/pandligtin/v1.json
+++ b/datasets/dataverkenner/pandligtin/pandligtin/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "pandligtin",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/pandligtinm/dataset.json
+++ b/datasets/dataverkenner/pandligtinm/dataset.json
@@ -15,7 +15,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "pandligtin",

--- a/datasets/dataverkenner/pandligtinm/dataset.sql
+++ b/datasets/dataverkenner/pandligtinm/dataset.sql
@@ -1,5 +1,5 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_pandligtinm_pandligtin as
-select 
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_pandligtinm_pandligtin_v1 as
+select
 bag_panden.id as "id",
 bag_panden.identificatie as "identificatie",
 bag_panden.volgnummer as "volgnummer",
@@ -35,10 +35,10 @@ left join gebieden_wijken on gebieden_buurten.ligt_in_wijk_id = gebieden_wijken.
 left join gebieden_stadsdelen on gebieden_wijken.ligt_in_stadsdeel_id = gebieden_stadsdelen.id
 left join gebieden_ggwgebieden on gebieden_buurten.ligt_in_ggwgebied_id = gebieden_ggwgebieden.id
 left join gebieden_bouwblokken on bag_panden.ligt_in_bouwblok_id=gebieden_bouwblokken.id
-where gebieden_bouwblokken.eind_geldigheid is null 
-and gebieden_buurten.eind_geldigheid is null 
-and gebieden_wijken.eind_geldigheid is null 
+where gebieden_bouwblokken.eind_geldigheid is null
+and gebieden_buurten.eind_geldigheid is null
+and gebieden_wijken.eind_geldigheid is null
 and gebieden_ggwgebieden.eind_geldigheid is null
-and gebieden_stadsdelen.eind_geldigheid is null 
+and gebieden_stadsdelen.eind_geldigheid is null
 and bag_panden.eind_geldigheid is null
 and bag_panden.status_omschrijving in ('Bouwaanvraag ontvangen','Bouwvergunning verleend','Bouw gestart','Pand in gebruik (niet ingemeten)','Pand in gebruik','Sloopvergunning verleend','Pand buiten gebruik','Verbouwing pand') with no data;

--- a/datasets/dataverkenner/pandligtinm/pandligtin/v1.json
+++ b/datasets/dataverkenner/pandligtinm/pandligtin/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "pandligtin",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "crs": "EPSG:28992",
   "auth": "OPENBAAR",
   "derivedFrom": [

--- a/datasets/dataverkenner/tenaamstellingen/dataset.json
+++ b/datasets/dataverkenner/tenaamstellingen/dataset.json
@@ -21,7 +21,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "tenaamstellingen",

--- a/datasets/dataverkenner/tenaamstellingen/dataset.sql
+++ b/datasets/dataverkenner/tenaamstellingen/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_tenaamstellingen_tenaamstellingen WITH (security_barrier) as
+create or replace view public.dataverkenner_tenaamstellingen_tenaamstellingen_v1 WITH (security_barrier) as
 select
 brk_2_tenaamstellingen.id as "id",
 brk_2_tenaamstellingen.identificatie as "identificatie",
@@ -17,5 +17,5 @@ brk_2_kadastralesubjecten.statutaire_naam as "kadastralesubjecten_statutaire_naa
 brk_2_kadastralesubjecten.type_subject as "kadastralesubjecten_type_subject"
 from brk_2_tenaamstellingen
 left join brk_2_kadastralesubjecten on brk_2_tenaamstellingen.van_brk_kadastraalsubject_id = brk_2_kadastralesubjecten.identificatie
-WHERE (brk_2_tenaamstellingen.datum_actueel_tot IS NULL or brk_2_tenaamstellingen.eind_geldigheid> now()) 
+WHERE (brk_2_tenaamstellingen.datum_actueel_tot IS NULL or brk_2_tenaamstellingen.eind_geldigheid> now())
 AND (brk_2_kadastralesubjecten.datum_actueel_tot IS NULL OR brk_2_kadastralesubjecten.datum_actueel_tot> now());

--- a/datasets/dataverkenner/tenaamstellingen/tenaamstellingen/v1.json
+++ b/datasets/dataverkenner/tenaamstellingen/tenaamstellingen/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "tenaamstellingen",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:tenaamstellingen",
     "brk2:kadastralesubjecten"

--- a/datasets/dataverkenner/tenaamstellingenm/dataset.json
+++ b/datasets/dataverkenner/tenaamstellingenm/dataset.json
@@ -18,7 +18,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "tenaamstellingen",

--- a/datasets/dataverkenner/tenaamstellingenm/dataset.sql
+++ b/datasets/dataverkenner/tenaamstellingenm/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_tenaamstellingenm_tenaamstellingen as
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_tenaamstellingenm_tenaamstellingen_v1 as
 select
 brk_2_tenaamstellingen.id as "id",
 brk_2_tenaamstellingen.identificatie as "identificatie",
@@ -17,6 +17,6 @@ brk_2_kadastralesubjecten.statutaire_naam as "kadastralesubjecten_statutaire_naa
 brk_2_kadastralesubjecten.type_subject as "kadastralesubjecten_type_subject"
 from brk_2_tenaamstellingen
 left join brk_2_kadastralesubjecten on brk_2_tenaamstellingen.van_brk_kadastraalsubject_id = brk_2_kadastralesubjecten.identificatie
-WHERE (brk_2_tenaamstellingen.datum_actueel_tot IS NULL or brk_2_tenaamstellingen.eind_geldigheid> now()) 
+WHERE (brk_2_tenaamstellingen.datum_actueel_tot IS NULL or brk_2_tenaamstellingen.eind_geldigheid> now())
 AND (brk_2_kadastralesubjecten.datum_actueel_tot IS NULL OR brk_2_kadastralesubjecten.datum_actueel_tot> now())
 with no data;

--- a/datasets/dataverkenner/tenaamstellingenm/tenaamstellingen/v1.json
+++ b/datasets/dataverkenner/tenaamstellingenm/tenaamstellingen/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "tenaamstellingen",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:tenaamstellingen",
     "brk2:kadastralesubjecten"

--- a/datasets/dataverkenner/zakelijkerechten/dataset.json
+++ b/datasets/dataverkenner/zakelijkerechten/dataset.json
@@ -18,7 +18,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "zakelijkerechten",

--- a/datasets/dataverkenner/zakelijkerechten/dataset.sql
+++ b/datasets/dataverkenner/zakelijkerechten/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.dataverkenner_zakelijkerechten_zakelijkerechten WITH (security_barrier) as
+create or replace view public.dataverkenner_zakelijkerechten_zakelijkerechten_v1 WITH (security_barrier) as
 SELECT
     brk_2_zakelijkerechten.id AS "id",
     brk_2_zakelijkerechten.identificatie AS "identificatie",
@@ -10,6 +10,6 @@ SELECT
     brk_2_zakelijkerechten.vve_identificatie_betrokken_bij_id AS "vve_identificatie_betrokken_bij_id",
     brk_2_zakelijkerechten.begin_geldigheid AS "begin_geldigheid",
     brk_2_zakelijkerechten.eind_geldigheid AS "eind_geldigheid"
-FROM 
+FROM
     brk_2_zakelijkerechten
     WHERE (brk_2_zakelijkerechten.datum_actueel_tot IS NULL OR brk_2_zakelijkerechten.datum_actueel_tot > now())

--- a/datasets/dataverkenner/zakelijkerechten/zakelijkerechten/v1.json
+++ b/datasets/dataverkenner/zakelijkerechten/zakelijkerechten/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "zakelijkerechten",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:zakelijkerechten"
   ],

--- a/datasets/dataverkenner/zakelijkerechtenm/dataset.json
+++ b/datasets/dataverkenner/zakelijkerechtenm/dataset.json
@@ -18,7 +18,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "zakelijkerechten",

--- a/datasets/dataverkenner/zakelijkerechtenm/dataset.sql
+++ b/datasets/dataverkenner/zakelijkerechtenm/dataset.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_zakelijkerechtenm_zakelijkerechten as
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.dataverkenner_zakelijkerechtenm_zakelijkerechten_v1 as
 SELECT
     brk_2_zakelijkerechten.id AS "id",
     brk_2_zakelijkerechten.identificatie AS "identificatie",
@@ -10,7 +10,7 @@ SELECT
     brk_2_zakelijkerechten.vve_identificatie_betrokken_bij_id AS "vve_identificatie_betrokken_bij_id",
     brk_2_zakelijkerechten.begin_geldigheid AS "begin_geldigheid",
     brk_2_zakelijkerechten.eind_geldigheid AS "eind_geldigheid"
-FROM 
+FROM
     brk_2_zakelijkerechten
     WHERE (brk_2_zakelijkerechten.datum_actueel_tot IS NULL OR brk_2_zakelijkerechten.datum_actueel_tot > now())
 with no data;

--- a/datasets/dataverkenner/zakelijkerechtenm/zakelijkerechten/v1.json
+++ b/datasets/dataverkenner/zakelijkerechtenm/zakelijkerechten/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "zakelijkerechten",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "brk2:zakelijkerechten"
   ],

--- a/datasets/verkenner/adresinformatie/adresinformatie/v1.json
+++ b/datasets/verkenner/adresinformatie/adresinformatie/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "adresinformatie",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "bag:nummeraanduidingen",
     "bag:openbareruimtes",

--- a/datasets/verkenner/adresinformatie/dataset.json
+++ b/datasets/verkenner/adresinformatie/dataset.json
@@ -14,7 +14,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "adresinformatie",

--- a/datasets/verkenner/adresinformatie/dataset.sql
+++ b/datasets/verkenner/adresinformatie/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.verkenner_adresinformatie_adresinformatie WITH (security_barrier) as
+create or replace view public.verkenner_adresinformatie_adresinformatie_v1 WITH (security_barrier) as
 select
 bag_nummeraanduidingen.id as "id",
 bag_nummeraanduidingen.identificatie as "identificatie",
@@ -209,14 +209,14 @@ gebieden_bouwblokken.eind_geldigheid as "gebieden_bouwblok_eind_geldigheid",
 gebieden_bouwblokken.geometrie as "gebieden_bouwblok_geometrie"
 from bag_nummeraanduidingen
 left join bag_openbareruimtes on bag_nummeraanduidingen.ligt_aan_openbareruimte_id = bag_openbareruimtes.id
-left join bag_woonplaatsen on bag_nummeraanduidingen.ligt_in_woonplaats_id = bag_woonplaatsen.id 
+left join bag_woonplaatsen on bag_nummeraanduidingen.ligt_in_woonplaats_id = bag_woonplaatsen.id
 left join bag_verblijfsobjecten on bag_nummeraanduidingen.adresseert_verblijfsobject_id=bag_verblijfsobjecten.id
-left join bag_ligplaatsen on bag_nummeraanduidingen.adresseert_ligplaats_id = bag_ligplaatsen.id 
-left join bag_standplaatsen on bag_nummeraanduidingen.adresseert_standplaats_identificatie = bag_standplaatsen.identificatie 
+left join bag_ligplaatsen on bag_nummeraanduidingen.adresseert_ligplaats_id = bag_ligplaatsen.id
+left join bag_standplaatsen on bag_nummeraanduidingen.adresseert_standplaats_identificatie = bag_standplaatsen.identificatie
 left join gebieden_buurten on bag_verblijfsobjecten.ligt_in_buurt_id=gebieden_buurten.id
 left join gebieden_wijken on gebieden_buurten.ligt_in_wijk_id = gebieden_wijken.id
 left join gebieden_stadsdelen on gebieden_wijken.ligt_in_stadsdeel_id = gebieden_stadsdelen.id
-left join gebieden_ggwgebieden on gebieden_stadsdelen.id = gebieden_ggwgebieden.id 
-left join bag_verblijfsobjecten_ligt_in_panden on bag_verblijfsobjecten.id = bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id 
+left join gebieden_ggwgebieden on gebieden_stadsdelen.id = gebieden_ggwgebieden.id
+left join bag_verblijfsobjecten_ligt_in_panden on bag_verblijfsobjecten.id = bag_verblijfsobjecten_ligt_in_panden.verblijfsobjecten_id
 left join bag_panden on bag_panden.id = bag_verblijfsobjecten_ligt_in_panden.ligt_in_panden_id
 left join gebieden_bouwblokken on bag_panden.ligt_in_bouwblok_id=gebieden_bouwblokken.id;

--- a/datasets/verkenner/verblijfsobjecten/dataset.json
+++ b/datasets/verkenner/verblijfsobjecten/dataset.json
@@ -13,7 +13,7 @@
     "v1": {
       "status": "beschikbaar",
       "lifecycleStatus": "stable",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "tables": [
         {
           "id": "verblijfsobjecten",

--- a/datasets/verkenner/verblijfsobjecten/dataset.sql
+++ b/datasets/verkenner/verblijfsobjecten/dataset.sql
@@ -1,4 +1,4 @@
-create or replace view public.verkenner_verblijfsobjecten_verblijfsobjecten WITH (security_barrier) as
+create or replace view public.verkenner_verblijfsobjecten_verblijfsobjecten_v1 WITH (security_barrier) as
 select
 bag_verblijfsobjecten.identificatie as "identificatie",
 bag_verblijfsobjecten.id as "id",

--- a/datasets/verkenner/verblijfsobjecten/verblijfsobjecten/v1.json
+++ b/datasets/verkenner/verblijfsobjecten/verblijfsobjecten/v1.json
@@ -1,7 +1,7 @@
 {
   "type": "table",
   "id": "verblijfsobjecten",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "derivedFrom": [
     "bag:verblijfsobjecten",
     "bag:panden"


### PR DESCRIPTION
Creating the views resulted in querying _v0 versions of the views, as the schema defined the tables with version 0.0.1. 

The version in the dataset and table schemas now matches the _v1 suffix in the sql creating the views and materialized views.

Done for both /dataverkenner/ and /verkenner/ folders.
