### PR TITLE
Alle changes CLVGJZ en SMIKO samenkomen met eerdere gedeeltelijke changes (#1739)

### DIFF
--- a/datasets/controlelijsten_geld_zorg/dataset.json
+++ b/datasets/controlelijsten_geld_zorg/dataset.json
@@ -2,7 +2,7 @@
     "id": "controlelijstenGeldZorg",
     "type": "dataset",
     "title": "Controlelijsten Verstrekte Gelden Jeugdhulp en Zorgvoorzieningen",
-    "description": "",
+    "description": "Controlelijsten met details over beschikkingen, factuurregels, leveringen, verplichtingen en clientnummers om de rechtmatigheid van betalingen (steekproefsgewijs) te toetsen binnen de voorzieningen van de Jeugdwet en de Wet maatschappelijke ondersteuning (Wmo) [p26001].",
     "publisher": {
         "$ref": "publishers/DTJZ"
     },

--- a/datasets/controlelijsten_geld_zorg/fBeschikteVzAio/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fBeschikteVzAio/v0.json
@@ -2,6 +2,7 @@
     "id": "fBeschikteVzAio",
     "title": "F beschiktevoorziening aio",
     "description": "Beschrijving voor f_beschiktevoorziening_aio",
+    "shortname": "BvzAIO",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -20,7 +21,7 @@
             "beschiktevoorzieningId",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "beschiktevoorzieningId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fBeschikteVzBvbt/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fBeschikteVzBvbt/v0.json
@@ -2,6 +2,7 @@
     "id": "fBeschikteVzBvbt",
     "title": "F beschiktevoorziening bvbt",
     "description": "Beschrijving voor f_beschiktevoorziening_bvbt",
+    "shortname": "BvzBVBT",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -20,7 +21,7 @@
             "beschiktevoorzieningId",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "beschiktevoorzieningId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fBeschikteVzDagbesteding/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fBeschikteVzDagbesteding/v0.json
@@ -2,6 +2,7 @@
     "id": "fBeschikteVzDagbesteding",
     "title": "F beschiktevoorziening dagbesteding",
     "description": "Beschrijving voor f_beschiktevoorziening_dagbesteding",
+    "shortname": "BvzDagbs",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -20,7 +21,7 @@
             "beschiktevoorzieningId",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "beschiktevoorzieningId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fBeschikteVzEsjh/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fBeschikteVzEsjh/v0.json
@@ -2,6 +2,7 @@
     "id": "fBeschikteVzEsjh",
     "title": "F beschiktevoorziening esjh",
     "description": "Beschrijving voor f_beschiktevoorziening_esjh",
+    "shortname": "BvzESJH",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -20,7 +21,7 @@
             "beschiktevoorzieningId",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "beschiktevoorzieningId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fBeschikteVzHsjh/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fBeschikteVzHsjh/v0.json
@@ -2,6 +2,7 @@
     "id": "fBeschikteVzHsjh",
     "title": "F beschiktevoorziening hsjh",
     "description": "Beschrijving voor f_beschiktevoorziening_hsjh",
+    "shortname": "BvzHSJH",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -20,7 +21,7 @@
             "beschiktevoorzieningId",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "beschiktevoorzieningId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fBeschikteVzVroegsteIngang/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fBeschikteVzVroegsteIngang/v0.json
@@ -2,6 +2,7 @@
     "id": "fBeschikteVzVroegsteIngang",
     "title": "F beschiktevoorziening vroegsteingangsdatum",
     "description": "Beschrijving voor f_beschiktevoorziening_vroegsteingangsdatum",
+    "shortname": "BvzVrgstIngang",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -22,7 +23,7 @@
             "voorziening",
             "leveringsvorm"
         ],
-        "display": "regeling",
+        "display": "clientZorgnedId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fFactuurregelWrv/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fFactuurregelWrv/v0.json
@@ -2,6 +2,7 @@
     "id": "fFactuurregelWrv",
     "title": "F factuurregel wrv",
     "description": "Beschrijving voor f_factuurregel_wrv",
+    "shortname": "FrWRV",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -22,7 +23,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "factuurId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fFactuurregelZinjeugd/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fFactuurregelZinjeugd/v0.json
@@ -2,6 +2,7 @@
     "id": "fFactuurregelZinjeugd",
     "title": "F factuurregel zinjeugd",
     "description": "Beschrijving voor f_factuurregel_zinjeugd",
+    "shortname": "FrZinJ",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -22,7 +23,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "factuurId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fFactuurregelZinwijkmobw/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fFactuurregelZinwijkmobw/v0.json
@@ -2,6 +2,7 @@
     "id": "fFactuurregelZinwijkmobw",
     "title": "F factuurregel zinwijkmobw",
     "description": "Beschrijving voor f_factuurregel_zinwijkmobw",
+    "shortname": "FrZinMOBW",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -22,7 +23,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "factuurId",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fLeveringAio/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fLeveringAio/v0.json
@@ -2,6 +2,7 @@
     "id": "fLeveringAio",
     "title": "F levering aio",
     "description": "Beschrijving voor f_levering_aio",
+    "shortname": "LvAIO",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -24,7 +25,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "toewijzingsnummerLevering",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fLeveringBvbt/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fLeveringBvbt/v0.json
@@ -2,6 +2,7 @@
     "id": "fLeveringBvbt",
     "title": "F levering bvbt",
     "description": "Beschrijving voor f_levering_bvbt",
+    "shortname": "LvBVBT",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -24,7 +25,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "toewijzingsnummerLevering",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fLeveringDagbesteding/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fLeveringDagbesteding/v0.json
@@ -2,6 +2,7 @@
     "id": "fLeveringDagbesteding",
     "title": "F levering dagbesteding",
     "description": "Beschrijving voor f_levering_dagbesteding",
+    "shortname": "LvDagbs",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -23,7 +24,7 @@
             "voorzieningsoort",
             "voorziening"
         ],
-        "display": "clientZorgnedId",
+        "display": "toewijzingsnummerLevering",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fLeveringEsjh/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fLeveringEsjh/v0.json
@@ -2,6 +2,7 @@
     "id": "fLeveringEsjh",
     "title": "F levering esjh",
     "description": "Beschrijving voor f_levering_esjh",
+    "shortname": "LvESJH",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -24,7 +25,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "toewijzingsnummerLevering",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fLeveringHsjh/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fLeveringHsjh/v0.json
@@ -2,6 +2,7 @@
     "id": "fLeveringHsjh",
     "title": "F levering hsjh",
     "description": "Beschrijving voor f_levering_hsjh",
+    "shortname": "LvHSJH",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -24,7 +25,7 @@
             "voorziening",
             "zorgaanbieder"
         ],
-        "display": "clientZorgnedId",
+        "display": "toewijzingsnummerLevering",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/controlelijsten_geld_zorg/fVpBdgjrPgbjeugd/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fVpBdgjrPgbjeugd/v0.json
@@ -2,6 +2,7 @@
     "id": "fVpBdgjrPgbjeugd",
     "title": "F verplichting budgetjaar pgbjeugd",
     "description": "Beschrijving voor f_verplichting_budgetjaar_pgbjeugd",
+    "shortname": "VpBdgjrPGBj",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -11,8 +12,6 @@
         "additionalProperties": false,
         "identifier": [
             "clientZorgnedId",
-            "productcategorie",
-            "voorzieningsoort",
             "voorziening",
             "zorgaanbieder"
         ],

--- a/datasets/controlelijsten_geld_zorg/fVpBdgjrPgbwijkzorgmobw/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fVpBdgjrPgbwijkzorgmobw/v0.json
@@ -2,6 +2,7 @@
     "id": "fVpBdgjrPgbwijkzorgmobw",
     "title": "F verplichting budgetjaar pgbwijkzorgmobw",
     "description": "Beschrijving voor f_verplichting_budgetjaar_pgbwijkzorgmobw",
