### PR TITLE
Add dataset scope for application (instead of granting FP/MDW)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
       - id: isort
         args: ['--filter-files']
   - repo: https://github.com/Amsterdam/schema-tools
-    rev: "v9.10.2"
+    rev: "v9.12.6"
     hooks:
       - id: validate-schema
         args: ['https://schemas.data.amsterdam.nl/schema@v4.2.0']

--- a/datasets/gemeentelijk_vastgoed/gebouwobjectenUitgebreid/v1.json
+++ b/datasets/gemeentelijk_vastgoed/gebouwobjectenUitgebreid/v1.json
@@ -5,7 +5,9 @@
   "status": "stable",
   "title": "Gebouwobjecten uitgebreid",
   "description": "Gegevens over de door de directie Gemeentelijk Vastgoed van de gemeente Amsterdam beheerde gebouwobjecten in volle eigendom of waar de gemeente Amsterdam een appartementsrecht heeft. Een gebouwobject kent veelal een relatie met een BAG-pand. Deze uitgebreide dataset bevat extra gegevens, onder andere contactgegevens van de assetmanager/beheerder van het pand. Hierom is deze set niet openbaar.",
-  "auth": "FP/MDW",
+  "auth": [
+    "FP/MDW"
+  ],
   "reasonsNonPublic": [
     "5.1 1d: Bevat persoonsgegevens"
   ],

--- a/datasets/gemeentelijk_vastgoed/gebouwobjectenUitgebreid/v1.json
+++ b/datasets/gemeentelijk_vastgoed/gebouwobjectenUitgebreid/v1.json
@@ -6,7 +6,8 @@
   "title": "Gebouwobjecten uitgebreid",
   "description": "Gegevens over de door de directie Gemeentelijk Vastgoed van de gemeente Amsterdam beheerde gebouwobjecten in volle eigendom of waar de gemeente Amsterdam een appartementsrecht heeft. Een gebouwobject kent veelal een relatie met een BAG-pand. Deze uitgebreide dataset bevat extra gegevens, onder andere contactgegevens van de assetmanager/beheerder van het pand. Hierom is deze set niet openbaar.",
   "auth": [
-    "FP/MDW"
+    "FP/MDW",
+    "GV/APP"
   ],
   "reasonsNonPublic": [
     "5.1 1d: Bevat persoonsgegevens"

--- a/scopes/SOEB/gv_app.json
+++ b/scopes/SOEB/gv_app.json
@@ -1,0 +1,12 @@
+{
+  "type": "scope",
+  "id": "GV/APP",
+  "name": "Gemeentelijke Voorzieningen dataset scope voor applicaties",
+  "accessPackages": {
+    "nonProduction": "EM4W-DATA-schemascope-ot-scope_gv_app",
+    "production": "EM4W-DATA-schemascope-p-scope_gv_app"
+  },
+  "owner": {
+    "$ref": "publishers/SOEB"
+  }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ dev =
     isort
     tbump >= 6.3.2  # Bumping version number and Git tagging
     build  # PEP5127 package builder (recommended by PYPA)
-    amsterdam-schema-tools >= 9.12.4
+    amsterdam-schema-tools >= 9.12.6
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Een applicatie van Maatschappelijke Voorzieningen wil toegang tot de gebouwobjecten_uitgebreid tabel van de dataset gemeentelijk vastgoed. Deze is afgeschermd met de FP/MDW scope, maar als we deze scope aan de applicatie toekennen, krijgt de applicatie ook toegang tot alle andere tabellen die FP/MDW hebben, en dat hoeft niet. Daarom hebben we voor deze dataset een nieuwe scope in het leven geroepen die gebruikt kan worden door system accounts/applicaties.

+ bump schema-tools in .pre-commit