### PR TITLE
Individuele export velden

### DIFF
--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -95,7 +95,7 @@
         },
         {
           "name": "velden",
-          "tables": ["velden",
+          "tables": ["velden"],
           "filetypes": [
             "csv",
             "geojson"

--- a/datasets/sport/dataset.json
+++ b/datasets/sport/dataset.json
@@ -92,6 +92,17 @@
           "scopes": [
             "openbaar"
           ]
+        },
+        {
+          "name": "velden",
+          "tables": ["velden",
+          "filetypes": [
+            "csv",
+            "geojson"
+          ],
+          "scopes": [
+            "openbaar"
+          ]
         }
       ],
       "tables": [


### PR DESCRIPTION
Een individuele export voor sportvelden omdat applicaties waaronder PowerBI geen zip-bestand met meerdere files kunnen uitlezen.