+    "shortname": "VpBdgjrPGBwzMOBW",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -11,8 +12,6 @@
         "additionalProperties": false,
         "identifier": [
             "clientZorgnedId",
-            "productcategorie",
-            "voorzieningsoort",
             "voorziening",
             "zorgaanbieder"
         ],

--- a/datasets/controlelijsten_geld_zorg/fVpBdgjrWra/v0.json
+++ b/datasets/controlelijsten_geld_zorg/fVpBdgjrWra/v0.json
@@ -2,6 +2,7 @@
     "id": "fVpBdgjrWra",
     "title": "F verplichting budgetjaar wra",
     "description": "Beschrijving voor f_verplichting_budgetjaar_wra",
+    "shortname": "VpBdgjrWRA",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -11,8 +12,6 @@
         "additionalProperties": false,
         "identifier": [
             "clientZorgnedId",
-            "productcategorie",
-            "voorzieningsoort",
             "voorziening",
             "zorgaanbieder"
         ],

--- a/datasets/controlelijsten_geld_zorg/mtaBusinessDefinities/v0.json
+++ b/datasets/controlelijsten_geld_zorg/mtaBusinessDefinities/v0.json
@@ -2,6 +2,7 @@
     "id": "mtaBusinessDefinities",
     "title": "Mta business definities",
     "description": "Beschrijving voor mta_business_definities",
+    "shortname": "mtaBusDefs",
     "type": "table",
     "version": "0.0.2",
     "status": "under_development",
@@ -10,13 +11,15 @@
         "type": "object",
         "additionalProperties": false,
         "identifier": [
-            "mtaIdBusinessDefinities"
+            "mtaIdBusinessDefinities",
+            "businessnaam"
         ],
         "required": [
             "schema",
-            "mtaIdBusinessDefinities"
+            "mtaIdBusinessDefinities",
+            "businessnaam"
         ],
