### PR TITLE
remove gebouwobjecten uitgebreid export due to scoping conflict

### DIFF
--- a/datasets/gemeentelijk_vastgoed/dataset.json
+++ b/datasets/gemeentelijk_vastgoed/dataset.json
@@ -68,21 +68,6 @@
           ]
         },
         {
-          "name": "gebouwobjecten_uitgebreid",
-          "filetypes": [
-            "csv",
-            "gpkg",
-            "geojson",
-            "jsonl"
-          ],
-          "scopes": [
-            "fp/mdw"
-          ],
-          "tables": [
-            "gebouwobjecten_uitgebreid"
-          ]
-        },
-        {
           "name": "verhuurbare_eenheden",
           "filetypes": [
             "csv",


### PR DESCRIPTION
Dit voorkwam dat de exports goed doorliepen. 

We gaan dat ook fixen, maar dit is de snelle manier om in ieder geval de rest door te laten lopen.