-        "display": "mtaIdBusinessDefinities",
+        "display": "businessnaam",
         "properties": {
             "schema": {
                 "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dataset.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dataset.json
@@ -1,0 +1,135 @@
+{
+    "id": "sociaalmedischeIndicatieKinderopvang",
+    "type": "dataset",
+    "title": "Sociaal-Medische Indicatie Kinderopvang",
+    "description": "Gegevens uit ZorgNed over het Sociaal Medische Indicatie Kinderopvang (SMI) proces van de Gemeente Amsterdam [p26002].",
+    "publisher": {
+        "$ref": "publishers/DTJZ"
+    },
+    "creator": "Datateam Jeugd en Zorg",
+    "auth": "DTJZ/SMIKO",
+    "reasonsNonPublic": [
+        "5.1 1d: Bevat persoonsgegevens"
+    ],
+    "authorizationGrantor": "Datateam Jeugd en Zorg",
+    "owner": "Gemeente Amsterdam",
+    "defaultVersion": "v0",
+    "versions": {
+        "v0": {
+            "status": "under_development",
+            "enableAPI": false,
+            "enableGeosearch": false,
+            "version": "0.0.1",
+            "tables": [
+                {
+                    "id": "dimafsluitreden",
+                    "$ref": "dimafsluitreden/v0"
+                },
+                {
+                    "id": "dimbasismodel",
+                    "$ref": "dimbasismodel/v0"
+                },
+                {
+                    "id": "dimdatum",
+                    "$ref": "dimdatum/v0"
+                },
+                {
+                    "id": "dimdeskundigheid",
+                    "$ref": "dimdeskundigheid/v0"
+                },
+                {
+                    "id": "dimdoorloopmethodiek",
+                    "$ref": "dimdoorloopmethodiek/v0"
+                },
+                {
+                    "id": "dimdoorlooptijd",
+                    "$ref": "dimdoorlooptijd/v0"
+                },
+                {
+                    "id": "dimgemeente",
+                    "$ref": "dimgemeente/v0"
+                },
+                {
+                    "id": "dimjaar",
+                    "$ref": "dimjaar/v0"
+                },
+                {
+                    "id": "dimjanee",
+                    "$ref": "dimjanee/v0"
+                },
+                {
+                    "id": "dimleeftijd",
+                    "$ref": "dimleeftijd/v0"
+                },
+                {
+                    "id": "dimleverancier",
+                    "$ref": "dimleverancier/v0"
+                },
+                {
+                    "id": "dimonderzoekwijze",
+                    "$ref": "dimonderzoekwijze/v0"
+                },
+                {
+                    "id": "dimpostcode",
+                    "$ref": "dimpostcode/v0"
+                },
+                {
+                    "id": "dimproces",
+                    "$ref": "dimproces/v0"
+                },
+                {
+                    "id": "dimprocessoort",
+                    "$ref": "dimprocessoort/v0"
+                },
+                {
+                    "id": "dimprocesstatus",
+                    "$ref": "dimprocesstatus/v0"
+                },
+                {
+                    "id": "dimregeling",
+                    "$ref": "dimregeling/v0"
+                },
+                {
+                    "id": "dimvoorziening",
+                    "$ref": "dimvoorziening/v0"
+                },
+                {
+                    "id": "dimvoorzieningstatus",
+                    "$ref": "dimvoorzieningstatus/v0"
+                },
+                {
+                    "id": "dimwijk",
+                    "$ref": "dimwijk/v0"
+                },
+                {
+                    "id": "feitbeschiktbedragperiodiek",
+                    "$ref": "feitbeschiktbedragperiodiek/v0"
+                },
+                {
+                    "id": "feitbeschiktevoorziening",
+                    "$ref": "feitbeschiktevoorziening/v0"
+                },
+                {
+                    "id": "feitclient",
+                    "$ref": "feitclient/v0"
+                },
+                {
+                    "id": "feitgeregistreerdevoorziening",
+                    "$ref": "feitgeregistreerdevoorziening/v0"
+                },
+                {
+                    "id": "feitleveringbedragperiodiek",
+                    "$ref": "feitleveringbedragperiodiek/v0"
+                },
+                {
+                    "id": "feitnegbeschiktevoorziening",
+                    "$ref": "feitnegbeschiktevoorziening/v0"
+                },
+                {
+                    "id": "feitproces",
+                    "$ref": "feitproces/v0"
+                }
+            ]
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimafsluitreden/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimafsluitreden/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimafsluitreden",
+    "title": "Dimafsluitreden",
+    "description": "Beschrijving voor dimafsluitreden",
+    "shortname": "dimAfsluitrdn",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimbasismodel/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimbasismodel/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimbasismodel",
+    "title": "Dimbasismodel",
+    "description": "Beschrijving voor dimbasismodel",
+    "shortname": "dimBsmdl",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimdatum/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimdatum/v0.json
@@ -1,0 +1,239 @@
+{
+    "id": "dimdatum",
+    "title": "Dimdatum",
+    "description": "Beschrijving voor dimdatum",
+    "shortname": "dimDtm",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [                        
+            "jaar",
+            "maand",
+            "dag"
+        ],
+        "required": [
+            "schema",
+            "datumgetal",
+            "datum",
+            "jaar",
+            "jaaromschr",
+            "maand",
+            "dag",
+            "dagomschr",
+            "dagvandeweek",
+            "dagvandeweekomschr",
+            "dagvandeweekomschrkort",
+            "iswerkdag",
+            "decennium",
+            "decenniumomschr",
+            "iseerstedagvandecennium",
+            "islaatstedagvandecennium",
+            "iseerstedagvanjaar",
+            "islaatstedagvanjaar",
+            "kwartaal",
+            "kwartaalomsch",
+            "iseerstedagvankwartaal",
+            "islaatstedagvankwartaal",
+            "maandomschr",
+            "maandomschrkort",
+            "islaatstedagvanmaand",
+            "iseerstedagvanmaand",
+            "week",
+            "weekomschr",
+            "iseerstedagvanweek",
+            "islaatstedagvanweek",
+            "cakjaar",
+            "cakjaaromschr",
+            "cakperiode",
+            "cakperiodeomschr",
+            "weekjaar"
+        ],
+        "display": "datum",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "datumgetal": {
+                "type": "number",
+                "title": "Datumgetal",
+                "description": "Beschrijving voor DATUMGETAL"
+            },
+            "datum": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Datum",
+                "description": "Beschrijving voor DATUM"
+            },
+            "jaar": {
+                "type": "string",
+                "title": "Jaar",
+                "description": "Beschrijving voor JAAR"
+            },
+            "jaaromschr": {
+                "type": "string",
+                "title": "Jaaromschr",
+                "description": "Beschrijving voor JAAROMSCHR"
+            },
+            "maand": {
+                "type": "string",
+                "title": "Maand",
+                "description": "Beschrijving voor MAAND"
+            },
+            "dag": {
+                "type": "string",
+                "title": "Dag",
+                "description": "Beschrijving voor DAG"
+            },
+            "dagomschr": {
+                "type": "string",
+                "title": "Dagomschr",
+                "description": "Beschrijving voor DAGOMSCHR"
+            },
+            "dagvandeweek": {
+                "type": "number",
+                "title": "Dagvandeweek",
+                "description": "Beschrijving voor DAGVANDEWEEK"
+            },
+            "dagvandeweekomschr": {
+                "type": "string",
+                "title": "Dagvandeweekomschr",
+                "description": "Beschrijving voor DAGVANDEWEEKOMSCHR"
+            },
+            "dagvandeweekomschrkort": {
+                "type": "string",
+                "title": "Dagvandeweekomschrkort",
+                "description": "Beschrijving voor DAGVANDEWEEKOMSCHRKORT"
+            },
+            "iswerkdag": {
+                "type": "number",
+                "title": "Iswerkdag",
+                "description": "Beschrijving voor ISWERKDAG"
+            },
+            "decennium": {
+                "type": "number",
+                "title": "Decennium",
+                "description": "Beschrijving voor DECENNIUM"
+            },
+            "decenniumomschr": {
+                "type": "string",
+                "title": "Decenniumomschr",
+                "description": "Beschrijving voor DECENNIUMOMSCHR"
+            },
+            "iseerstedagvandecennium": {
+                "type": "number",
+                "title": "Iseerstedagvandecennium",
+                "description": "Beschrijving voor ISEERSTEDAGVANDECENNIUM"
+            },
+            "islaatstedagvandecennium": {
+                "type": "number",
+                "title": "Islaatstedagvandecennium",
+                "description": "Beschrijving voor ISLAATSTEDAGVANDECENNIUM"
+            },
+            "iseerstedagvanjaar": {
+                "type": "number",
+                "title": "Iseerstedagvanjaar",
+                "description": "Beschrijving voor ISEERSTEDAGVANJAAR"
+            },
+            "islaatstedagvanjaar": {
+                "type": "number",
+                "title": "Islaatstedagvanjaar",
+                "description": "Beschrijving voor ISLAATSTEDAGVANJAAR"
+            },
+            "kwartaal": {
+                "type": "number",
+                "title": "Kwartaal",
+                "description": "Beschrijving voor KWARTAAL"
+            },
+            "kwartaalomsch": {
+                "type": "string",
+                "title": "Kwartaalomsch",
+                "description": "Beschrijving voor KWARTAALOMSCH"
+            },
+            "iseerstedagvankwartaal": {
+                "type": "number",
+                "title": "Iseerstedagvankwartaal",
+                "description": "Beschrijving voor ISEERSTEDAGVANKWARTAAL"
+            },
+            "islaatstedagvankwartaal": {
+                "type": "number",
+                "title": "Islaatstedagvankwartaal",
+                "description": "Beschrijving voor ISLAATSTEDAGVANKWARTAAL"
+            },
+            "maandomschr": {
+                "type": "string",
+                "title": "Maandomschr",
+                "description": "Beschrijving voor MAANDOMSCHR"
+            },
+            "maandomschrkort": {
+                "type": "string",
+                "title": "Maandomschrkort",
+                "description": "Beschrijving voor MAANDOMSCHRKORT"
+            },
+            "islaatstedagvanmaand": {
+                "type": "number",
+                "title": "Islaatstedagvanmaand",
+                "description": "Beschrijving voor ISLAATSTEDAGVANMAAND"
+            },
+            "iseerstedagvanmaand": {
+                "type": "number",
+                "title": "Iseerstedagvanmaand",
+                "description": "Beschrijving voor ISEERSTEDAGVANMAAND"
+            },
+            "week": {
+                "type": "number",
+                "title": "Week",
+                "description": "Beschrijving voor WEEK"
+            },
+            "weekomschr": {
+                "type": "string",
+                "title": "Weekomschr",
+                "description": "Beschrijving voor WEEKOMSCHR"
+            },
+            "iseerstedagvanweek": {
+                "type": "number",
+                "title": "Iseerstedagvanweek",
+                "description": "Beschrijving voor ISEERSTEDAGVANWEEK"
+            },
+            "islaatstedagvanweek": {
+                "type": "number",
+                "title": "Islaatstedagvanweek",
+                "description": "Beschrijving voor ISLAATSTEDAGVANWEEK"
+            },
+            "cakjaar": {
+                "type": "number",
+                "title": "Cakjaar",
+                "description": "Beschrijving voor CAKJAAR"
+            },
+            "cakjaaromschr": {
+                "type": "string",
+                "title": "Cakjaaromschr",
+                "description": "Beschrijving voor CAKJAAROMSCHR"
+            },
+            "cakperiode": {
+                "type": "number",
+                "title": "Cakperiode",
+                "description": "Beschrijving voor CAKPERIODE"
+            },
+            "cakperiodeomschr": {
+                "type": "string",
+                "title": "Cakperiodeomschr",
+                "description": "Beschrijving voor CAKPERIODEOMSCHR"
+            },
+            "weekjaar": {
+                "type": "number",
+                "title": "Weekjaar",
+                "description": "Beschrijving voor WEEKJAAR"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimdeskundigheid/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimdeskundigheid/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimdeskundigheid",
+    "title": "Dimdeskundigheid",
+    "description": "Beschrijving voor dimdeskundigheid",
+    "shortname": "dimDskh",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam"            
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimdoorloopmethodiek/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimdoorloopmethodiek/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimdoorloopmethodiek",
+    "title": "Dimdoorloopmethodiek",
+    "description": "Beschrijving voor dimdoorloopmethodiek",
+    "shortname": "dimDrlmthd",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimdoorlooptijd/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimdoorlooptijd/v0.json
@@ -1,0 +1,56 @@
+{
+    "id": "dimdoorlooptijd",
+    "title": "Dimdoorlooptijd",
+    "description": "Beschrijving voor dimdoorlooptijd",
+    "shortname": "dimDrltd",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam",
+            "categorie"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "categorie": {
+                "type": "string",
+                "title": "Categorie",
+                "description": "Beschrijving voor CATEGORIE"
+            },
+            "volgordecategorie": {
+                "type": "number",
+                "title": "Volgordecategorie",
+                "description": "Beschrijving voor VOLGORDECATEGORIE"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimgemeente/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimgemeente/v0.json
@@ -1,0 +1,52 @@
+{
+    "id": "dimgemeente",
+    "title": "Dimgemeente",
+    "description": "Beschrijving voor dimgemeente",
+    "shortname": "dimGmt",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam",
+            "land"
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam",
+            "land"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "land": {
+                "type": "string",
+                "title": "Land",
+                "description": "Beschrijving voor LAND"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimjaar/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimjaar/v0.json
@@ -1,0 +1,46 @@
+{
+    "id": "dimjaar",
+    "title": "Dimjaar",
+    "description": "Beschrijving voor dimjaar",
+    "shortname": "dimJr",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam",
+            "mtaLaadDatumtijd"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimjanee/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimjanee/v0.json
@@ -1,0 +1,50 @@
+{
+    "id": "dimjanee",
+    "title": "Dimjanee",
+    "description": "Beschrijving voor dimjanee",
+    "shortname": "dimJN",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "waarde": {
+                "type": "number",
+                "title": "Waarde",
+                "description": "Beschrijving voor WAARDE"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimleeftijd/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimleeftijd/v0.json
@@ -1,0 +1,75 @@
+{
+    "id": "dimleeftijd",
+    "title": "Dimleeftijd",
+    "description": "Beschrijving voor dimleeftijd",
+    "shortname": "dimLftd",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"            
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "isjongerdan13": {
+                "type": "number",
+                "title": "Isjongerdan13",
+                "description": "Beschrijving voor ISJONGERDAN13"
+            },
+            "isjongerdan18": {
+                "type": "number",
+                "title": "Isjongerdan18",
+                "description": "Beschrijving voor ISJONGERDAN18"
+            },
+            "isjongerdan21": {
+                "type": "number",
+                "title": "Isjongerdan21",
+                "description": "Beschrijving voor ISJONGERDAN21"
+            },
+            "isjongerdan24": {
+                "type": "number",
+                "title": "Isjongerdan24",
+                "description": "Beschrijving voor ISJONGERDAN24"
+            },
+            "leeftijdcategoriecbs": {
+                "type": "string",
+                "title": "Leeftijdcategoriecbs",
+                "description": "Beschrijving voor LEEFTIJDCATEGORIECBS"
+            },
+            "leeftijdcategoriejeugd": {
+                "type": "string",
+                "title": "Leeftijdcategoriejeugd",
+                "description": "Beschrijving voor LEEFTIJDCATEGORIEJEUGD"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimleverancier/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimleverancier/v0.json
@@ -1,0 +1,181 @@
+{
+    "id": "dimleverancier",
+    "title": "Dimleverancier",
+    "description": "Beschrijving voor dimleverancier",
+    "shortname": "dimLvrcr",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam",
+            "agbcode",
+            "kvk"
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam",
+            "agbcode",
+            "kvk",
+            "soortleveranciercode",
+            "soortleverancier"
+        ],
+        "display": "code",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "agbcode": {
+                "type": "string",
+                "title": "Agbcode",
+                "description": "Beschrijving voor AGBCODE"
+            },
+            "kvk": {
+                "type": "string",
+                "title": "Kvk",
+                "description": "Beschrijving voor KVK"
+            },
+            "soortleveranciercode": {
+                "type": "string",
+                "title": "Soortleveranciercode",
+                "description": "Beschrijving voor SOORTLEVERANCIERCODE"
+            },
+            "soortleverancier": {
+                "type": "string",
+                "title": "Soortleverancier",
+                "description": "Beschrijving voor SOORTLEVERANCIER"
+            },
+            "specifiekeLeveranciersoort": {
+                "type": "string",
+                "title": "Specifieke leveranciersoort",
+                "description": "Beschrijving voor SPECIFIEKE_LEVERANCIERSOORT"
+            },
+            "externkenmerk": {
+                "type": "string",
+                "title": "Externkenmerk",
+                "description": "Beschrijving voor EXTERNKENMERK"
+            },
+            "avacode": {
+                "type": "string",
+                "title": "Avacode",
+                "description": "Beschrijving voor AVACODE"
+            },
+            "btwnr": {
+                "type": "string",
+                "title": "Btwnr",
+                "description": "Beschrijving voor BTWNR"
+            },
+            "iban": {
+                "type": "string",
+                "title": "Iban",
+                "description": "Beschrijving voor IBAN"
+            },
+            "ibantnv": {
+                "type": "string",
+                "title": "Ibantnv",
+                "description": "Beschrijving voor IBANTNV"
+            },
+            "postcode": {
+                "type": "string",
+                "title": "Postcode",
+                "description": "Beschrijving voor POSTCODE"
+            },
+            "woonplaats": {
+                "type": "string",
+                "title": "Woonplaats",
+                "description": "Beschrijving voor WOONPLAATS"
+            },
+            "huisnummer": {
+                "type": "number",
+                "title": "Huisnummer",
+                "description": "Beschrijving voor HUISNUMMER"
+            },
+            "huisletter": {
+                "type": "string",
+                "title": "Huisletter",
+                "description": "Beschrijving voor HUISLETTER"
+            },
+            "toevoeging": {
+                "type": "string",
+                "title": "Toevoeging",
+                "description": "Beschrijving voor TOEVOEGING"
+            },
+            "straat": {
+                "type": "string",
+                "title": "Straat",
+                "description": "Beschrijving voor STRAAT"
+            },
+            "brinnr": {
+                "type": "string",
+                "title": "Brinnr",
+                "description": "Beschrijving voor BRINNR"
+            },
+            "locatiecode": {
+                "type": "string",
+                "title": "Locatiecode",
+                "description": "Beschrijving voor LOCATIECODE"
+            },
+            "coradreslandcode": {
+                "type": "string",
+                "title": "Coradreslandcode",
+                "description": "Beschrijving voor CORADRESLANDCODE"
+            },
+            "coradrespostcode": {
+                "type": "string",
+                "title": "Coradrespostcode",
+                "description": "Beschrijving voor CORADRESPOSTCODE"
+            },
+            "coradreswoonplaats": {
+                "type": "string",
+                "title": "Coradreswoonplaats",
+                "description": "Beschrijving voor CORADRESWOONPLAATS"
+            },
+            "coradresstraat": {
+                "type": "string",
+                "title": "Coradresstraat",
+                "description": "Beschrijving voor CORADRESSTRAAT"
+            },
+            "coradreshuisnummer": {
+                "type": "number",
+                "title": "Coradreshuisnummer",
+                "description": "Beschrijving voor CORADRESHUISNUMMER"
+            },
+            "coradreshuisletter": {
+                "type": "string",
+                "title": "Coradreshuisletter",
+                "description": "Beschrijving voor CORADRESHUISLETTER"
+            },
+            "coradreshuisnrtoevoeging": {
+                "type": "string",
+                "title": "Coradreshuisnrtoevoeging",
+                "description": "Beschrijving voor CORADRESHUISNRTOEVOEGING"
+            },
+            "coradreslocatiebeschrijving": {
+                "type": "string",
+                "title": "Coradreslocatiebeschrijving",
+                "description": "Beschrijving voor CORADRESLOCATIEBESCHRIJVING"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimonderzoekwijze/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimonderzoekwijze/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimonderzoekwijze",
+    "title": "Dimonderzoekwijze",
+    "description": "Beschrijving voor dimonderzoekwijze",
+    "shortname": "dimOzwz",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam"
+        ],
+        "display": "code",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimpostcode/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimpostcode/v0.json
@@ -1,0 +1,51 @@
+{
+    "id": "dimpostcode",
+    "title": "Dimpostcode",
+    "description": "Beschrijving voor dimpostcode",
+    "shortname": "dimPcd",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam",
+            "postcodekort"
+        ],
+        "display": "code",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "postcodekort": {
+                "type": "string",
+                "title": "Postcodekort",
+                "description": "Beschrijving voor POSTCODEKORT"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimproces/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimproces/v0.json
@@ -1,0 +1,58 @@
+{
+    "id": "dimproces",
+    "title": "Dimproces",
+    "description": "Beschrijving voor dimproces",
+    "shortname": "dimPrcs",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam",
+            "processoort"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam",
+            "processoort"
+            
+        ],
+        "display": "nummer",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "processoort": {
+                "type": "string",
+                "title": "Processoort",
+                "description": "Beschrijving voor PROCESSOORT"
+            },
+            "regeling": {
+                "type": "string",
+                "title": "Regeling",
+                "description": "Beschrijving voor REGELING"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimprocessoort/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimprocessoort/v0.json
@@ -1,0 +1,47 @@
+{
+    "id": "dimprocessoort",
+    "title": "Dimprocessoort",
+    "description": "Beschrijving voor dimprocessoort",
+    "shortname": "dimPrcssrt",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam",
+            "mtaLaadDatumtijd"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam",
+            "mtaLaadDatumtijd"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimprocesstatus/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimprocesstatus/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimprocesstatus",
+    "title": "Dimprocesstatus",
+    "description": "Beschrijving voor dimprocesstatus",
+    "shortname": "dimPrcssts",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimregeling/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimregeling/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimregeling",
+    "title": "Dimregeling",
+    "description": "Beschrijving voor dimregeling",
+    "shortname": "dimRglng",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimvoorziening/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimvoorziening/v0.json
@@ -1,0 +1,135 @@
+{
+    "id": "dimvoorziening",
+    "title": "Dimvoorziening",
+    "description": "Beschrijving voor dimvoorziening",
+    "shortname": "dimVrzng",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "code",
+            "naam"            
+        ],
+        "required": [
+            "schema",
+            "code",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "code": {
+                "type": "string",
+                "title": "Code",
+                "description": "Beschrijving voor CODE"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "productcode": {
+                "type": "string",
+                "title": "Productcode",
+                "description": "Beschrijving voor PRODUCTCODE"
+            },
+            "typenr": {
+                "type": "number",
+                "title": "Typenr",
+                "description": "Beschrijving voor TYPENR"
+            },
+            "type": {
+                "type": "string",
+                "title": "Type",
+                "description": "Beschrijving voor TYPE"
+            },
+            "wetcode": {
+                "type": "number",
+                "title": "Wetcode",
+                "description": "Beschrijving voor WETCODE"
+            },
+            "regeling": {
+                "type": "string",
+                "title": "Regeling",
+                "description": "Beschrijving voor REGELING"
+            },
+            "productcategoriecode": {
+                "type": "string",
+                "title": "Productcategoriecode",
+                "description": "Beschrijving voor PRODUCTCATEGORIECODE"
+            },
+            "productcategorie": {
+                "type": "string",
+                "title": "Productcategorie",
+                "description": "Beschrijving voor PRODUCTCATEGORIE"
+            },
+            "productcluster": {
+                "type": "string",
+                "title": "Productcluster",
+                "description": "Beschrijving voor PRODUCTCLUSTER"
+            },
+            "voorzieningsoortcode": {
+                "type": "string",
+                "title": "Voorzieningsoortcode",
+                "description": "Beschrijving voor VOORZIENINGSOORTCODE"
+            },
+            "voorzieningsoort": {
+                "type": "string",
+                "title": "Voorzieningsoort",
+                "description": "Beschrijving voor VOORZIENINGSOORT"
+            },
+            "svbregeling": {
+                "type": "string",
+                "title": "Svbregeling",
+                "description": "Beschrijving voor SVBREGELING"
+            },
+            "toewijzingsoort": {
+                "type": "string",
+                "title": "Toewijzingsoort",
+                "description": "Beschrijving voor TOEWIJZINGSOORT"
+            },
+            "cbsafwijkproductcategoriecode": {
+                "type": "string",
+                "title": "Cbsafwijkproductcategoriecode",
+                "description": "Beschrijving voor CBSAFWIJKPRODUCTCATEGORIECODE"
+            },
+            "cbsafwijkendeproductcategorie": {
+                "type": "string",
+                "title": "Cbsafwijkendeproductcategorie",
+                "description": "Beschrijving voor CBSAFWIJKENDEPRODUCTCATEGORIE"
+            },
+            "minimaleingangsdatum": {
+                "type": "number",
+                "title": "Minimaleingangsdatum",
+                "description": "Beschrijving voor MINIMALEINGANGSDATUM"
+            },
+            "maximaledatumgeldigheid": {
+                "type": "number",
+                "title": "Maximaledatumgeldigheid",
+                "description": "Beschrijving voor MAXIMALEDATUMGELDIGHEID"
+            },
+            "leveringsvorm": {
+                "type": "string",
+                "title": "Leveringsvorm",
+                "description": "Beschrijving voor LEVERINGSVORM"
+            },
+            "soortpeildatumtarief": {
+                "type": "string",
+                "title": "Soortpeildatumtarief",
+                "description": "Beschrijving voor SOORTPEILDATUMTARIEF"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimvoorzieningstatus/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimvoorzieningstatus/v0.json
@@ -1,0 +1,45 @@
+{
+    "id": "dimvoorzieningstatus",
+    "title": "Dimvoorzieningstatus",
+    "description": "Beschrijving voor dimvoorzieningstatus",
+    "shortname": "dimVrzngsts",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/dimwijk/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/dimwijk/v0.json
@@ -1,0 +1,66 @@
+{
+    "id": "dimwijk",
+    "title": "Dimwijk",
+    "description": "Beschrijving voor dimwijk",
+    "shortname": "dimWk",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "nummer",
+            "naam",
+            "gemeentecode",
+            "gemeentenaam",
+            "land"
+        ],
+        "required": [
+            "schema",
+            "nummer",
+            "naam",
+            "gemeentecode",
+            "gemeentenaam",
+            "land"
+        ],
+        "display": "naam",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "nummer": {
+                "type": "string",
+                "title": "Nummer",
+                "description": "Beschrijving voor NUMMER"
+            },
+            "naam": {
+                "type": "string",
+                "title": "Naam",
+                "description": "Beschrijving voor NAAM"
+            },
+            "gemeentecode": {
+                "type": "string",
+                "title": "Gemeentecode",
+                "description": "Beschrijving voor GEMEENTECODE"
+            },
+            "gemeentenaam": {
+                "type": "string",
+                "title": "Gemeentenaam",
+                "description": "Beschrijving voor GEMEENTENAAM"
+            },
+            "land": {
+                "type": "string",
+                "title": "Land",
+                "description": "Beschrijving voor LAND"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitbeschiktbedragperiodiek/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitbeschiktbedragperiodiek/v0.json
@@ -1,0 +1,122 @@
+{
+    "id": "feitbeschiktbedragperiodiek",
+    "title": "Feitbeschiktbedragperiodiek",
+    "description": "Beschrijving voor feitbeschiktbedragperiodiek",
+    "shortname": "ftBsktBdrgPrd",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [            
+            "xbeschiktevoorzieningnr",
+            "xcasusnr",
+            "xclientnr"            
+        ],
+        "required": [
+            "schema",
+            "xbeschiktevoorzieningnr",
+            "xcasusnr",
+            "xclientnr"            
+        ],
+        "display": "xbeschiktevoorzieningnr",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "rleverancier": {
+                "type": "string",
+                "title": "Rleverancier",
+                "description": "Beschrijving voor RLEVERANCIER"
+            },
+            "rpostcode": {
+                "type": "string",
+                "title": "Rpostcode",
+                "description": "Beschrijving voor RPOSTCODE"
+            },
+            "rvoorziening": {
+                "type": "string",
+                "title": "Rvoorziening",
+                "description": "Beschrijving voor RVOORZIENING"
+            },
+            "maantal": {
+                "type": "number",
+                "title": "Maantal",
+                "description": "Beschrijving voor MAANTAL"
+            },
+            "mbedrag": {
+                "type": "number",
+                "title": "Mbedrag",
+                "description": "Beschrijving voor MBEDRAG"
+            },
+            "abedragperdag": {
+                "type": "number",
+                "title": "Abedragperdag",
+                "description": "Beschrijving voor ABEDRAGPERDAG"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "rkalenderjaar": {
+                "type": "number",
+                "title": "Rkalenderjaar",
+                "description": "Beschrijving voor RKALENDERJAAR"
+            },
+            "rleeftijd": {
+                "type": "number",
+                "title": "Rleeftijd",
+                "description": "Beschrijving voor RLEEFTIJD"
+            },
+            "rvoorzieningstatus": {
+                "type": "string",
+                "title": "Rvoorzieningstatus",
+                "description": "Beschrijving voor RVOORZIENINGSTATUS"
+            },
+            "rwijk": {
+                "type": "string",
+                "title": "Rwijk",
+                "description": "Beschrijving voor RWIJK"
+            },
+            "xbeschiktevoorzieningnr": {
+                "type": "string",
+                "title": "Xbeschiktevoorzieningnr",
+                "description": "Beschrijving voor XBESCHIKTEVOORZIENINGNR"
+            },
+            "xcasusnr": {
+                "type": "string",
+                "title": "Xcasusnr",
+                "description": "Beschrijving voor XCASUSNR"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "aaantaldagenactiefkalenderjaar": {
+                "type": "number",
+                "title": "Aaantaldagenactiefkalenderjaar",
+                "description": "Beschrijving voor AAANTALDAGENACTIEFKALENDERJAAR"
+            },
+            "reindegeldigdatumkalenderjaar": {
+                "type": "number",
+                "title": "Reindegeldigdatumkalenderjaar",
+                "description": "Beschrijving voor REINDEGELDIGDATUMKALENDERJAAR"
+            },
+            "ringangsdatumkalenderjaar": {
+                "type": "number",
+                "title": "Ringangsdatumkalenderjaar",
+                "description": "Beschrijving voor RINGANGSDATUMKALENDERJAAR"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitbeschiktevoorziening/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitbeschiktevoorziening/v0.json
@@ -1,0 +1,127 @@
+{
+    "id": "feitbeschiktevoorziening",
+    "title": "Feitbeschiktevoorziening",
+    "description": "Beschrijving voor feitbeschiktevoorziening",
+    "shortname": "feitBsktVrzng",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [            
+            "xbeschiktevoorzieningnr",
+            "xcasusnr",
+            "xclientnr"            
+        ],
+        "required": [
+            "schema",
+            "xbeschiktevoorzieningnr",
+            "xcasusnr",
+            "xclientnr"            
+        ],
+        "display": "xbeschiktevoorzieningnr",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "maantal": {
+                "type": "number",
+                "title": "Maantal",
+                "description": "Beschrijving voor MAANTAL"
+            },
+            "rcheckdatum": {
+                "type": "number",
+                "title": "Rcheckdatum",
+                "description": "Beschrijving voor RCHECKDATUM"
+            },
+            "reinddatum": {
+                "type": "number",
+                "title": "Reinddatum",
+                "description": "Beschrijving voor REINDDATUM"
+            },
+            "reindegeldigvorigezelfdevrz": {
+                "type": "number",
+                "title": "Reindegeldigvorigezelfdevrz",
+                "description": "Beschrijving voor REINDEGELDIGVORIGEZELFDEVRZ"
+            },
+            "ringangsdatumvoorziening": {
+                "type": "number",
+                "title": "Ringangsdatumvoorziening",
+                "description": "Beschrijving voor RINGANGSDATUMVOORZIENING"
+            },
+            "rleeftijd": {
+                "type": "number",
+                "title": "Rleeftijd",
+                "description": "Beschrijving voor RLEEFTIJD"
+            },
+            "rleeftijdopingangsdatum": {
+                "type": "number",
+                "title": "Rleeftijdopingangsdatum",
+                "description": "Beschrijving voor RLEEFTIJDOPINGANGSDATUM"
+            },
+            "rleverancier": {
+                "type": "string",
+                "title": "Rleverancier",
+                "description": "Beschrijving voor RLEVERANCIER"
+            },
+            "xbeschiktevoorzieningnr": {
+                "type": "string",
+                "title": "Xbeschiktevoorzieningnr",
+                "description": "Beschrijving voor XBESCHIKTEVOORZIENINGNR"
+            },
+            "xcasusnr": {
+                "type": "string",
+                "title": "Xcasusnr",
+                "description": "Beschrijving voor XCASUSNR"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "xreferentieleverancier": {
+                "type": "string",
+                "title": "Xreferentieleverancier",
+                "description": "Beschrijving voor XREFERENTIELEVERANCIER"
+            },
+            "rpostcode": {
+                "type": "string",
+                "title": "Rpostcode",
+                "description": "Beschrijving voor RPOSTCODE"
+            },
+            "rregeling": {
+                "type": "string",
+                "title": "Rregeling",
+                "description": "Beschrijving voor RREGELING"
+            },
+            "rvoorziening": {
+                "type": "string",
+                "title": "Rvoorziening",
+                "description": "Beschrijving voor RVOORZIENING"
+            },
+            "rvoorzieningstatus": {
+                "type": "number",
+                "title": "Rvoorzieningstatus",
+                "description": "Beschrijving voor RVOORZIENINGSTATUS"
+            },
+            "rwijk": {
+                "type": "number",
+                "title": "Rwijk",
+                "description": "Beschrijving voor RWIJK"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitclient/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitclient/v0.json
@@ -1,0 +1,73 @@
+{
+    "id": "feitclient",
+    "title": "Feitclient",
+    "description": "Beschrijving voor feitclient",
+    "shortname": "feitClnt",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [            
+            "xclientnr"
+        ],
+        "required": [
+            "schema",            
+            "xclientnr"
+        ],
+        "display": "xclientnr",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "woonplaats": {
+                "type": "string",
+                "title": "Woonplaats",
+                "description": "Beschrijving voor WOONPLAATS"
+            },
+            "maantal": {
+                "type": "number",
+                "title": "Maantal",
+                "description": "Beschrijving voor MAANTAL"
+            },
+            "rgeboortedatum": {
+                "type": "string",
+                "title": "Rgeboortedatum",
+                "description": "Beschrijving voor RGEBOORTEDATUM"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "rpostcode": {
+                "type": "string",
+                "title": "Rpostcode",
+                "description": "Beschrijving voor RPOSTCODE"
+            },
+            "rschool": {
+                "type": "string",
+                "title": "Rschool",
+                "description": "Beschrijving voor RSCHOOL"
+            },
+            "rwijk": {
+                "type": "string",
+                "title": "Rwijk",
+                "description": "Beschrijving voor RWIJK"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitgeregistreerdevoorziening/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitgeregistreerdevoorziening/v0.json
@@ -1,0 +1,122 @@
+{
+    "id": "feitgeregistreerdevoorziening",
+    "title": "Feitgeregistreerdevoorziening",
+    "description": "Beschrijving voor feitgeregistreerdevoorziening",
+    "shortname": "feitGrgVrzng",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+            "xcasusnr",
+            "xclientnr",
+            "xvoorzieningnr"
+        ],
+        "required": [
+            "schema",
+            "xcasusnr",
+            "xclientnr",
+            "xvoorzieningnr"            
+        ],
+        "display": "xcasusnr",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "rbeschikt": {
+                "type": "number",
+                "title": "Rbeschikt",
+                "description": "Beschrijving voor RBESCHIKT"
+            },
+            "rleeftijd": {
+                "type": "number",
+                "title": "Rleeftijd",
+                "description": "Beschrijving voor RLEEFTIJD"
+            },
+            "rleeftijdopingangsdatum": {
+                "type": "number",
+                "title": "Rleeftijdopingangsdatum",
+                "description": "Beschrijving voor RLEEFTIJDOPINGANGSDATUM"
+            },
+            "rleverancier": {
+                "type": "string",
+                "title": "Rleverancier",
+                "description": "Beschrijving voor RLEVERANCIER"
+            },
+            "rregeling": {
+                "type": "number",
+                "title": "Rregeling",
+                "description": "Beschrijving voor RREGELING"
+            },
+            "maantal": {
+                "type": "number",
+                "title": "Maantal",
+                "description": "Beschrijving voor MAANTAL"
+            },
+            "rcheckdatum": {
+                "type": "number",
+                "title": "Rcheckdatum",
+                "description": "Beschrijving voor RCHECKDATUM"
+            },
+            "reinddatum": {
+                "type": "number",
+                "title": "Reinddatum",
+                "description": "Beschrijving voor REINDDATUM"
+            },
+            "reindegeldigvorigezelfdevrz": {
+                "type": "number",
+                "title": "Reindegeldigvorigezelfdevrz",
+                "description": "Beschrijving voor REINDEGELDIGVORIGEZELFDEVRZ"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "ringangsdatumvoorziening": {
+                "type": "number",
+                "title": "Ringangsdatumvoorziening",
+                "description": "Beschrijving voor RINGANGSDATUMVOORZIENING"
+            },
+            "rvoorziening": {
+                "type": "string",
+                "title": "Rvoorziening",
+                "description": "Beschrijving voor RVOORZIENING"
+            },
+            "rgeslacht": {
+                "type": "string",
+                "title": "Rgeslacht",
+                "description": "Beschrijving voor RGESLACHT"
+            },
+            "xcasusnr": {
+                "type": "string",
+                "title": "Xcasusnr",
+                "description": "Beschrijving voor XCASUSNR"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "xvoorzieningnr": {
+                "type": "string",
+                "title": "Xvoorzieningnr",
+                "description": "Beschrijving voor XVOORZIENINGNR"
+            },
+            "rleverancierlevering": {
+                "type": "string",
+                "title": "Rleverancierlevering",
+                "description": "Beschrijving voor RLEVERANCIERLEVERING"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitleveringbedragperiodiek/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitleveringbedragperiodiek/v0.json
@@ -1,0 +1,94 @@
+{
+    "id": "feitleveringbedragperiodiek",
+    "title": "Feitleveringbedragperiodiek",
+    "description": "Beschrijving voor feitleveringbedragperiodiek",
+    "shortname": "feitLvrngBdgPrdk",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [            
+            "xbeschiktevoorzieningnr",
+            "xcasusnr",
+            "xclientnr",
+            "rvoorziening"
+        ],
+        "required": [
+            "schema",
+            "xbeschiktevoorzieningnr",
+            "xcasusnr",
+            "xclientnr",
+            "rvoorziening"
+        ],
+        "display": "xbeschiktevoorzieningnr",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "rkalenderjaar": {
+                "type": "number",
+                "title": "Rkalenderjaar",
+                "description": "Beschrijving voor RKALENDERJAAR"
+            },
+            "rleverancier": {
+                "type": "string",
+                "title": "Rleverancier",
+                "description": "Beschrijving voor RLEVERANCIER"
+            },
+            "maantal": {
+                "type": "number",
+                "title": "Maantal",
+                "description": "Beschrijving voor MAANTAL"
+            },
+            "mbedrag": {
+                "type": "number",
+                "title": "Mbedrag",
+                "description": "Beschrijving voor MBEDRAG"
+            },
+            "abedragperdag": {
+                "type": "number",
+                "title": "Abedragperdag",
+                "description": "Beschrijving voor ABEDRAGPERDAG"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "rleveringstatus": {
+                "type": "string",
+                "title": "Rleveringstatus",
+                "description": "Beschrijving voor RLEVERINGSTATUS"
+            },
+            "xbeschiktevoorzieningnr": {
+                "type": "string",
+                "title": "Xbeschiktevoorzieningnr",
+                "description": "Beschrijving voor XBESCHIKTEVOORZIENINGNR"
+            },
+            "xcasusnr": {
+                "type": "string",
+                "title": "Xcasusnr",
+                "description": "Beschrijving voor XCASUSNR"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "rvoorziening": {
+                "type": "string",
+                "title": "Rvoorziening",
+                "description": "Beschrijving voor RVOORZIENING"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitnegbeschiktevoorziening/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitnegbeschiktevoorziening/v0.json
@@ -1,0 +1,82 @@
+{
+    "id": "feitnegbeschiktevoorziening",
+    "title": "Feitnegbeschiktevoorziening",
+    "description": "Beschrijving voor feitnegbeschiktevoorziening",
+    "shortname": "feitNegBsktVrzng",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [            
+            "xcasusnr",
+            "xclientnr",            
+            "rvoorziening"            
+        ],
+        "required": [
+            "schema",
+            "xcasusnr",
+            "xclientnr",
+            "rvoorziening"            
+        ],
+        "display": "xcasusnr",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "rleeftijd": {
+                "type": "number",
+                "title": "Rleeftijd",
+                "description": "Beschrijving voor RLEEFTIJD"
+            },
+            "rleverancier": {
+                "type": "string",
+                "title": "Rleverancier",
+                "description": "Beschrijving voor RLEVERANCIER"
+            },
+            "rbeschikkingsdatum": {
+                "type": "number",
+                "title": "Rbeschikkingsdatum",
+                "description": "Beschrijving voor RBESCHIKKINGSDATUM"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "xcasusnr": {
+                "type": "string",
+                "title": "Xcasusnr",
+                "description": "Beschrijving voor XCASUSNR"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "rpostcode": {
+                "type": "string",
+                "title": "Rpostcode",
+                "description": "Beschrijving voor RPOSTCODE"
+            },
+            "rvoorziening": {
+                "type": "string",
+                "title": "Rvoorziening",
+                "description": "Beschrijving voor RVOORZIENING"
+            },
+            "rwijk": {
+                "type": "string",
+                "title": "Rwijk",
+                "description": "Beschrijving voor RWIJK"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/sociaalmedische_indicatie_kinderopvang/feitproces/v0.json
+++ b/datasets/sociaalmedische_indicatie_kinderopvang/feitproces/v0.json
@@ -1,0 +1,229 @@
+{
+    "id": "feitproces",
+    "title": "Feitproces",
+    "description": "Beschrijving voor feitproces",
+    "shortname": "feitPrcs",
+    "type": "table",
+    "version": "0.0.1",
+    "status": "under_development",
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [            
+            "xcasusnr",
+            "xclientnr",
+            "xhulpvraagnummer",            
+            "xprocesnr"
+        ],
+        "required": [
+            "schema",
+            "xcasusnr",
+            "xclientnr",
+            "xhulpvraagnummer",            
+            "xprocesnr"
+        ],
+        "display": "maantal",
+        "properties": {
+            "schema": {
+                "$ref": "https://schemas.data.amsterdam.nl/schema@v4.0.0#/definitions/schema"
+            },
+            "maantal": {
+                "type": "number",
+                "title": "Maantal",
+                "description": "Beschrijving voor MAANTAL"
+            },
+            "mgeschataantalgesprekken": {
+                "type": "number",
+                "title": "Mgeschataantalgesprekken",
+                "description": "Beschrijving voor MGESCHATAANTALGESPREKKEN"
+            },
+            "azaakid": {
+                "type": "string",
+                "title": "Azaakid",
+                "description": "Beschrijving voor AZAAKID"
+            },
+            "raantaldagendoorlooptijd": {
+                "type": "number",
+                "title": "Raantaldagendoorlooptijd",
+                "description": "Beschrijving voor RAANTALDAGENDOORLOOPTIJD"
+            },
+            "raantaldagenechtedoorlooptijd": {
+                "type": "number",
+                "title": "Raantaldagenechtedoorlooptijd",
+                "description": "Beschrijving voor RAANTALDAGENECHTEDOORLOOPTIJD"
+            },
+            "raantaldagenextradoorlooptijd": {
+                "type": "number",
+                "title": "Raantaldagenextradoorlooptijd",
+                "description": "Beschrijving voor RAANTALDAGENEXTRADOORLOOPTIJD"
+            },
+            "raantaldagennaregopslot": {
+                "type": "number",
+                "title": "Raantaldagennaregopslot",
+                "description": "Beschrijving voor RAANTALDAGENNAREGOPSLOT"
+            },
+            "raantaldagentelaat": {
+                "type": "number",
+                "title": "Raantaldagentelaat",
+                "description": "Beschrijving voor RAANTALDAGENTELAAT"
+            },
+            "rafsluitreden": {
+                "type": "number",
+                "title": "Rafsluitreden",
+                "description": "Beschrijving voor RAFSLUITREDEN"
+            },
+            "rbasismodel": {
+                "type": "string",
+                "title": "Rbasismodel",
+                "description": "Beschrijving voor RBASISMODEL"
+            },
+            "rdagendltijdminusextradltijd": {
+                "type": "number",
+                "title": "Rdagendltijdminusextradltijd",
+                "description": "Beschrijving voor RDAGENDLTIJDMINUSEXTRADLTIJD"
+            },
+            "rdatumafsluiten": {
+                "type": "number",
+                "title": "Rdatumafsluiten",
+                "description": "Beschrijving voor RDATUMAFSLUITEN"
+            },
+            "rdatumbeschikking": {
+                "type": "number",
+                "title": "Rdatumbeschikking",
+                "description": "Beschrijving voor RDATUMBESCHIKKING"
+            },
+            "rdatumeersteafspraak": {
+                "type": "number",
+                "title": "Rdatumeersteafspraak",
+                "description": "Beschrijving voor RDATUMEERSTEAFSPRAAK"
+            },
+            "rdatumopslot": {
+                "type": "number",
+                "title": "Rdatumopslot",
+                "description": "Beschrijving voor RDATUMOPSLOT"
+            },
+            "rdatumplanmelding": {
+                "type": "number",
+                "title": "Rdatumplanmelding",
+                "description": "Beschrijving voor RDATUMPLANMELDING"
+            },
+            "rdatumregistratie": {
+                "type": "number",
+                "title": "Rdatumregistratie",
+                "description": "Beschrijving voor RDATUMREGISTRATIE"
+            },
+            "rdatumstart": {
+                "type": "number",
+                "title": "Rdatumstart",
+                "description": "Beschrijving voor RDATUMSTART"
+            },
+            "rdatumstartbewaartermijn": {
+                "type": "number",
+                "title": "Rdatumstartbewaartermijn",
+                "description": "Beschrijving voor RDATUMSTARTBEWAARTERMIJN"
+            },
+            "rdatumuiterstedoorlooptijd": {
+                "type": "number",
+                "title": "Rdatumuiterstedoorlooptijd",
+                "description": "Beschrijving voor RDATUMUITERSTEDOORLOOPTIJD"
+            },
+            "rdeskundigheidproces": {
+                "type": "string",
+                "title": "Rdeskundigheidproces",
+                "description": "Beschrijving voor RDESKUNDIGHEIDPROCES"
+            },
+            "rdeskundigheidscreening": {
+                "type": "string",
+                "title": "Rdeskundigheidscreening",
+                "description": "Beschrijving voor RDESKUNDIGHEIDSCREENING"
+            },
+            "rdoorloopmethodiek": {
+                "type": "number",
+                "title": "Rdoorloopmethodiek",
+                "description": "Beschrijving voor RDOORLOOPMETHODIEK"
+            },
+            "reinddatumdoorlooptijd": {
+                "type": "number",
+                "title": "Reinddatumdoorlooptijd",
+                "description": "Beschrijving voor REINDDATUMDOORLOOPTIJD"
+            },
+            "rgemeente": {
+                "type": "string",
+                "title": "Rgemeente",
+                "description": "Beschrijving voor RGEMEENTE"
+            },
+            "rheeftmedeondertekenaar": {
+                "type": "number",
+                "title": "Rheeftmedeondertekenaar",
+                "description": "Beschrijving voor RHEEFTMEDEONDERTEKENAAR"
+            },
+            "ronderzoekwijzebijregistreren": {
+                "type": "string",
+                "title": "Ronderzoekwijzebijregistreren",
+                "description": "Beschrijving voor RONDERZOEKWIJZEBIJREGISTREREN"
+            },
+            "rontstaanuitproces": {
+                "type": "string",
+                "title": "Rontstaanuitproces",
+                "description": "Beschrijving voor RONTSTAANUITPROCES"
+            },
+            "rproces": {
+                "type": "string",
+                "title": "Rproces",
+                "description": "Beschrijving voor RPROCES"
+            },
+            "rprocesstatus": {
+                "type": "string",
+                "title": "Rprocesstatus",
+                "description": "Beschrijving voor RPROCESSTATUS"
+            },
+            "rregeling": {
+                "type": "string",
+                "title": "Rregeling",
+                "description": "Beschrijving voor RREGELING"
+            },
+            "rsoort": {
+                "type": "string",
+                "title": "Rsoort",
+                "description": "Beschrijving voor RSOORT"
+            },
+            "xcasusnr": {
+                "type": "string",
+                "title": "Xcasusnr",
+                "description": "Beschrijving voor XCASUSNR"
+            },
+            "xclientnr": {
+                "type": "string",
+                "title": "Xclientnr",
+                "description": "Beschrijving voor XCLIENTNR"
+            },
+            "xhulpvraagnummer": {
+                "type": "string",
+                "title": "Xhulpvraagnummer",
+                "description": "Beschrijving voor XHULPVRAAGNUMMER"
+            },
+            "xontstaanuitprocesnr": {
+                "type": "string",
+                "title": "Xontstaanuitprocesnr",
+                "description": "Beschrijving voor XONTSTAANUITPROCESNR"
+            },
+            "xprocesnr": {
+                "type": "string",
+                "title": "Xprocesnr",
+                "description": "Beschrijving voor XPROCESNR"
+            },
+            "xrelatienr": {
+                "type": "string",
+                "title": "Xrelatienr",
+                "description": "Beschrijving voor XRELATIENR"
+            },
+            "mtaLaadDatumtijd": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Mta laad datumtijd",
+                "description": "Beschrijving voor MTA_LAAD_DATUMTIJD"
+            }
+        }
+    }
+}

--- a/datasets/trajectus_mutatielijsten/dataset.json
+++ b/datasets/trajectus_mutatielijsten/dataset.json
@@ -2,7 +2,7 @@
     "id": "trajectusMutatielijsten",
     "type": "dataset",
     "title": "Trajectus mutatielijsten",
-    "description": "Zorgaanbieders werken met het berichtenverkeer waardoor de gegevens in ZorgNed automatisch bijgewerkt worden met wijzigingen. In Trajectus gebeurt dit niet automatisch, waardoor medewerkers van Services dit wekelijks doen op basis van wijzigingen in ZorgNed. Met dit dataproduct leveren we 4 lijsten zodat services weet voor welke cliënten in Trajectus zij de opvang moeten sluiten, de wachtlijst moeten sluiten, de opvang moeten openen of de wachtlijstbegeleiding moeten sluiten.",
+    "description": "Zorgaanbieders werken met het berichtenverkeer waardoor de gegevens in ZorgNed automatisch bijgewerkt worden met wijzigingen. In Trajectus gebeurt dit niet automatisch, waardoor medewerkers van Services dit wekelijks doen op basis van wijzigingen in ZorgNed. Met dit dataproduct leveren we 4 lijsten zodat services weet voor welke cliënten in Trajectus zij de opvang moeten sluiten, de wachtlijst moeten sluiten, de opvang moeten openen of de wachtlijstbegeleiding moeten sluiten [p26005].",
     "publisher": {
         "$ref": "publishers/DTJZ"
     },

--- a/scopes/DTJZ/dtjz_smiko.json
+++ b/scopes/DTJZ/dtjz_smiko.json
@@ -1,0 +1,12 @@
+{
+  "type": "scope",
+  "id": "DTJZ/SMIKO",
+  "name": "DTJZ/SMIKO",
+  "accessPackages": {    
+    "nonProduction": "EM4W-DPJZ-dbwengineer",
+    "production": "EM4W-DPJZ-schemascope-p-sociaal-medische-indicatie-kinderopvang"
+  },
+  "owner": {
+    "$ref": "publishers/DTJZ"
+  }
+}


### PR DESCRIPTION
* Extract vanuit AS generator

* CLVGJZ aangepast en SMI toegevoegd

* Scope CLVGJZ toegevoegd (#1718)

* Scope SMIKO aan DTJZ toegevoegd

* CLVGJZ tabellen naar 0.0.2

* Short names

* CLVGZ businessnaam fix

* Numbers to Strings

* SMIKO version property fix

* SMIKO directory and id consistent

* Verdwaalde bestanden cleanup

* CLVGJZ tables also  under_development

* SMIKO tables under_development

* version fix in datasets/controlelijsten_geld_zorg/mtaBusinessDefinities/v0.json

* descriptions in datasets